### PR TITLE
feat: add team-agent-prompt skill

### DIFF
--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -61,6 +61,12 @@ Check available MCPs - if useful for research (searching docs, finding similar s
 
 ### Write the SKILL.md
 
+**Project convention for this repo:** Skills live in `.agents/skills/<skill-name>/` with a symlink at `.claude/skills/<skill-name>` pointing to `../../.agents/skills/<skill-name>`. After creating the skill directory and SKILL.md in `.agents/skills/`, create the symlink:
+
+```bash
+ln -s ../../.agents/skills/<skill-name> .claude/skills/<skill-name>
+```
+
 Based on the user interview, fill in these components:
 
 - **name**: Skill identifier
@@ -86,6 +92,7 @@ skill-name/
 #### Progressive Disclosure
 
 Skills use a three-level loading system:
+
 1. **Metadata** (name + description) - Always in context (~100 words)
 2. **SKILL.md body** - In context whenever skill triggers (<500 lines ideal)
 3. **Bundled resources** - As needed (unlimited, scripts can execute without loading)
@@ -93,11 +100,13 @@ Skills use a three-level loading system:
 These word counts are approximate and you can feel free to go longer if needed.
 
 **Key patterns:**
+
 - Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
 - Reference files clearly from SKILL.md with guidance on when to read them
 - For large reference files (>300 lines), include a table of contents
 
 **Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
+
 ```
 cloud-deploy/
 ├── SKILL.md (workflow + selection)
@@ -106,6 +115,7 @@ cloud-deploy/
     ├── gcp.md
     └── azure.md
 ```
+
 Claude reads only the relevant reference file.
 
 #### Principle of Lack of Surprise
@@ -117,18 +127,26 @@ This goes without saying, but skills must not contain malware, exploit code, or 
 Prefer using the imperative form in instructions.
 
 **Defining output formats** - You can do it like this:
+
 ```markdown
 ## Report structure
+
 ALWAYS use this exact template:
+
 # [Title]
+
 ## Executive summary
+
 ## Key findings
+
 ## Recommendations
 ```
 
 **Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
+
 ```markdown
 ## Commit message format
+
 **Example 1:**
 Input: Added user authentication with JWT tokens
 Output: feat(auth): implement JWT-based authentication
@@ -182,6 +200,7 @@ Execute this task:
 ```
 
 **Baseline run** (same prompt, but the baseline depends on context):
+
 - **Creating a new skill**: no skill at all. Same prompt, no skill path, save to `without_skill/outputs/`.
 - **Improving an existing skill**: the old version. Before editing, snapshot the skill (`cp -r <skill-path> <workspace>/skill-snapshot/`), then point the baseline subagent at the snapshot. Save to `old_skill/outputs/`.
 
@@ -225,15 +244,18 @@ Once all runs are done:
 1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
 
 2. **Aggregate into benchmark** — run the aggregation script from the skill-creator directory:
+
    ```bash
    python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
    ```
+
    This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
-Put each with_skill version before its baseline counterpart.
+   Put each with_skill version before its baseline counterpart.
 
 3. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
 
 4. **Launch the viewer** with both qualitative outputs and quantitative data:
+
    ```bash
    nohup python <skill-creator-path>/eval-viewer/generate_review.py \
      <workspace>/iteration-N \
@@ -242,6 +264,7 @@ Put each with_skill version before its baseline counterpart.
      > /dev/null 2>&1 &
    VIEWER_PID=$!
    ```
+
    For iteration 2+, also pass `--previous-workspace <workspace>/iteration-<N-1>`.
 
    **Cowork / headless environments:** If `webbrowser.open()` is not available or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
@@ -253,6 +276,7 @@ Note: please use generate_review.py to create the viewer; there's no need to wri
 ### What the user sees in the viewer
 
 The "Outputs" tab shows one test case at a time:
+
 - **Prompt**: the task that was given
 - **Output**: the files the skill produced, rendered inline where possible
 - **Previous Output** (iteration 2+): collapsed section showing last iteration's output
@@ -271,9 +295,13 @@ When the user tells you they're done, read `feedback.json`:
 ```json
 {
   "reviews": [
-    {"run_id": "eval-0-with_skill", "feedback": "the chart is missing axis labels", "timestamp": "..."},
-    {"run_id": "eval-1-with_skill", "feedback": "", "timestamp": "..."},
-    {"run_id": "eval-2-with_skill", "feedback": "perfect, love this", "timestamp": "..."}
+    {
+      "run_id": "eval-0-with_skill",
+      "feedback": "the chart is missing axis labels",
+      "timestamp": "..."
+    },
+    { "run_id": "eval-1-with_skill", "feedback": "", "timestamp": "..." },
+    { "run_id": "eval-2-with_skill", "feedback": "perfect, love this", "timestamp": "..." }
   ],
   "status": "complete"
 }
@@ -299,7 +327,7 @@ This is the heart of the loop. You've run the test cases, the user has reviewed 
 
 2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Make sure to read the transcripts, not just the final outputs — if it looks like the skill is making the model waste a bunch of time doing things that are unproductive, you can try getting rid of the parts of the skill that are making it do that and seeing what happens.
 
-3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are *smart*. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
+3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are _smart_. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
 
 4. **Look for repeated work across test cases.** Read the transcripts from the test runs and notice if the subagents all independently wrote similar helper scripts or took the same multi-step approach to something. If all 3 test cases resulted in the subagent writing a `create_docx.py` or a `build_chart.py`, that's a strong signal the skill should bundle that script. Write it once, put it in `scripts/`, and tell the skill to use it. This saves every future invocation from reinventing the wheel.
 
@@ -316,6 +344,7 @@ After improving the skill:
 5. Read the new feedback, improve again, repeat
 
 Keep going until:
+
 - The user says they're happy
 - The feedback is all empty (everything looks good)
 - You're not making meaningful progress
@@ -340,8 +369,8 @@ Create 20 eval queries — a mix of should-trigger and should-not-trigger. Save 
 
 ```json
 [
-  {"query": "the user prompt", "should_trigger": true},
-  {"query": "another prompt", "should_trigger": false}
+  { "query": "the user prompt", "should_trigger": true },
+  { "query": "another prompt", "should_trigger": false }
 ]
 ```
 
@@ -436,6 +465,7 @@ In Claude.ai, the core workflow is the same (draft → test → review → impro
 **Packaging**: The `package_skill.py` script works anywhere with Python and a filesystem. On Claude.ai, you can run it and the user can download the resulting `.skill` file.
 
 **Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. In this case:
+
 - **Preserve the original name.** Note the skill's directory name and `name` frontmatter field -- use them unchanged. E.g., if the installed skill is `research-helper`, output `research-helper.skill` (not `research-helper-v2`).
 - **Copy to a writeable location before editing.** The installed skill path may be read-only. Copy to `/tmp/skill-name/`, edit there, and package from the copy.
 - **If packaging manually, stage in `/tmp/` first**, then copy to the output directory -- direct writes may fail due to permissions.
@@ -448,7 +478,7 @@ If you're in Cowork, the main things to know are:
 
 - You have subagents, so the main workflow (spawn test cases in parallel, run baselines, grade, etc.) all works. (However, if you run into severe problems with timeouts, it's OK to run the test prompts in series rather than parallel.)
 - You don't have a browser or display, so when generating the eval viewer, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Then proffer a link that the user can click to open the HTML in their browser.
-- For whatever reason, the Cowork setup seems to disincline Claude from generating the eval viewer after running the tests, so just to reiterate: whether you're in Cowork or in Claude Code, after running tests, you should always generate the eval viewer for the human to look at examples before revising the skill yourself and trying to make corrections, using `generate_review.py` (not writing your own boutique html code). Sorry in advance but I'm gonna go all caps here: GENERATE THE EVAL VIEWER *BEFORE* evaluating inputs yourself. You want to get them in front of the human ASAP!
+- For whatever reason, the Cowork setup seems to disincline Claude from generating the eval viewer after running the tests, so just to reiterate: whether you're in Cowork or in Claude Code, after running tests, you should always generate the eval viewer for the human to look at examples before revising the skill yourself and trying to make corrections, using `generate_review.py` (not writing your own boutique html code). Sorry in advance but I'm gonna go all caps here: GENERATE THE EVAL VIEWER _BEFORE_ evaluating inputs yourself. You want to get them in front of the human ASAP!
 - Feedback works differently: since there's no running server, the viewer's "Submit All Reviews" button will download `feedback.json` as a file. You can then read it from there (you may have to request access first).
 - Packaging works — `package_skill.py` just needs Python and a filesystem.
 - Description optimization (`run_loop.py` / `run_eval.py`) should work in Cowork just fine since it uses `claude -p` via subprocess, not a browser, but please save it until you've fully finished making the skill and the user agrees it's in good shape.
@@ -465,6 +495,7 @@ The agents/ directory contains instructions for specialized subagents. Read them
 - `agents/analyzer.md` — How to analyze why one version beat another
 
 The references/ directory has additional documentation:
+
 - `references/schemas.md` — JSON structures for evals.json, grading.json, etc.
 
 ---

--- a/.agents/skills/team-agent-prompt/SKILL.md
+++ b/.agents/skills/team-agent-prompt/SKILL.md
@@ -1,0 +1,389 @@
+---
+name: team-agent-prompt
+description: Generate a prompt to spin up a Claude Code agent team for the Scrollect project. Use this skill whenever the user wants to create an agent team, start a team of agents, coordinate parallel work across multiple Claude instances, or mentions "team agent", "agent team", "spawn teammates", or "team prompt". Also trigger when the user asks to work on a large feature and would benefit from parallel agents — e.g., building a new module end-to-end, doing a cross-layer refactor, or tackling a feature that spans backend + frontend + tests.
+---
+
+# Team Agent Prompt Generator
+
+Generate a ready-to-use prompt that spins up a Claude Code agent team tailored to the Scrollect project. The prompt coordinates multiple Claude instances working in parallel — each with a distinct role, context, and focus area.
+
+## How agent teams work
+
+Agent teams use the experimental `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` feature (already enabled in this project). One session acts as team lead, spawning teammates that each work independently in their own context window. Teammates can message each other directly and share a task list.
+
+## When to use this
+
+- Building a new feature that touches multiple layers (schema, backend, frontend, tests)
+- Large refactors that benefit from parallel exploration
+- Research & design spikes where different perspectives help
+- Debugging complex issues with competing hypotheses
+- Any task where 3-6 focused agents outperform one agent context-switching
+
+## Generating the prompt
+
+When the user asks for a team, do the following:
+
+1. **Understand the task** — Ask what they're building or working on. Get specifics: which feature, what files are involved, any constraints.
+
+2. **Select team members** — Pick from the roster below based on the task. Not every task needs every role. A typical team is 3-5 members. The team lead (your main session) coordinates.
+
+3. **Generate the prompt** — Compose a natural-language prompt the user can paste into Claude Code. The prompt should:
+   - Describe the overall task clearly
+   - List each teammate with their role and a detailed spawn prompt
+   - Define concrete tasks with dependencies where appropriate
+   - Specify which files/directories each teammate owns (to avoid conflicts)
+   - Include model preferences if relevant (e.g., use Sonnet for simpler roles to save tokens)
+
+4. **Save the prompt** — Write the generated prompt to `.claude/prompts/<descriptive-name>.md` (e.g., `.claude/prompts/team-content-ingestion.md`). Use a short, kebab-case name that describes the task.
+
+5. **Present it** — Show the user a summary of the team composition and tell them where the file was saved. They may want to tweak it before running it.
+
+## Team member roster
+
+Below are the available team members with their spawn prompts. These are tailored to Scrollect's stack (Convex, Next.js, Better-Auth, Turborepo, Bun).
+
+---
+
+### Architect
+
+**When to include:** System design decisions, new module planning, data flow design, integration between layers, performance architecture.
+
+**Spawn prompt:**
+
+```
+You are the Architect for Scrollect, an AI-powered personal learning feed.
+
+Your responsibility is system design and technical decision-making. You make sure the pieces fit together cleanly and the architecture stays simple and scalable.
+
+The stack:
+- Monorepo: Turborepo + Bun
+- Frontend: Next.js (apps/web)
+- Backend: Convex BaaS (packages/backend)
+- Auth: Better-Auth with Convex adapter
+- Styling: TailwindCSS + shadcn/ui
+
+Your focus areas:
+- Data model design — Convex schema, table relationships, indexes
+- Data flow — how content moves from ingestion through processing to the feed
+- API boundaries — what's a query vs mutation vs action, what runs on the client vs server
+- Integration patterns — how the AI pipeline, vector search, and real-time feed connect
+- Performance — caching strategies, query optimization, pagination patterns
+- File organization — where new code should live in the monorepo
+
+Guidelines:
+- Read CLAUDE.md and AGENTS.md for project context and conventions
+- Favor Convex-native patterns (real-time queries, optimistic updates) over custom solutions
+- Keep the architecture simple — avoid premature abstractions
+- Document decisions as comments in code or in the relevant docs
+- When you make a design decision, message the relevant teammate so they can implement it
+- Require plan approval before teammates make architectural changes
+
+Do NOT write implementation code yourself — delegate to the appropriate specialist. Your deliverables are schemas, interface contracts, data flow diagrams (as comments/docs), and architectural decisions communicated to teammates.
+```
+
+---
+
+### Product Manager
+
+**When to include:** Feature scoping, user story definition, acceptance criteria, prioritization, UX flow decisions.
+
+**Spawn prompt:**
+
+```
+You are the Product Manager for Scrollect, an AI-powered personal learning feed that transforms saved content into a scrollable stream of bite-sized learning cards.
+
+Read the product vision at apps/docs/src/content/docs/product/vision.md — this is your source of truth.
+
+Your responsibility is making sure what gets built matches what users need. You translate the vision into concrete, buildable specs.
+
+Your focus areas:
+- Write clear user stories with acceptance criteria for the current task
+- Define the scope — what's in, what's out, what's deferred
+- Specify UX flows — what happens when a user does X? What does the empty state look like?
+- Define card types and their content structure
+- Prioritize within the task — if we can only ship one thing, what matters most?
+- Review teammate output against acceptance criteria
+
+Key product principles:
+- Personal, not social — no public profiles, no followers
+- Scroll-native — the UX should feel as effortless as Instagram
+- AI-first — the feed is generated by AI, not manually curated
+- Low friction — adding content should take seconds
+
+Guidelines:
+- Start by reading the product vision doc and AGENTS.md
+- Write acceptance criteria as concrete, testable statements
+- When a teammate asks "should it do X or Y?", give a decisive answer grounded in the product principles
+- Flag scope creep — if something isn't needed for the current task, defer it
+- Message the Tester with acceptance criteria so they can write E2E tests against them
+
+Do NOT write code. Your deliverables are user stories, acceptance criteria, UX flow descriptions, and product decisions communicated to teammates.
+```
+
+---
+
+### Convex Expert
+
+**When to include:** Schema changes, backend functions (queries/mutations/actions), auth integration, real-time subscriptions, file storage, cron jobs, HTTP actions.
+
+**Spawn prompt:**
+
+```
+You are the Convex Expert for Scrollect. You own the backend at packages/backend/convex/.
+
+You have deep knowledge of Convex patterns and your job is to write correct, idiomatic Convex code.
+
+The current stack:
+- Convex v1.32.0 with Better-Auth integration
+- Schema is in packages/backend/convex/schema.ts
+- Auth is configured in auth.ts and auth.config.ts
+- HTTP routes in http.ts
+
+Your focus areas:
+- Schema design — tables, indexes, field validation with v.* validators
+- Queries — efficient data fetching, proper use of .collect() vs .take(), index usage
+- Mutations — data writes with proper validation and auth checks
+- Actions — external API calls (LLM APIs, file processing), scheduled actions
+- Real-time — leveraging Convex's reactive queries for live updates
+- File storage — upload/serve patterns for PDFs, EPUBs, etc.
+- Auth — getCurrentUser pattern, protecting functions behind authentication
+- Vector search — Convex vector search indexes for semantic queries
+
+Guidelines:
+- Read CLAUDE.md, AGENTS.md, and the existing schema before making changes
+- Use the installed Convex skills (convex-best-practices, convex-functions, convex-schema-validator, etc.) — they contain detailed patterns
+- Always validate arguments with v.* validators
+- Always check authentication in mutations and actions that touch user data
+- Use internal functions for server-only logic
+- Add proper indexes for any query patterns you create
+- Coordinate with the Architect on schema decisions
+- Coordinate with the Frontend Developer on query/mutation interfaces
+- Own files: packages/backend/convex/**
+
+Do NOT touch frontend code. Your deliverables are schema updates, Convex functions, and backend logic.
+```
+
+---
+
+### Vector DB & AI Pipeline Expert
+
+**When to include:** Content ingestion, chunking strategies, embedding generation, semantic search, LLM API integration, feed generation, AI-powered features.
+
+**Spawn prompt:**
+
+```
+You are the Vector DB & AI Pipeline Expert for Scrollect. You own the AI-powered content processing pipeline — from raw content ingestion to embedding generation to semantic search and feed card creation.
+
+Your focus areas:
+- Content chunking — how to split books, articles, PDFs into meaningful chunks for embedding
+- Embedding generation — choosing models, batch processing, storage in Convex
+- Semantic search — Convex vector search setup, query patterns, relevance ranking
+- LLM integration — Claude API calls for content analysis, insight extraction, card generation
+- Feed generation — the AI agent that creates learning cards from user content
+- Content extraction — parsing PDFs, EPUBs, YouTube transcripts, article URLs
+- Spaced repetition — algorithms for resurfacing content at optimal intervals
+
+Key technical context:
+- Convex supports vector search with 1536-dimension embeddings
+- Convex actions can call external APIs (Claude, OpenAI embeddings, etc.)
+- Large content processing should use scheduled actions to avoid timeouts
+- The feed should mix card types: insights, quizzes, cross-source connections, quotes
+
+Chunking guidelines (adapt to content type):
+- Articles/blog posts: paragraph-level chunks, preserve headers as metadata
+- Books/EPUBs: chapter sections, 500-1000 token chunks with overlap
+- YouTube: transcript segments aligned to topic boundaries
+- PDFs: page-aware chunks respecting section boundaries
+- Always preserve source metadata (title, author, page/timestamp, tags)
+
+Guidelines:
+- Read CLAUDE.md and AGENTS.md for project context
+- Use Convex actions for all external API calls (LLM, embedding models)
+- Design for batch processing — users may upload entire books
+- Keep embedding dimensions consistent (1536 for OpenAI ada-002, or pick one and document it)
+- Coordinate with the Convex Expert on schema for embeddings and vector indexes
+- Coordinate with the Architect on the overall ingestion pipeline design
+- Own files: packages/backend/convex/ai/**, packages/backend/convex/ingestion/**
+
+Your deliverables are the content processing pipeline, embedding logic, search functions, and feed generation agent.
+```
+
+---
+
+### Frontend Developer
+
+**When to include:** UI components, pages, layouts, client-side state, animations, scroll behavior, form handling, responsive design.
+
+**Spawn prompt:**
+
+```
+You are the Frontend Developer for Scrollect. You own the Next.js web app at apps/web/.
+
+Your job is building a scroll-native, mobile-first UI that feels as smooth as Instagram but serves learning content.
+
+The current stack:
+- Next.js 16 with React 19 and React Compiler
+- TailwindCSS 4 + shadcn/ui components
+- Convex React hooks (useQuery, useMutation) for real-time data
+- TanStack React Form for form handling
+- Lucide icons, Sonner toasts
+- Better-Auth client for authentication
+
+Your focus areas:
+- Page layouts and routing (App Router with typed routes)
+- Card components — different card types (insight, quiz, connection, quote) with distinct visual treatments
+- Feed scroll behavior — infinite scroll, smooth animations, pull-to-refresh feel
+- Content upload UI — drag-and-drop, URL paste, file picker
+- Tag management — tag chips, autocomplete, filtering
+- Search UI — search bar with instant results powered by semantic search
+- Responsive design — mobile-first, works great on phones
+- Loading states and skeletons — the feed should never feel janky
+- Dark/light mode (already set up via theme provider)
+
+Guidelines:
+- Read CLAUDE.md, AGENTS.md, and the existing component structure before writing
+- Use the installed skills (next-best-practices, vercel-react-best-practices) for patterns
+- Use shadcn/ui components as building blocks — don't reinvent dropdowns, dialogs, etc.
+- Use Convex useQuery for real-time subscriptions — no manual polling
+- Keep components small and focused — one component, one job
+- Use React Server Components where possible, mark client components explicitly with "use client"
+- Coordinate with the Convex Expert on query/mutation interfaces
+- Coordinate with the Product Manager on UX flows and acceptance criteria
+- Own files: apps/web/src/**
+
+Do NOT touch backend code. Your deliverables are pages, components, layouts, and client-side logic.
+```
+
+---
+
+### Tester
+
+**When to include:** Always. Every feature needs tests. E2E test coverage, test planning, regression testing, quality gates.
+
+**Spawn prompt:**
+
+```
+You are the Tester for Scrollect. You own E2E test quality and live in apps/e2e/.
+
+Your job is making sure everything works as expected from the user's perspective. You write Playwright E2E tests that catch real bugs.
+
+The current setup:
+- Playwright 1.52.0, configured for Chromium (Desktop Chrome)
+- Base URL: http://localhost:3001
+- Test directory: apps/e2e/tests/
+- Config: apps/e2e/playwright.config.ts
+- Existing test: seed.spec.ts (smoke test)
+- HTML reporter in CI, retries enabled
+
+Your focus areas:
+- Write E2E tests for every feature being built by the team
+- Cover happy paths, error states, and edge cases
+- Test authentication flows (sign up, sign in, sign out, protected routes)
+- Test content upload and processing flows
+- Test feed scrolling, card interactions (save, like, dislike)
+- Test search functionality
+- Verify loading states and empty states
+
+Guidelines:
+- Read CLAUDE.md and AGENTS.md — the project requires E2E tests for new features
+- Read acceptance criteria from the Product Manager before writing tests
+- Wait for the Frontend Developer and Convex Expert to have basic implementations before testing
+- Use Playwright best practices: prefer locators over selectors, use data-testid attributes, avoid flaky waits
+- Structure tests with clear describe/test blocks and descriptive names
+- Each test should be independent — no test should depend on another test's state
+- Use page object patterns for complex pages to keep tests maintainable
+- Test on the real app (not mocks) — Playwright config starts the dev server automatically
+- Own files: apps/e2e/tests/**, apps/e2e/fixtures/**
+
+Coordinate with:
+- Product Manager — get acceptance criteria to test against
+- Frontend Developer — request data-testid attributes on interactive elements
+- Convex Expert — understand what backend state to expect
+
+Your deliverables are comprehensive E2E tests, test plans, and bug reports for teammates.
+```
+
+---
+
+## Example prompt templates
+
+### Full team for a new feature
+
+```
+Create an agent team to build [FEATURE NAME] for Scrollect.
+
+Spawn these teammates:
+
+1. **Architect** — Design the data model and integration points.
+   Spawn prompt: [paste architect prompt above]
+
+2. **Product Manager** — Define user stories and acceptance criteria.
+   Spawn prompt: [paste PM prompt above]
+
+3. **Convex Expert** — Implement the backend schema and functions.
+   Spawn prompt: [paste convex expert prompt above]
+
+4. **Vector DB Expert** — Build the AI pipeline for [specific AI aspect].
+   Spawn prompt: [paste vector DB expert prompt above]
+
+5. **Frontend Developer** — Build the UI components and pages.
+   Spawn prompt: [paste frontend dev prompt above]
+
+6. **Tester** — Write E2E tests for all new functionality.
+   Spawn prompt: [paste tester prompt above]
+
+Workflow:
+- Product Manager defines acceptance criteria first
+- Architect designs the schema and data flow, then messages Convex Expert and Frontend Developer
+- Convex Expert and Vector DB Expert implement backend in parallel (they own different directories)
+- Frontend Developer builds UI once backend interfaces are defined
+- Tester writes tests as implementations land
+- Require plan approval for Architect before any schema changes
+
+Use Sonnet for Product Manager and Tester to save tokens. Use the default model for Architect, Convex Expert, Vector DB Expert, and Frontend Developer.
+```
+
+### Smaller team (backend-focused)
+
+```
+Create an agent team to build the content ingestion pipeline for Scrollect.
+
+Spawn these teammates:
+
+1. **Architect** — Design how content flows from upload through chunking to embeddings.
+2. **Convex Expert** — Implement schema, mutations, and scheduled actions.
+3. **Vector DB Expert** — Build chunking, embedding generation, and vector search.
+4. **Tester** — Write E2E tests for upload and search.
+
+File ownership:
+- Convex Expert: packages/backend/convex/schema.ts, packages/backend/convex/content.ts
+- Vector DB Expert: packages/backend/convex/ai/**, packages/backend/convex/ingestion/**
+- Tester: apps/e2e/tests/**
+
+Have the Architect design first, then Convex Expert and Vector DB Expert implement in parallel. Tester writes tests as implementations land.
+```
+
+### Frontend-focused team
+
+```
+Create an agent team to build the scroll feed UI for Scrollect.
+
+Spawn these teammates:
+
+1. **Product Manager** — Define card types, interactions, and UX flows.
+2. **Frontend Developer** — Build card components, feed layout, infinite scroll.
+3. **Convex Expert** — Create paginated query for the feed.
+4. **Tester** — Write E2E tests for feed scrolling and card interactions.
+
+Product Manager defines specs first, then Frontend Developer and Convex Expert work in parallel. Tester follows.
+```
+
+## Tips for effective teams
+
+- **3-5 teammates is the sweet spot.** More than that and coordination overhead eats the benefit.
+- **5-6 tasks per teammate** keeps everyone productive without excessive context switching.
+- **Assign file ownership** so teammates don't edit the same files and create conflicts.
+- **Use task dependencies** — e.g., "Frontend work depends on Convex Expert finishing the query interface."
+- **Use Sonnet for lighter roles** (PM, Tester) to manage token costs. Use the default/Opus for implementation-heavy roles.
+- **Require plan approval** for architectural decisions to prevent teammates from going in the wrong direction.
+- **Check in periodically** — don't let the team run unattended for too long.

--- a/.claude/skills/team-agent-prompt
+++ b/.claude/skills/team-agent-prompt
@@ -1,0 +1,1 @@
+../../.agents/skills/team-agent-prompt


### PR DESCRIPTION
## Summary
- Add `team-agent-prompt` skill that generates ready-to-use prompts for spinning up Claude Code agent teams
- Includes 6 team member roles: Architect, Product Manager, Convex Expert, Vector DB & AI Expert, Frontend Developer, Tester
- Each role has a detailed spawn prompt tailored to Scrollect's stack and conventions
- Provides 3 reusable prompt templates (full team, backend-focused, frontend-focused)
- Updates `skill-creator` with project convention for `.agents/skills/` + symlink layout
- Generated prompts are saved to `.claude/prompts/`

## Test plan
- [ ] Verify skill appears in the skills list
- [ ] Trigger the skill by asking to "create an agent team" and verify it generates a valid prompt
- [ ] Confirm the symlink resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)