### PR TITLE
feat(#30): provider abstraction layer (ADR-001)

### DIFF
--- a/packages/backend/convex/providers/convexVectors.ts
+++ b/packages/backend/convex/providers/convexVectors.ts
@@ -1,0 +1,83 @@
+import type { ActionCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import type { VectorFilter, VectorPoint, VectorSearchResult, VectorStore } from "./types";
+
+/**
+ * Convex native vector search implementation.
+ *
+ * This is the recommended starting point per ADR-001: it requires no external
+ * services, has zero network latency, and is fully managed by Convex.
+ *
+ * The VectorStore interface enables swapping to Qdrant if richer filtering
+ * or higher scale is needed in the future.
+ *
+ * Requires a `vectorIndex("by_embedding", ...)` on the chunks table in schema.ts.
+ * See ADR-001 "Vector Store Decision" section for the schema addition.
+ */
+export class ConvexVectorStore implements VectorStore {
+  private ctx: ActionCtx;
+  private upsertRef: unknown;
+  private deleteRef: unknown;
+
+  constructor(ctx: ActionCtx, upsertRef: unknown, deleteRef: unknown) {
+    this.ctx = ctx;
+    this.upsertRef = upsertRef;
+    this.deleteRef = deleteRef;
+  }
+
+  async ensureCollection(): Promise<void> {
+    // No-op: Convex vector indexes are defined in the schema
+  }
+
+  async upsert(points: VectorPoint[]): Promise<void> {
+    if (points.length === 0) return;
+
+    // Store embeddings directly in the chunks table via internal mutation
+    await (this.ctx as ActionCtx).runMutation(
+      this.upsertRef as never,
+      {
+        points: points.map((p) => ({
+          chunkId: p.payload.chunkId as Id<"chunks">,
+          embedding: p.vector,
+        })),
+      } as never,
+    );
+  }
+
+  async search(
+    vector: number[],
+    filter: VectorFilter,
+    topK: number,
+  ): Promise<VectorSearchResult[]> {
+    const results = await this.ctx.vectorSearch("chunks", "by_embedding", {
+      vector,
+      limit: topK,
+      filter: (q: { eq: (field: string, value: string) => unknown }) =>
+        q.eq("userId", filter.userId),
+    } as never);
+
+    return (
+      results as Array<{
+        _id: string;
+        _score: number;
+        documentId: string;
+        chunkIndex: number;
+      }>
+    ).map((r) => ({
+      id: r._id,
+      score: r._score,
+      payload: {
+        chunkId: r._id,
+        documentId: r.documentId,
+        chunkIndex: r.chunkIndex,
+        userId: filter.userId,
+      },
+    }));
+  }
+
+  async delete(ids: string[]): Promise<void> {
+    if (ids.length === 0) return;
+
+    await (this.ctx as ActionCtx).runMutation(this.deleteRef as never, { chunkIds: ids } as never);
+  }
+}

--- a/packages/backend/convex/providers/datalab.ts
+++ b/packages/backend/convex/providers/datalab.ts
@@ -1,0 +1,73 @@
+import type { PdfParser, PollResult } from "./types";
+
+export class DatalabParser implements PdfParser {
+  private apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async submit(fileUrl: string): Promise<string> {
+    const formData = new FormData();
+    formData.append("file_url", fileUrl);
+    formData.append("output_format", "markdown");
+    formData.append("mode", "accurate");
+    formData.append("disable_image_extraction", "true");
+
+    const response = await fetch("https://www.datalab.to/api/v1/convert", {
+      method: "POST",
+      headers: { "X-API-Key": this.apiKey },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Datalab submit failed: ${response.status} ${errorText}`);
+    }
+
+    const data = await response.json();
+    if (!data.success || !data.request_check_url) {
+      throw new Error(`Datalab submit failed: ${JSON.stringify(data)}`);
+    }
+
+    return data.request_check_url;
+  }
+
+  async poll(checkUrl: string): Promise<PollResult> {
+    const response = await fetch(checkUrl, {
+      headers: { "X-API-Key": this.apiKey },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Datalab poll failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    if (data.status === "complete") {
+      if (!data.success) {
+        return {
+          status: "error",
+          errorMessage: data.error ?? "Datalab conversion failed",
+        };
+      }
+      const markdown = data.markdown?.trim();
+      if (!markdown) {
+        return {
+          status: "error",
+          errorMessage: "No text content could be extracted from the PDF",
+        };
+      }
+      return { status: "complete", markdown };
+    }
+
+    if (data.status === "error") {
+      return {
+        status: "error",
+        errorMessage: data.error ?? "Datalab parsing failed",
+      };
+    }
+
+    return { status: "pending" };
+  }
+}

--- a/packages/backend/convex/providers/openai.ts
+++ b/packages/backend/convex/providers/openai.ts
@@ -1,0 +1,36 @@
+import type { EmbeddingProvider } from "./types";
+
+export class OpenAIEmbeddings implements EmbeddingProvider {
+  private apiKey: string;
+  private model: string;
+  readonly dimensions: number;
+
+  constructor(apiKey: string, model: string = "text-embedding-3-small", dimensions: number = 1536) {
+    this.apiKey = apiKey;
+    this.model = model;
+    this.dimensions = dimensions;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const response = await fetch("https://api.openai.com/v1/embeddings", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ input: texts, model: this.model }),
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(`OpenAI embedding failed: ${JSON.stringify(data)}`);
+    }
+
+    // Sort by index to guarantee order matches input
+    return data.data
+      .sort((a: { index: number }, b: { index: number }) => a.index - b.index)
+      .map((d: { embedding: number[] }) => d.embedding);
+  }
+}

--- a/packages/backend/convex/providers/qdrant.ts
+++ b/packages/backend/convex/providers/qdrant.ts
@@ -1,0 +1,105 @@
+import type { VectorFilter, VectorPoint, VectorSearchResult, VectorStore } from "./types";
+
+const COLLECTION_NAME = "scrollect_chunks";
+
+/**
+ * Qdrant vector store implementation.
+ *
+ * Uses the Qdrant REST API directly (no SDK dependency) to keep the provider
+ * lightweight and compatible with Convex's action runtime.
+ */
+export class QdrantVectorStore implements VectorStore {
+  private url: string;
+  private apiKey: string;
+  private vectorSize: number;
+
+  constructor(url: string, apiKey: string, vectorSize: number = 1536) {
+    // Strip trailing slash for consistent URL construction
+    this.url = url.replace(/\/+$/, "");
+    this.apiKey = apiKey;
+    this.vectorSize = vectorSize;
+  }
+
+  private async request(path: string, options: RequestInit = {}): Promise<unknown> {
+    const response = await fetch(`${this.url}${path}`, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        "api-key": this.apiKey,
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(
+        `Qdrant ${options.method ?? "GET"} ${path} failed: ${response.status} ${body}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  async ensureCollection(): Promise<void> {
+    const data = (await this.request("/collections")) as {
+      result: { collections: Array<{ name: string }> };
+    };
+    const exists = data.result.collections.some((c) => c.name === COLLECTION_NAME);
+    if (!exists) {
+      await this.request(`/collections/${COLLECTION_NAME}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          vectors: { size: this.vectorSize, distance: "Cosine" },
+        }),
+      });
+    }
+  }
+
+  async upsert(points: VectorPoint[]): Promise<void> {
+    if (points.length === 0) return;
+
+    await this.request(`/collections/${COLLECTION_NAME}/points?wait=true`, {
+      method: "PUT",
+      body: JSON.stringify({
+        points: points.map((p) => ({
+          id: p.id,
+          vector: p.vector,
+          payload: p.payload,
+        })),
+      }),
+    });
+  }
+
+  async search(
+    vector: number[],
+    filter: VectorFilter,
+    topK: number,
+  ): Promise<VectorSearchResult[]> {
+    const data = (await this.request(`/collections/${COLLECTION_NAME}/points/search`, {
+      method: "POST",
+      body: JSON.stringify({
+        vector,
+        limit: topK,
+        filter: {
+          must: [{ key: "userId", match: { value: filter.userId } }],
+        },
+        with_payload: true,
+      }),
+    })) as { result: Array<{ id: string; score: number; payload: VectorPoint["payload"] }> };
+
+    return data.result.map((r) => ({
+      id: r.id,
+      score: r.score,
+      payload: r.payload,
+    }));
+  }
+
+  async delete(ids: string[]): Promise<void> {
+    if (ids.length === 0) return;
+
+    await this.request(`/collections/${COLLECTION_NAME}/points/delete?wait=true`, {
+      method: "POST",
+      body: JSON.stringify({ points: ids }),
+    });
+  }
+}

--- a/packages/backend/convex/providers/types.ts
+++ b/packages/backend/convex/providers/types.ts
@@ -1,0 +1,63 @@
+// --- PDF Parser ---
+
+export interface PollResult {
+  status: "pending" | "complete" | "error";
+  markdown?: string;
+  errorMessage?: string;
+}
+
+export interface PdfParser {
+  /** Submit a PDF for parsing. Returns a check URL for polling. */
+  submit(fileUrl: string): Promise<string>;
+
+  /** Poll for parsing result. */
+  poll(checkUrl: string): Promise<PollResult>;
+}
+
+// --- Embedding Provider ---
+
+export interface EmbeddingProvider {
+  /** The dimensionality of the embedding vectors. */
+  readonly dimensions: number;
+
+  /** Generate embeddings for a batch of texts. Returns one vector per input text. */
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+// --- Vector Store ---
+
+export interface VectorPoint {
+  /** Deterministic ID derived from chunk ID for idempotent upserts. */
+  id: string;
+  vector: number[];
+  payload: {
+    chunkId: string;
+    documentId: string;
+    chunkIndex: number;
+    userId: string;
+  };
+}
+
+export interface VectorFilter {
+  userId: string;
+}
+
+export interface VectorSearchResult {
+  id: string;
+  score: number;
+  payload: VectorPoint["payload"];
+}
+
+export interface VectorStore {
+  /** Ensure the backing collection/index exists. Idempotent. */
+  ensureCollection(): Promise<void>;
+
+  /** Upsert vectors. Overwrites existing points with the same ID. */
+  upsert(points: VectorPoint[]): Promise<void>;
+
+  /** Search for similar vectors, filtered by userId. */
+  search(vector: number[], filter: VectorFilter, topK: number): Promise<VectorSearchResult[]>;
+
+  /** Delete vectors by ID. */
+  delete(ids: string[]): Promise<void>;
+}


### PR DESCRIPTION
## Summary

- Add `packages/backend/convex/providers/` directory with interfaces and concrete implementations for the document processing pipeline's external services
- **Interfaces** (`types.ts`): `PdfParser`, `EmbeddingProvider`, `VectorStore` with supporting types (`PollResult`, `VectorPoint`, `VectorFilter`, `VectorSearchResult`)
- **Implementations**: `DatalabParser` (PDF parsing), `OpenAIEmbeddings` (embeddings), `QdrantVectorStore` (Qdrant REST API), `ConvexVectorStore` (Convex native vectors)
- All providers use constructor injection and are independently testable with no pipeline orchestration dependencies
- Qdrant implementation uses REST API directly (no SDK) for lighter footprint in Convex action runtime

## Test plan

- [x] `bun run check` — lint and format pass
- [x] `bun turbo run build` — all packages build successfully
- [x] `bun run test:e2e` — 6 passed, 3 skipped (pre-existing)
- [ ] Verify TypeScript compiles with strict mode (covered by build)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)