### PR TITLE
feat(#31): pipeline orchestration with resumability (ADR-001)

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -18,8 +18,14 @@ import type * as healthCheck from "../healthCheck.js";
 import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
 import type * as parsing from "../parsing.js";
+import type * as pipeline from "../pipeline.js";
 import type * as privateData from "../privateData.js";
 import type * as processingJobs from "../processingJobs.js";
+import type * as providers_convexVectors from "../providers/convexVectors.js";
+import type * as providers_datalab from "../providers/datalab.js";
+import type * as providers_openai from "../providers/openai.js";
+import type * as providers_qdrant from "../providers/qdrant.js";
+import type * as providers_types from "../providers/types.js";
 
 import type { ApiFromModules, FilterApi, FunctionReference } from "convex/server";
 
@@ -34,8 +40,14 @@ declare const fullApi: ApiFromModules<{
   helpers: typeof helpers;
   http: typeof http;
   parsing: typeof parsing;
+  pipeline: typeof pipeline;
   privateData: typeof privateData;
   processingJobs: typeof processingJobs;
+  "providers/convexVectors": typeof providers_convexVectors;
+  "providers/datalab": typeof providers_datalab;
+  "providers/openai": typeof providers_openai;
+  "providers/qdrant": typeof providers_qdrant;
+  "providers/types": typeof providers_types;
 }>;
 
 /**

--- a/packages/backend/convex/chunks.ts
+++ b/packages/backend/convex/chunks.ts
@@ -1,8 +1,8 @@
 import type { GenericCtx } from "@convex-dev/better-auth";
 import { v } from "convex/values";
 
-import type { DataModel } from "./_generated/dataModel";
-import { internalMutation, query } from "./_generated/server";
+import type { DataModel, Id } from "./_generated/dataModel";
+import { internalMutation, internalQuery, query } from "./_generated/server";
 import { authComponent } from "./auth";
 
 export const listByDocument = query({
@@ -29,24 +29,71 @@ export const createBatch = internalMutation({
     chunks: v.array(
       v.object({
         content: v.string(),
+        chunkIndex: v.number(),
         tokenCount: v.number(),
       }),
     ),
   },
   handler: async (ctx, args) => {
     const now = Date.now();
-    const ids = await Promise.all(
-      args.chunks.map((chunk, index) =>
-        ctx.db.insert("chunks", {
-          documentId: args.documentId,
-          content: chunk.content,
-          chunkIndex: index,
-          tokenCount: chunk.tokenCount,
-          embedded: false,
-          createdAt: now,
-        }),
-      ),
-    );
+    const ids: Id<"chunks">[] = [];
+    for (const chunk of args.chunks) {
+      const existing = await ctx.db
+        .query("chunks")
+        .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+        .filter((q) => q.eq(q.field("chunkIndex"), chunk.chunkIndex))
+        .first();
+
+      if (existing) {
+        ids.push(existing._id);
+        continue;
+      }
+
+      const id = await ctx.db.insert("chunks", {
+        documentId: args.documentId,
+        content: chunk.content,
+        chunkIndex: chunk.chunkIndex,
+        tokenCount: chunk.tokenCount,
+        embedded: false,
+        createdAt: now,
+      });
+      ids.push(id);
+    }
     return ids;
+  },
+});
+
+export const listByDocumentInternal = internalQuery({
+  args: { documentId: v.id("documents") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("chunks")
+      .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+      .collect();
+  },
+});
+
+export const listUnembedded = internalQuery({
+  args: { documentId: v.id("documents") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("chunks")
+      .withIndex("by_documentId_unembedded", (q) =>
+        q.eq("documentId", args.documentId).eq("embedded", false),
+      )
+      .collect();
+  },
+});
+
+export const markEmbedded = internalMutation({
+  args: {
+    chunkId: v.id("chunks"),
+    embeddingId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.chunkId, {
+      embedded: true,
+      embeddingId: args.embeddingId,
+    });
   },
 });

--- a/packages/backend/convex/documents.ts
+++ b/packages/backend/convex/documents.ts
@@ -1,8 +1,9 @@
 import type { GenericCtx } from "@convex-dev/better-auth";
 import { v } from "convex/values";
 
+import { internal } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
-import { internalMutation, mutation, query } from "./_generated/server";
+import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
 import { authComponent } from "./auth";
 
 export const generateUploadUrl = mutation({
@@ -35,6 +36,9 @@ export const create = mutation({
       chunkCount: 0,
       userId: user._id,
       createdAt: Date.now(),
+    });
+    await ctx.scheduler.runAfter(0, internal.pipeline.startProcessing, {
+      documentId,
     });
     return documentId;
   },
@@ -85,6 +89,9 @@ export const updateStatus = internalMutation({
     ),
     errorMessage: v.optional(v.string()),
     chunkCount: v.optional(v.number()),
+    failedAt: v.optional(
+      v.union(v.literal("parsing"), v.literal("chunking"), v.literal("embedding")),
+    ),
   },
   handler: async (ctx, args) => {
     const { id, ...fields } = args;
@@ -95,6 +102,47 @@ export const updateStatus = internalMutation({
     if (fields.chunkCount !== undefined) {
       update.chunkCount = fields.chunkCount;
     }
+    if (fields.failedAt !== undefined) {
+      update.failedAt = fields.failedAt;
+    }
     await ctx.db.patch(id, update);
+  },
+});
+
+export const setDatalabCheckUrl = internalMutation({
+  args: {
+    id: v.id("documents"),
+    checkUrl: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.id, { datalabCheckUrl: args.checkUrl });
+  },
+});
+
+export const getInternal = internalQuery({
+  args: { id: v.id("documents") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id);
+  },
+});
+
+export const retry = mutation({
+  args: { id: v.id("documents") },
+  handler: async (ctx, args) => {
+    const user = await authComponent.safeGetAuthUser(ctx as unknown as GenericCtx<DataModel>);
+    if (!user) {
+      throw new Error("Not authenticated");
+    }
+    const doc = await ctx.db.get(args.id);
+    if (!doc || doc.userId !== user._id) {
+      throw new Error("Document not found");
+    }
+    if (doc.status !== "error") {
+      throw new Error("Document is not in error state");
+    }
+    await ctx.db.patch(args.id, { errorMessage: undefined });
+    await ctx.scheduler.runAfter(0, internal.pipeline.resumeProcessing, {
+      documentId: args.id,
+    });
   },
 });

--- a/packages/backend/convex/parsing.ts
+++ b/packages/backend/convex/parsing.ts
@@ -102,7 +102,10 @@ export const pollDatalabResult = internalAction({
       // Store chunks in batches to avoid mutation size limits
       const allChunkIds = [];
       for (let i = 0; i < chunks.length; i += CHUNK_BATCH_SIZE) {
-        const batch = chunks.slice(i, i + CHUNK_BATCH_SIZE);
+        const batch = chunks.slice(i, i + CHUNK_BATCH_SIZE).map((c, j) => ({
+          ...c,
+          chunkIndex: i + j,
+        }));
         const ids = await ctx.runMutation(internal.chunks.createBatch, {
           documentId: args.documentId,
           chunks: batch,
@@ -187,7 +190,8 @@ export const parseMarkdown = internalAction({
         throw new Error("File is empty");
       }
 
-      const chunks = chunkMarkdown(text);
+      const rawChunks = chunkMarkdown(text);
+      const chunks = rawChunks.map((c, i) => ({ ...c, chunkIndex: i }));
 
       await ctx.runMutation(internal.chunks.createBatch, {
         documentId: args.documentId,

--- a/packages/backend/convex/pipeline.ts
+++ b/packages/backend/convex/pipeline.ts
@@ -1,0 +1,494 @@
+"use node";
+
+import { v } from "convex/values";
+
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import type { ActionCtx } from "./_generated/server";
+import { internalAction } from "./_generated/server";
+import { chunkMarkdown } from "./chunking";
+import { DatalabParser } from "./providers/datalab";
+import { OpenAIEmbeddings } from "./providers/openai";
+import { QdrantVectorStore } from "./providers/qdrant";
+import type { EmbeddingProvider, VectorStore } from "./providers/types";
+
+const CHUNK_STORE_BATCH_SIZE = 50;
+const EMBED_BATCH_SIZE = 100;
+const MAX_EMBED_RETRIES = 3;
+
+const INITIAL_POLL_DELAY_MS = 5_000;
+const MAX_POLL_DELAY_MS = 40_000;
+const MAX_POLL_DURATION_MS = 300_000;
+
+function getPollDelay(attempt: number): number {
+  return Math.min(INITIAL_POLL_DELAY_MS * Math.pow(2, attempt), MAX_POLL_DELAY_MS);
+}
+
+function createEmbeddingProvider(): EmbeddingProvider {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error("OPENAI_API_KEY environment variable is not set");
+  return new OpenAIEmbeddings(apiKey);
+}
+
+function createVectorStore(): VectorStore {
+  const url = process.env.QDRANT_URL;
+  const apiKey = process.env.QDRANT_API_KEY;
+  if (!url || !apiKey)
+    throw new Error("QDRANT_URL and QDRANT_API_KEY environment variables are required");
+  return new QdrantVectorStore(url, apiKey);
+}
+
+// --- Entry Point ---
+
+export const startProcessing = internalAction({
+  args: { documentId: v.id("documents") },
+  handler: async (ctx, { documentId }) => {
+    const doc = await ctx.runQuery(internal.documents.getInternal, { id: documentId });
+    if (!doc) throw new Error(`Document ${documentId} not found`);
+
+    if (doc.fileType === "pdf") {
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: documentId,
+        status: "parsing",
+      });
+      await submitPdfParsingImpl(ctx, documentId, doc.storageId);
+    } else {
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: documentId,
+        status: "parsing",
+      });
+      await fetchAndParseMarkdownImpl(ctx, documentId, doc.storageId);
+    }
+  },
+});
+
+// --- PDF Parsing ---
+
+async function submitPdfParsingImpl(
+  ctx: ActionCtx,
+  documentId: Id<"documents">,
+  storageId: Id<"_storage">,
+) {
+  try {
+    const apiKey = process.env.DATALAB_API_KEY;
+    if (!apiKey) throw new Error("DATALAB_API_KEY environment variable is not set");
+
+    const fileUrl = await ctx.storage.getUrl(storageId);
+    if (!fileUrl) throw new Error("File not found in storage");
+
+    const parser = new DatalabParser(apiKey);
+    const checkUrl = await parser.submit(fileUrl);
+
+    // Persist checkpoint BEFORE polling starts
+    await ctx.runMutation(internal.documents.setDatalabCheckUrl, {
+      id: documentId,
+      checkUrl,
+    });
+
+    const startedAt = Date.now();
+    await ctx.scheduler.runAfter(INITIAL_POLL_DELAY_MS, internal.pipeline.pollDatalabResult, {
+      documentId,
+      checkUrl,
+      attempt: 0,
+      startedAt,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "PDF submission failed";
+    await ctx.runMutation(internal.documents.updateStatus, {
+      id: documentId,
+      status: "error",
+      errorMessage: message,
+      failedAt: "parsing",
+    });
+  }
+}
+
+export const pollDatalabResult = internalAction({
+  args: {
+    documentId: v.id("documents"),
+    checkUrl: v.string(),
+    attempt: v.number(),
+    startedAt: v.number(),
+  },
+  handler: async (ctx, { documentId, checkUrl, attempt, startedAt }) => {
+    const elapsed = Date.now() - startedAt;
+    if (elapsed > MAX_POLL_DURATION_MS) {
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: documentId,
+        status: "error",
+        errorMessage: "PDF parsing timed out after 5 minutes",
+        failedAt: "parsing",
+      });
+      return;
+    }
+
+    try {
+      const apiKey = process.env.DATALAB_API_KEY;
+      if (!apiKey) throw new Error("DATALAB_API_KEY environment variable is not set");
+
+      const parser = new DatalabParser(apiKey);
+      const result = await parser.poll(checkUrl);
+
+      if (result.status === "complete") {
+        await ctx.scheduler.runAfter(0, internal.pipeline.chunkAndStore, {
+          documentId,
+          markdown: result.markdown!,
+        });
+        return;
+      }
+
+      if (result.status === "error") {
+        await ctx.runMutation(internal.documents.updateStatus, {
+          id: documentId,
+          status: "error",
+          errorMessage: result.errorMessage ?? "PDF parsing failed",
+          failedAt: "parsing",
+        });
+        return;
+      }
+
+      // Still pending — schedule next poll with exponential backoff
+      const nextDelay = getPollDelay(attempt);
+      await ctx.scheduler.runAfter(nextDelay, internal.pipeline.pollDatalabResult, {
+        documentId,
+        checkUrl,
+        attempt: attempt + 1,
+        startedAt,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Polling failed";
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: documentId,
+        status: "error",
+        errorMessage: message,
+        failedAt: "parsing",
+      });
+    }
+  },
+});
+
+// --- Markdown Parsing ---
+
+async function fetchAndParseMarkdownImpl(
+  ctx: ActionCtx,
+  documentId: Id<"documents">,
+  storageId: Id<"_storage">,
+) {
+  try {
+    const url = await ctx.storage.getUrl(storageId);
+    if (!url) throw new Error("File not found in storage");
+
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`Failed to download file: ${response.statusText}`);
+
+    const text = await response.text();
+    if (!text.trim()) throw new Error("File is empty");
+
+    await ctx.scheduler.runAfter(0, internal.pipeline.chunkAndStore, {
+      documentId,
+      markdown: text,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Markdown parsing failed";
+    await ctx.runMutation(internal.documents.updateStatus, {
+      id: documentId,
+      status: "error",
+      errorMessage: message,
+      failedAt: "parsing",
+    });
+  }
+}
+
+// --- Chunking ---
+
+export const chunkAndStore = internalAction({
+  args: {
+    documentId: v.id("documents"),
+    markdown: v.string(),
+  },
+  handler: async (ctx, { documentId, markdown }) => {
+    try {
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: documentId,
+        status: "chunking",
+      });
+
+      const rawChunks = chunkMarkdown(markdown);
+      const chunks = rawChunks.map((c, i) => ({
+        content: c.content,
+        chunkIndex: i,
+        tokenCount: c.tokenCount,
+      }));
+
+      console.log(`[chunkAndStore] ${chunks.length} chunks for document ${documentId}`);
+
+      const allChunkIds: Id<"chunks">[] = [];
+      for (let i = 0; i < chunks.length; i += CHUNK_STORE_BATCH_SIZE) {
+        const batch = chunks.slice(i, i + CHUNK_STORE_BATCH_SIZE);
+        const ids = await ctx.runMutation(internal.chunks.createBatch, {
+          documentId,
+          chunks: batch,
+        });
+        allChunkIds.push(...ids);
+      }
+
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: documentId,
+        status: "embedding",
+        chunkCount: chunks.length,
+      });
+
+      // Fan-out embedding batches
+      await fanOutEmbedding(ctx, documentId, allChunkIds);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Chunking failed";
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: documentId,
+        status: "error",
+        errorMessage: message,
+        failedAt: "chunking",
+      });
+    }
+  },
+});
+
+// --- Embedding ---
+
+async function fanOutEmbedding(
+  ctx: ActionCtx,
+  documentId: Id<"documents">,
+  chunkIds: Id<"chunks">[],
+) {
+  if (chunkIds.length === 0) {
+    await ctx.runMutation(internal.documents.updateStatus, {
+      id: documentId,
+      status: "ready",
+      chunkCount: 0,
+    });
+    return;
+  }
+
+  const totalBatches = Math.ceil(chunkIds.length / EMBED_BATCH_SIZE);
+  const jobId = await ctx.runMutation(internal.processingJobs.create, {
+    documentId,
+    totalBatches,
+  });
+
+  for (let i = 0; i < chunkIds.length; i += EMBED_BATCH_SIZE) {
+    const batchChunkIds = chunkIds.slice(i, i + EMBED_BATCH_SIZE);
+    await ctx.scheduler.runAfter(0, internal.pipeline.embedBatch, {
+      jobId,
+      documentId,
+      chunkIds: batchChunkIds,
+      retryCount: 0,
+    });
+  }
+}
+
+export const embedBatch = internalAction({
+  args: {
+    jobId: v.id("processingJobs"),
+    documentId: v.id("documents"),
+    chunkIds: v.array(v.id("chunks")),
+    retryCount: v.number(),
+  },
+  handler: async (ctx, { jobId, documentId, chunkIds, retryCount }) => {
+    try {
+      const embedder = createEmbeddingProvider();
+      const vectorStore = createVectorStore();
+
+      // Fetch chunk contents
+      const chunks = await Promise.all(
+        chunkIds.map((id) => ctx.runQuery(internal.helpers.getChunk, { id })),
+      );
+
+      // Get document for userId
+      const doc = await ctx.runQuery(internal.documents.getInternal, { id: documentId });
+      if (!doc) throw new Error(`Document ${documentId} not found`);
+
+      const validChunks = chunks.filter(
+        (c): c is NonNullable<typeof c> => c !== null && !c.embedded,
+      );
+
+      if (validChunks.length === 0) {
+        // All chunks already embedded — mark batch complete
+        const job = await ctx.runMutation(internal.processingJobs.markBatchComplete, {
+          id: jobId,
+          failed: false,
+        });
+        await checkCompletion(ctx, job, documentId);
+        return;
+      }
+
+      const texts = validChunks.map((c) => c.content);
+      const vectors = await embedder.embed(texts);
+
+      // Build vector points with deterministic IDs
+      const points = validChunks.map((chunk, i) => ({
+        id: chunk._id as string,
+        vector: vectors[i],
+        payload: {
+          chunkId: chunk._id as string,
+          documentId: documentId as string,
+          chunkIndex: chunk.chunkIndex,
+          userId: doc.userId,
+        },
+      }));
+
+      await vectorStore.upsert(points);
+
+      // Mark each chunk as embedded
+      for (const chunk of validChunks) {
+        await ctx.runMutation(internal.chunks.markEmbedded, {
+          chunkId: chunk._id,
+          embeddingId: chunk._id as string,
+        });
+      }
+
+      // Mark batch complete and check fan-in
+      const job = await ctx.runMutation(internal.processingJobs.markBatchComplete, {
+        id: jobId,
+        failed: false,
+      });
+      await checkCompletion(ctx, job, documentId);
+    } catch (error) {
+      console.error(`[embedBatch] Error (attempt ${retryCount}):`, error);
+
+      if (retryCount < MAX_EMBED_RETRIES) {
+        const delayMs = Math.pow(2, retryCount) * 1000;
+        await ctx.scheduler.runAfter(delayMs, internal.pipeline.embedBatch, {
+          jobId,
+          documentId,
+          chunkIds,
+          retryCount: retryCount + 1,
+        });
+        return;
+      }
+
+      // Retries exhausted
+      const job = await ctx.runMutation(internal.processingJobs.markBatchComplete, {
+        id: jobId,
+        failed: true,
+      });
+      await checkCompletion(ctx, job, documentId);
+    }
+  },
+});
+
+async function checkCompletion(
+  ctx: ActionCtx,
+  job: { totalBatches: number; completedBatches: number; failedBatches: number },
+  documentId: Id<"documents">,
+) {
+  if (job.completedBatches + job.failedBatches < job.totalBatches) {
+    return;
+  }
+
+  if (job.failedBatches > 0) {
+    await ctx.runMutation(internal.documents.updateStatus, {
+      id: documentId,
+      status: "error",
+      errorMessage: `${job.failedBatches}/${job.totalBatches} embedding batches failed`,
+      failedAt: "embedding",
+    });
+  } else {
+    await ctx.runMutation(internal.documents.updateStatus, {
+      id: documentId,
+      status: "ready",
+    });
+  }
+}
+
+// --- Resumability ---
+
+export const resumeProcessing = internalAction({
+  args: { documentId: v.id("documents") },
+  handler: async (ctx, { documentId }) => {
+    const doc = await ctx.runQuery(internal.documents.getInternal, { id: documentId });
+    if (!doc) throw new Error(`Document ${documentId} not found`);
+    if (doc.status !== "error") return;
+
+    switch (doc.failedAt) {
+      case "parsing":
+        if (doc.datalabCheckUrl) {
+          // Resume polling from saved checkpoint
+          await ctx.runMutation(internal.documents.updateStatus, {
+            id: documentId,
+            status: "parsing",
+          });
+          await ctx.scheduler.runAfter(0, internal.pipeline.pollDatalabResult, {
+            documentId,
+            checkUrl: doc.datalabCheckUrl,
+            attempt: 0,
+            startedAt: Date.now(),
+          });
+        } else {
+          // Re-start processing from scratch
+          await ctx.scheduler.runAfter(0, internal.pipeline.startProcessing, {
+            documentId,
+          });
+        }
+        break;
+
+      case "chunking": {
+        const allChunks = await ctx.runQuery(internal.chunks.listByDocumentInternal, {
+          documentId,
+        });
+        if (allChunks.length > 0) {
+          // Chunks exist — skip to embedding
+          await ctx.runMutation(internal.documents.updateStatus, {
+            id: documentId,
+            status: "embedding",
+          });
+          await ctx.scheduler.runAfter(0, internal.pipeline.embedUnembeddedChunks, {
+            documentId,
+          });
+        } else {
+          // No chunks — re-start from scratch
+          await ctx.scheduler.runAfter(0, internal.pipeline.startProcessing, {
+            documentId,
+          });
+        }
+        break;
+      }
+
+      case "embedding":
+        await ctx.runMutation(internal.documents.updateStatus, {
+          id: documentId,
+          status: "embedding",
+        });
+        await ctx.scheduler.runAfter(0, internal.pipeline.embedUnembeddedChunks, {
+          documentId,
+        });
+        break;
+
+      default:
+        // No failedAt — restart from scratch
+        await ctx.scheduler.runAfter(0, internal.pipeline.startProcessing, {
+          documentId,
+        });
+        break;
+    }
+  },
+});
+
+export const embedUnembeddedChunks = internalAction({
+  args: { documentId: v.id("documents") },
+  handler: async (ctx, { documentId }) => {
+    const unembedded = await ctx.runQuery(internal.chunks.listUnembedded, {
+      documentId,
+    });
+
+    if (unembedded.length === 0) {
+      // All chunks already embedded
+      await ctx.runMutation(internal.documents.updateStatus, {
+        id: documentId,
+        status: "ready",
+      });
+      return;
+    }
+
+    const chunkIds = unembedded.map((c) => c._id);
+    await fanOutEmbedding(ctx, documentId, chunkIds);
+  },
+});

--- a/packages/backend/convex/processingJobs.ts
+++ b/packages/backend/convex/processingJobs.ts
@@ -29,15 +29,25 @@ export const markBatchComplete = internalMutation({
     if (!job) {
       throw new Error(`Processing job ${args.id} not found`);
     }
-    if (args.failed) {
-      await ctx.db.patch(args.id, {
-        failedBatches: job.failedBatches + 1,
-      });
-    } else {
-      await ctx.db.patch(args.id, {
-        completedBatches: job.completedBatches + 1,
-      });
-    }
+    const update = args.failed
+      ? { failedBatches: job.failedBatches + 1 }
+      : { completedBatches: job.completedBatches + 1 };
+    await ctx.db.patch(args.id, update);
+    return {
+      ...job,
+      ...update,
+    };
+  },
+});
+
+export const getByDocument = internalQuery({
+  args: { documentId: v.id("documents") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("processingJobs")
+      .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+      .order("desc")
+      .first();
   },
 });
 

--- a/packages/backend/convex/providers/convexVectors.ts
+++ b/packages/backend/convex/providers/convexVectors.ts
@@ -49,15 +49,19 @@ export class ConvexVectorStore implements VectorStore {
     filter: VectorFilter,
     topK: number,
   ): Promise<VectorSearchResult[]> {
-    const results = await this.ctx.vectorSearch("chunks", "by_embedding", {
-      vector,
-      limit: topK,
-      filter: (q: { eq: (field: string, value: string) => unknown }) =>
-        q.eq("userId", filter.userId),
-    } as never);
+    const results = await (this.ctx as ActionCtx).vectorSearch(
+      "chunks" as never,
+      "by_embedding" as never,
+      {
+        vector,
+        limit: topK,
+        filter: (q: { eq: (field: string, value: string) => unknown }) =>
+          q.eq("userId", filter.userId),
+      } as never,
+    );
 
     return (
-      results as Array<{
+      results as unknown as Array<{
         _id: string;
         _score: number;
         documentId: string;


### PR DESCRIPTION
## Summary

- Implements `pipeline.ts` — the core processing orchestration with full resumability as defined in ADR-001
- **Entry point**: `startProcessing(documentId)` reads fileType, dispatches to PDF (Datalab) or Markdown path
- **Parsing**: `submitPdfParsing` persists `datalabCheckUrl` checkpoint before polling; `pollDatalabResult` uses exponential backoff (5s, 10s, 20s, 40s cap) with 5-min total timeout
- **Chunking**: `chunkAndStore` splits via `chunkMarkdown()`, batch inserts 50/batch with idempotent `createBatch` (dedup by `chunkIndex`)
- **Embedding**: Fan-out/fan-in pattern — `embedBatch` generates embeddings via `EmbeddingProvider`, upserts to `VectorStore`, marks each chunk `embedded: true`; retries up to 3x with exponential backoff (1s, 2s, 4s)
- **Resumability**: `resumeProcessing` reads `failedAt` and dispatches to correct stage; `embedUnembeddedChunks` only processes `embedded === false` chunks
- **Wiring**: `documents.create` auto-schedules `pipeline.startProcessing`; new `documents.retry` mutation for user-triggered resume
- Fixes `convexVectors.ts` type cast errors that broke web build

## Changed files

| File | Change |
|------|--------|
| `pipeline.ts` | **New** — full pipeline orchestration |
| `chunks.ts` | Idempotent `createBatch` (dedup by chunkIndex), `listUnembedded`, `listByDocumentInternal`, `markEmbedded` |
| `documents.ts` | `create` schedules pipeline, `retry` mutation, `setDatalabCheckUrl`, `getInternal`, `failedAt` in `updateStatus` |
| `processingJobs.ts` | `markBatchComplete` returns updated job for fan-in, `getByDocument` query |
| `parsing.ts` | Updated to match new `createBatch` signature (adds `chunkIndex`) |
| `convexVectors.ts` | Fixed type casts for web build compatibility |

## Test plan

- [x] Lint passes (`bun run check`)
- [x] Build passes (`bun turbo build`)
- [x] E2E tests pass (6 passed, 3 skipped)
- [ ] Manual: Upload a PDF end-to-end → status: uploaded → parsing → chunking → embedding → ready
- [ ] Manual: Upload a markdown file end-to-end
- [ ] Manual: Kill mid-embedding, retry → only unembedded chunks processed

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)