### PR TITLE
feat(#11): add document processing orchestration pipeline

### DIFF
--- a/packages/backend/convex/documents.ts
+++ b/packages/backend/convex/documents.ts
@@ -1,6 +1,7 @@
 import type { GenericCtx } from "@convex-dev/better-auth";
 import { v } from "convex/values";
 
+import { internal } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
 import { internalMutation, mutation, query } from "./_generated/server";
 import { authComponent } from "./auth";
@@ -27,7 +28,7 @@ export const create = mutation({
     if (!user) {
       throw new Error("Not authenticated");
     }
-    return await ctx.db.insert("documents", {
+    const documentId = await ctx.db.insert("documents", {
       title: args.title,
       fileType: args.fileType,
       storageId: args.storageId,
@@ -36,6 +37,10 @@ export const create = mutation({
       userId: user.userId,
       createdAt: Date.now(),
     });
+    await ctx.scheduler.runAfter(0, internal.processing.processDocument, {
+      documentId,
+    });
+    return documentId;
   },
 });
 

--- a/packages/backend/convex/parsing.ts
+++ b/packages/backend/convex/parsing.ts
@@ -60,7 +60,7 @@ export function chunkContent(text: string): { content: string; tokenCount: numbe
   return chunks;
 }
 
-function chunkMarkdown(text: string): { content: string; tokenCount: number }[] {
+export function chunkMarkdown(text: string): { content: string; tokenCount: number }[] {
   const headingPattern = /\n(?=#{1,3} )/;
   const sections = text.split(headingPattern).filter((s) => s.trim());
 

--- a/packages/backend/convex/processing.ts
+++ b/packages/backend/convex/processing.ts
@@ -1,0 +1,119 @@
+import { PDFParse } from "pdf-parse";
+import { v } from "convex/values";
+
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { internalAction } from "./_generated/server";
+import { chunkContent, chunkMarkdown } from "./parsing";
+
+export const processDocument = internalAction({
+  args: {
+    documentId: v.id("documents"),
+  },
+  handler: async (ctx, args) => {
+    const doc = await ctx.runQuery(internal.embeddings.getDocument, {
+      id: args.documentId,
+    });
+    if (!doc) {
+      throw new Error(`Document ${args.documentId} not found`);
+    }
+
+    // Step 1: Set status to "processing"
+    await ctx.runMutation(internal.documents.updateStatus, {
+      id: args.documentId,
+      status: "processing",
+    });
+
+    let chunks: { content: string; tokenCount: number }[];
+
+    try {
+      // Step 2: Fetch file from storage
+      const url = await ctx.storage.getUrl(doc.storageId);
+      if (!url) {
+        throw new Error("File not found in storage");
+      }
+
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to download file: ${response.statusText}`);
+      }
+
+      // Step 3: Parse content based on file type
+      if (doc.fileType === "pdf") {
+        const buffer = Buffer.from(await response.arrayBuffer());
+        if (buffer.length === 0) {
+          throw new Error("File is empty");
+        }
+        const parser = new PDFParse({ data: new Uint8Array(buffer) });
+        const result = await parser.getText();
+        await parser.destroy();
+        const text = result.text?.trim();
+        if (!text) {
+          throw new Error("No text content could be extracted from the PDF");
+        }
+        chunks = chunkContent(text);
+      } else {
+        const text = await response.text();
+        if (!text.trim()) {
+          throw new Error("File is empty");
+        }
+        chunks = chunkMarkdown(text);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error during parsing";
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: args.documentId,
+        status: "error",
+        errorMessage: message,
+      });
+      return;
+    }
+
+    // Step 4: Store chunks in DB
+    let chunkIds: Id<"chunks">[];
+    try {
+      chunkIds = await ctx.runMutation(internal.chunks.createBatch, {
+        documentId: args.documentId,
+        chunks,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error storing chunks";
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: args.documentId,
+        status: "error",
+        errorMessage: message,
+      });
+      return;
+    }
+
+    // Step 5: Update chunk count after successful parsing
+    await ctx.runMutation(internal.documents.updateStatus, {
+      id: args.documentId,
+      status: "processing",
+      chunkCount: chunks.length,
+    });
+
+    // Step 6: Embed chunks in Qdrant
+    try {
+      await ctx.runAction(internal.embeddings.embedChunks, {
+        chunkIds,
+      });
+    } catch (error) {
+      // Partial failure: chunks are stored but embedding failed
+      const message = error instanceof Error ? error.message : "Unknown error during embedding";
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: args.documentId,
+        status: "error",
+        errorMessage: message,
+      });
+      return;
+    }
+
+    // Step 7: Mark document as ready
+    await ctx.runMutation(internal.documents.updateStatus, {
+      id: args.documentId,
+      status: "ready",
+      chunkCount: chunks.length,
+    });
+  },
+});


### PR DESCRIPTION
## Summary
- Create `processing.ts` with `processDocument` internal action that orchestrates the full pipeline: set status → fetch file → parse (PDF/MD) → chunk → store in DB → embed in Qdrant → update status
- Update `documents.create` mutation to schedule `processDocument` via `ctx.scheduler.runAfter(0, ...)` immediately after insert
- Export `chunkMarkdown` from `parsing.ts` for reuse in the orchestrator

## Acceptance Criteria
- [x] `processing.processDocument` internal action — orchestrates full pipeline with proper error handling
- [x] `documents.create` schedules `processing.processDocument` after insert
- [x] Partial failure handling: if parsing succeeds but embedding fails, chunks are stored, status is "error"
- [x] Document `chunkCount` updated after successful parsing
- [x] End-to-end flow: upload → pending → processing → ready (or error)

## Test plan
- [ ] Upload a PDF file → verify document transitions pending → processing → ready
- [ ] Upload a Markdown file → verify same status transitions
- [ ] Upload an empty file → verify status becomes "error" with descriptive message
- [ ] Simulate embedding failure → verify chunks are stored but status is "error"

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)