### PR TITLE
feat(#8): add Convex file storage + document mutations

### DIFF
--- a/packages/backend/convex/documents.ts
+++ b/packages/backend/convex/documents.ts
@@ -1,0 +1,95 @@
+import type { GenericCtx } from "@convex-dev/better-auth";
+import { v } from "convex/values";
+
+import type { DataModel } from "./_generated/dataModel";
+import { internalMutation, mutation, query } from "./_generated/server";
+import { authComponent } from "./auth";
+
+export const generateUploadUrl = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx as unknown as GenericCtx<DataModel>);
+    if (!user) {
+      throw new Error("Not authenticated");
+    }
+    return await ctx.storage.generateUploadUrl();
+  },
+});
+
+export const create = mutation({
+  args: {
+    title: v.string(),
+    fileType: v.union(v.literal("pdf"), v.literal("md")),
+    storageId: v.id("_storage"),
+  },
+  handler: async (ctx, args) => {
+    const user = await authComponent.safeGetAuthUser(ctx as unknown as GenericCtx<DataModel>);
+    if (!user) {
+      throw new Error("Not authenticated");
+    }
+    return await ctx.db.insert("documents", {
+      title: args.title,
+      fileType: args.fileType,
+      storageId: args.storageId,
+      status: "pending",
+      chunkCount: 0,
+      userId: user.userId,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx as unknown as GenericCtx<DataModel>);
+    if (!user) {
+      return [];
+    }
+    return await ctx.db
+      .query("documents")
+      .withIndex("by_userId", (q) => q.eq("userId", user.userId))
+      .order("desc")
+      .collect();
+  },
+});
+
+export const get = query({
+  args: { id: v.id("documents") },
+  handler: async (ctx, args) => {
+    const user = await authComponent.safeGetAuthUser(ctx as unknown as GenericCtx<DataModel>);
+    if (!user) {
+      return null;
+    }
+    const doc = await ctx.db.get(args.id);
+    if (!doc || doc.userId !== user.userId) {
+      return null;
+    }
+    return doc;
+  },
+});
+
+export const updateStatus = internalMutation({
+  args: {
+    id: v.id("documents"),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("processing"),
+      v.literal("ready"),
+      v.literal("error"),
+    ),
+    errorMessage: v.optional(v.string()),
+    chunkCount: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const { id, ...fields } = args;
+    const update: Record<string, unknown> = { status: fields.status };
+    if (fields.errorMessage !== undefined) {
+      update.errorMessage = fields.errorMessage;
+    }
+    if (fields.chunkCount !== undefined) {
+      update.chunkCount = fields.chunkCount;
+    }
+    await ctx.db.patch(id, update);
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `packages/backend/convex/documents.ts` with all document CRUD operations
- `generateUploadUrl` mutation — generates Convex file storage upload URL (auth required)
- `create` mutation — creates a document record with `status: "pending"` (accepts title, fileType, storageId)
- `list` query — returns all documents for the authenticated user, ordered by `createdAt` desc
- `get` query — returns a single document by ID with ownership check
- `updateStatus` internal mutation — for the processing pipeline (not client-callable)
- All public functions require Better-Auth authentication

## Test plan
- [ ] Verify `generateUploadUrl` rejects unauthenticated requests
- [ ] Verify `create` inserts a document with `status: "pending"` and `chunkCount: 0`
- [ ] Verify `list` only returns documents belonging to the authenticated user
- [ ] Verify `get` returns `null` for documents owned by other users
- [ ] Verify `updateStatus` is not callable from the client (internal mutation)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)