### PR TITLE
feat(#9): add PDF & Markdown parsing + content chunking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,6 +89,7 @@
         "better-auth": "catalog:",
         "convex": "catalog:",
         "dotenv": "catalog:",
+        "pdf-parse": "^2.4.5",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -425,6 +426,28 @@
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.3", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA=="],
+
+    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.80", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.80", "@napi-rs/canvas-darwin-arm64": "0.1.80", "@napi-rs/canvas-darwin-x64": "0.1.80", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80", "@napi-rs/canvas-linux-arm64-gnu": "0.1.80", "@napi-rs/canvas-linux-arm64-musl": "0.1.80", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80", "@napi-rs/canvas-linux-x64-gnu": "0.1.80", "@napi-rs/canvas-linux-x64-musl": "0.1.80", "@napi-rs/canvas-win32-x64-msvc": "0.1.80" } }, "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww=="],
+
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.80", "", { "os": "android", "cpu": "arm64" }, "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ=="],
+
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.80", "", { "os": "darwin", "cpu": "arm64" }, "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ=="],
+
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.80", "", { "os": "darwin", "cpu": "x64" }, "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA=="],
+
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.80", "", { "os": "linux", "cpu": "arm" }, "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ=="],
+
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.80", "", { "os": "linux", "cpu": "arm64" }, "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw=="],
+
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.80", "", { "os": "linux", "cpu": "arm64" }, "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg=="],
+
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.80", "", { "os": "linux", "cpu": "none" }, "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw=="],
+
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.80", "", { "os": "linux", "cpu": "x64" }, "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA=="],
+
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.80", "", { "os": "linux", "cpu": "x64" }, "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg=="],
+
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.80", "", { "os": "win32", "cpu": "x64" }, "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
@@ -2057,6 +2080,10 @@
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pdf-lib": ["pdf-lib@1.17.1", "", { "dependencies": { "@pdf-lib/standard-fonts": "^1.0.0", "@pdf-lib/upng": "^1.0.1", "pako": "^1.0.11", "tslib": "^1.11.1" } }, "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw=="],
+
+    "pdf-parse": ["pdf-parse@2.4.5", "", { "dependencies": { "@napi-rs/canvas": "0.1.80", "pdfjs-dist": "5.4.296" }, "bin": { "pdf-parse": "bin/cli.mjs" } }, "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg=="],
+
+    "pdfjs-dist": ["pdfjs-dist@5.4.296", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.80" } }, "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q=="],
 
     "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
 

--- a/packages/backend/convex/chunks.ts
+++ b/packages/backend/convex/chunks.ts
@@ -1,0 +1,31 @@
+import { v } from "convex/values";
+
+import { internalMutation } from "./_generated/server";
+
+export const createBatch = internalMutation({
+  args: {
+    documentId: v.id("documents"),
+    chunks: v.array(
+      v.object({
+        content: v.string(),
+        tokenCount: v.number(),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const ids = await Promise.all(
+      args.chunks.map((chunk, index) =>
+        ctx.db.insert("chunks", {
+          documentId: args.documentId,
+          content: chunk.content,
+          chunkIndex: index,
+          tokenCount: chunk.tokenCount,
+          embeddingStatus: "pending",
+          createdAt: now,
+        }),
+      ),
+    );
+    return ids;
+  },
+});

--- a/packages/backend/convex/parsing.ts
+++ b/packages/backend/convex/parsing.ts
@@ -1,0 +1,191 @@
+import { v } from "convex/values";
+import { PDFParse } from "pdf-parse";
+
+import { internal } from "./_generated/api";
+import { internalAction } from "./_generated/server";
+
+const TARGET_CHUNK_SIZE = 750;
+const CHUNK_OVERLAP = 50;
+const MIN_CHUNK_SIZE = 100;
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+export function chunkContent(text: string): { content: string; tokenCount: number }[] {
+  const chunks: { content: string; tokenCount: number }[] = [];
+  if (!text.trim()) return chunks;
+
+  const totalTokens = estimateTokens(text);
+  if (totalTokens <= TARGET_CHUNK_SIZE + MIN_CHUNK_SIZE) {
+    return [{ content: text.trim(), tokenCount: estimateTokens(text.trim()) }];
+  }
+
+  const charChunkSize = TARGET_CHUNK_SIZE * 4;
+  const charOverlap = CHUNK_OVERLAP * 4;
+  let start = 0;
+
+  while (start < text.length) {
+    let end = Math.min(start + charChunkSize, text.length);
+
+    if (end < text.length) {
+      const searchStart = Math.max(end - 200, start);
+      const segment = text.slice(searchStart, end + 200);
+
+      const breakPoints = ["\n\n", "\n", ". ", "? ", "! ", "; ", ", ", " "];
+      let bestBreak = -1;
+
+      for (const bp of breakPoints) {
+        const idx = segment.lastIndexOf(bp, end - searchStart);
+        if (idx !== -1) {
+          bestBreak = searchStart + idx + bp.length;
+          break;
+        }
+      }
+
+      if (bestBreak > start) {
+        end = bestBreak;
+      }
+    }
+
+    const chunkText = text.slice(start, end).trim();
+    if (chunkText.length > 0) {
+      chunks.push({ content: chunkText, tokenCount: estimateTokens(chunkText) });
+    }
+
+    start = end - charOverlap;
+    if (start >= text.length) break;
+  }
+
+  return chunks;
+}
+
+function chunkMarkdown(text: string): { content: string; tokenCount: number }[] {
+  const headingPattern = /\n(?=#{1,3} )/;
+  const sections = text.split(headingPattern).filter((s) => s.trim());
+
+  const chunks: { content: string; tokenCount: number }[] = [];
+
+  for (const section of sections) {
+    const tokens = estimateTokens(section);
+    if (tokens <= TARGET_CHUNK_SIZE + MIN_CHUNK_SIZE) {
+      const trimmed = section.trim();
+      if (trimmed) {
+        chunks.push({ content: trimmed, tokenCount: estimateTokens(trimmed) });
+      }
+    } else {
+      chunks.push(...chunkContent(section));
+    }
+  }
+
+  return chunks;
+}
+
+export const parsePdf = internalAction({
+  args: {
+    documentId: v.id("documents"),
+    storageId: v.id("_storage"),
+  },
+  handler: async (ctx, args) => {
+    await ctx.runMutation(internal.documents.updateStatus, {
+      id: args.documentId,
+      status: "processing",
+    });
+
+    try {
+      const url = await ctx.storage.getUrl(args.storageId);
+      if (!url) {
+        throw new Error("File not found in storage");
+      }
+
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to download file: ${response.statusText}`);
+      }
+
+      const buffer = Buffer.from(await response.arrayBuffer());
+      if (buffer.length === 0) {
+        throw new Error("File is empty");
+      }
+
+      const parser = new PDFParse({ data: new Uint8Array(buffer) });
+      const result = await parser.getText();
+      await parser.destroy();
+      const text = result.text?.trim();
+      if (!text) {
+        throw new Error("No text content could be extracted from the PDF");
+      }
+
+      const chunks = chunkContent(text);
+
+      await ctx.runMutation(internal.chunks.createBatch, {
+        documentId: args.documentId,
+        chunks,
+      });
+
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: args.documentId,
+        status: "ready",
+        chunkCount: chunks.length,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error during PDF parsing";
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: args.documentId,
+        status: "error",
+        errorMessage: message,
+      });
+    }
+  },
+});
+
+export const parseMarkdown = internalAction({
+  args: {
+    documentId: v.id("documents"),
+    storageId: v.id("_storage"),
+  },
+  handler: async (ctx, args) => {
+    await ctx.runMutation(internal.documents.updateStatus, {
+      id: args.documentId,
+      status: "processing",
+    });
+
+    try {
+      const url = await ctx.storage.getUrl(args.storageId);
+      if (!url) {
+        throw new Error("File not found in storage");
+      }
+
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to download file: ${response.statusText}`);
+      }
+
+      const text = await response.text();
+      if (!text.trim()) {
+        throw new Error("File is empty");
+      }
+
+      const chunks = chunkMarkdown(text);
+
+      await ctx.runMutation(internal.chunks.createBatch, {
+        documentId: args.documentId,
+        chunks,
+      });
+
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: args.documentId,
+        status: "ready",
+        chunkCount: chunks.length,
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unknown error during Markdown parsing";
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: args.documentId,
+        status: "error",
+        errorMessage: message,
+      });
+    }
+  },
+});

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -13,6 +13,7 @@
     "better-auth": "catalog:",
     "convex": "catalog:",
     "dotenv": "catalog:",
+    "pdf-parse": "^2.4.5",
     "zod": "catalog:"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Add `parsing.parsePdf` and `parsing.parseMarkdown` internal actions that download files from Convex storage, extract/parse content, chunk it, and store chunks via `chunks.createBatch`
- Add `chunkContent` helper that splits text into ~500-1000 token chunks with ~50 token overlap, preferring natural break points (paragraphs, sentences, headings)
- Markdown parsing respects heading boundaries (splits at `#`, `##`, `###`) before further chunking large sections
- Graceful error handling for empty files, missing storage, encrypted PDFs, and parse failures — sets document status to `"error"` with a message

## Test plan
- [ ] Upload a multi-page PDF and verify chunks are created with correct `chunkIndex` and `tokenCount`
- [ ] Upload a Markdown file with multiple headings and verify it splits at heading boundaries
- [ ] Upload an empty file and verify the document status is set to `"error"` with appropriate message
- [ ] Verify `embeddingStatus` is set to `"pending"` on all created chunks
- [ ] Verify document status transitions: `pending` → `processing` → `ready` (or `error`)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)