### PR TITLE
feat(#14): add content library page with document list and status

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "catalog:",
+    "date-fns": "^4.1.0",
     "dotenv": "catalog:",
     "lucide-react": "^0.577.0",
     "next": "^16.1.1",

--- a/apps/web/src/app/library/[documentId]/page.tsx
+++ b/apps/web/src/app/library/[documentId]/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Authenticated, AuthLoading, Unauthenticated } from "convex/react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+function UnauthenticatedRedirect() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace("/signin");
+  }, [router]);
+  return null;
+}
+
+export default function DocumentDetailPage() {
+  return (
+    <>
+      <Authenticated>
+        <div className="container mx-auto max-w-3xl px-4 py-8">
+          <h1 className="text-2xl font-bold">Document Detail</h1>
+          <p className="mt-2 text-muted-foreground">Document details will appear here.</p>
+        </div>
+      </Authenticated>
+      <Unauthenticated>
+        <UnauthenticatedRedirect />
+      </Unauthenticated>
+      <AuthLoading>
+        <div className="flex flex-1 items-center justify-center">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-foreground" />
+        </div>
+      </AuthLoading>
+    </>
+  );
+}

--- a/apps/web/src/app/library/page.tsx
+++ b/apps/web/src/app/library/page.tsx
@@ -1,8 +1,151 @@
 "use client";
 
-import { Authenticated, AuthLoading, Unauthenticated } from "convex/react";
+import { api } from "@scrollect/backend/convex/_generated/api";
+import type { Doc } from "@scrollect/backend/convex/_generated/dataModel";
+import { Authenticated, AuthLoading, Unauthenticated, useQuery } from "convex/react";
+import { formatDistanceToNow } from "date-fns";
+import { FileText, Upload } from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const statusConfig = {
+  pending: {
+    label: "Pending",
+    className: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
+  },
+  processing: {
+    label: "Processing",
+    className: "bg-blue-100 text-blue-800 animate-pulse dark:bg-blue-900/30 dark:text-blue-400",
+  },
+  ready: {
+    label: "Ready",
+    className: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  },
+  error: {
+    label: "Error",
+    className: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  },
+} as const;
+
+const fileTypeIcons: Record<string, string> = {
+  pdf: "\u{1F4C4}",
+  md: "\u{1F4DD}",
+};
+
+function StatusBadge({ status }: { status: keyof typeof statusConfig }) {
+  const config = statusConfig[status];
+  return (
+    <Badge variant="outline" className={config.className}>
+      {config.label}
+    </Badge>
+  );
+}
+
+function DocumentCardSkeleton() {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-5 w-5" />
+          <Skeleton className="h-5 w-40" />
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-5 w-20" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function LibraryContent() {
+  const documents = useQuery(api.documents.list);
+
+  if (documents === undefined) {
+    return (
+      <div className="container mx-auto max-w-3xl px-4 py-8">
+        <h1 className="text-2xl font-bold">My Library</h1>
+        <p className="mt-2 text-muted-foreground">
+          Your uploaded documents and their processing status.
+        </p>
+        <div className="mt-6 grid gap-3">
+          <DocumentCardSkeleton />
+          <DocumentCardSkeleton />
+          <DocumentCardSkeleton />
+        </div>
+      </div>
+    );
+  }
+
+  if (documents.length === 0) {
+    return (
+      <div className="container mx-auto max-w-3xl px-4 py-8">
+        <h1 className="text-2xl font-bold">My Library</h1>
+        <div className="mt-12 flex flex-col items-center gap-4 text-center">
+          <FileText className="h-12 w-12 text-muted-foreground/50" />
+          <div>
+            <p className="text-lg font-medium">No documents yet</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Upload your first file to get started.
+            </p>
+          </div>
+          <Button render={<Link href="/upload" />}>
+            <Upload className="mr-2 h-4 w-4" />
+            Upload your first file
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-8">
+      <h1 className="text-2xl font-bold">My Library</h1>
+      <p className="mt-2 text-muted-foreground">
+        Your uploaded documents and their processing status.
+      </p>
+      <div className="mt-6 grid gap-3">
+        {documents.map((doc: Doc<"documents">) => (
+          <Link
+            key={doc._id}
+            href={`/library/${doc._id}` as `/library/${string}`}
+            className="block"
+          >
+            <Card className="transition-colors hover:bg-muted/50">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <span>{fileTypeIcons[doc.fileType] ?? "\u{1F4C4}"}</span>
+                  <span className="truncate">{doc.title}</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-3">
+                  <StatusBadge status={doc.status} />
+                  {doc.status === "ready" && (
+                    <span className="text-xs text-muted-foreground">
+                      {doc.chunkCount} chunk{doc.chunkCount !== 1 ? "s" : ""}
+                    </span>
+                  )}
+                  <span className="text-xs text-muted-foreground">
+                    {formatDistanceToNow(doc.createdAt, { addSuffix: true })}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 function UnauthenticatedRedirect() {
   const router = useRouter();
@@ -16,10 +159,7 @@ export default function LibraryPage() {
   return (
     <>
       <Authenticated>
-        <div className="container mx-auto max-w-3xl px-4 py-8">
-          <h1 className="text-2xl font-bold">Library</h1>
-          <p className="mt-2 text-muted-foreground">Your content library will appear here.</p>
-        </div>
+        <LibraryContent />
       </Authenticated>
       <Unauthenticated>
         <UnauthenticatedRedirect />

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  });
+}
+
+export { Badge, badgeVariants };

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "convex": "catalog:",
+        "date-fns": "^4.1.0",
         "dotenv": "catalog:",
         "lucide-react": "^0.577.0",
         "next": "^16.1.1",
@@ -1306,6 +1307,8 @@
     "dagre-d3-es": ["dagre-d3-es@7.0.13", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "dayjs": ["dayjs@1.11.19", "", {}, "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="],
 


### PR DESCRIPTION
## Summary
- Add `/library` page displaying all uploaded documents with real-time status updates via Convex subscription
- Document cards show title, file type icon (PDF/MD), color-coded status badges (pending/processing/ready/error), relative upload date (via `date-fns`), and chunk count
- Empty state with friendly message and link to upload page
- Skeleton loading state while data loads
- Placeholder `/library/[documentId]` detail page for navigation targets

## Test plan
- [ ] Visit `/library` while unauthenticated — should redirect to `/signin`
- [ ] Visit `/library` with no documents — should show empty state with upload link
- [ ] Upload a document via `/upload` and verify it appears in the library
- [ ] Verify status badge updates in real-time as document processes (pending → processing → ready)
- [ ] Verify color coding: pending (amber), processing (blue pulse), ready (green), error (red)
- [ ] Verify relative dates display correctly (e.g., "2 hours ago")
- [ ] Click a document card — should navigate to `/library/[documentId]`
- [ ] Verify skeleton loading state appears briefly on page load

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)