### PR TITLE
feat: add structured wide event logging to backend

### DIFF
--- a/.agents/skills/wide-event-logging/SKILL.md
+++ b/.agents/skills/wide-event-logging/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: wide-event-logging
+description: Structured logging using the wide event pattern for Convex backend functions. Use this skill whenever adding logging, debugging pipeline issues, instrumenting functions, adding observability, or discussing console.log practices in the backend. Also trigger when the user mentions "wide events", structured logs, or asks how to make backend functions more debuggable. This skill applies to any work in packages/backend/convex/.
+---
+
+# Wide Event Logging
+
+This project uses a "wide event" logging pattern (inspired by [loggingsucks.com](https://loggingsucks.com)): **one structured JSON log line per function execution** that captures all relevant business context. This replaces scattered `console.log` / `console.error` calls with a single, rich event per function.
+
+## Why wide events
+
+Traditional logging sprinkles multiple log lines throughout a function. This makes it hard to correlate context across lines and creates noise. A wide event collects all context into one object and emits it once when the function completes. Benefits:
+
+- **One line = one function execution** — easy to filter and search in the Convex dashboard
+- **All context in one place** — no need to mentally stitch together multiple log lines
+- **Duration is automatic** — every event includes `durationMs`
+- **Errors are structured** — `error: true` + `errorMessage` fields, not free-form strings
+- **Convex enriches automatically** — `function_path`, `request_id`, `type`, and `timestamp` are added by the platform
+
+## The WideEvent class
+
+Located at `packages/backend/convex/logging.ts`:
+
+```typescript
+import { WideEvent } from "./logging";
+```
+
+### API
+
+```typescript
+const evt = new WideEvent("pipeline.startProcessing"); // operation name + start timer
+evt.set("documentId", id); // single key-value
+evt.set({ fileType: "pdf", userId: "abc" }); // bulk set from object
+evt.setError(error); // sets error=true + errorMessage
+evt.emit(); // logs JSON with durationMs
+```
+
+All methods except `emit()` are chainable.
+
+## Instrumentation pattern
+
+Every instrumented function follows this exact structure:
+
+```typescript
+handler: async (ctx, args) => {
+  const evt = new WideEvent("module.functionName");
+  evt.set({
+    /* args and initial context */
+  });
+  try {
+    // ... business logic ...
+    // Add context as it becomes available:
+    evt.set("chunkCount", chunks.length);
+  } catch (error) {
+    evt.setError(error);
+    throw error; // re-throw so Convex tracks the failure
+  } finally {
+    evt.emit(); // ALWAYS emit, success or failure
+  }
+};
+```
+
+Key rules:
+
+1. **Create the event at the top** of the handler, before any async work
+2. **Set args immediately** so they appear even if the function fails early
+3. **`emit()` goes in `finally`** so it fires on both success and failure paths
+4. **Re-throw errors** after `setError()` — the wide event captures context, but Convex still needs to see the error for its own tracking
+5. **One emit per function** — never call `emit()` more than once
+
+## Passing events to helpers
+
+When a top-level handler delegates to a private helper function, pass the `WideEvent` instance so the helper can add its own context. The helper calls `evt.set()` and `evt.setError()` but **never** `evt.emit()` — the top-level handler is responsible for emitting.
+
+```typescript
+// Top-level handler creates and emits
+handler: async (ctx, args) => {
+  const evt = new WideEvent("pipeline.startProcessing");
+  try {
+    // ...
+    await submitPdfParsingImpl(ctx, documentId, storageId, evt);
+  } catch (error) {
+    evt.setError(error);
+    throw error;
+  } finally {
+    evt.emit();
+  }
+};
+
+// Helper adds context but does NOT emit
+async function submitPdfParsingImpl(ctx, documentId, storageId, evt: WideEvent) {
+  try {
+    evt.set("path", "pdf");
+    // ...
+  } catch (error) {
+    evt.setError(error);
+    // handle error (e.g., update status), but do NOT emit or re-throw
+    // (the top-level handler controls the emit lifecycle)
+  }
+}
+```
+
+## Sub-operation timing
+
+For functions that call external services, measure individual operations and attach them to the parent event:
+
+```typescript
+const t0 = Date.now();
+const vectors = await embedder.embed(texts);
+evt.set("embedDurationMs", Date.now() - t0);
+
+const t1 = Date.now();
+await vectorStore.upsert(points);
+evt.set("upsertDurationMs", Date.now() - t1);
+```
+
+This reveals which external call is the bottleneck without adding extra log lines.
+
+## What to log vs. what to skip
+
+### Instrument these (high-value targets)
+
+- **Actions** (`internalAction`, `action`) — these do external I/O and are the most likely to fail or be slow
+- **Mutations that represent user-initiated operations** — e.g., `documents.create` (upload), `documents.retry` (retry failed processing)
+- **Pipeline steps** — each stage of a multi-step pipeline should emit one wide event
+
+### Skip these
+
+- **High-frequency internal queries/mutations** — `getInternal`, `updateStatus`, `listByDocument`. Convex already logs their execution metadata. Adding wide events would create noise.
+- **Simple queries** — `list`, `get`. Not enough business logic to justify.
+- **Helpers that are always called within an instrumented parent** — they contribute to the parent's event instead.
+
+## What NOT to do
+
+- **No `console.log` / `console.error`** — use `WideEvent` instead. If you see an ad-hoc console call, replace it.
+- **No log levels** — every wide event uses `console.log`. The `error: true` field distinguishes failures. Convex dashboard can filter on JSON field values.
+- **No global state or singletons** — each function creates its own `WideEvent` instance.
+- **No separate log table in Convex** — storage cost with no real benefit over structured console output.
+- **No `customFunction` wrappers for logging** — too much indirection for this codebase size. Keep it explicit.
+
+## Field naming conventions
+
+Use camelCase for all field names. Common fields:
+
+| Field          | Description                                                          |
+| -------------- | -------------------------------------------------------------------- |
+| `op`           | Operation name (set by constructor), e.g. `"pipeline.chunkAndStore"` |
+| `durationMs`   | Total function duration (set by `emit()`)                            |
+| `error`        | `true` when function failed (set by `setError()`)                    |
+| `errorMessage` | Error description (set by `setError()`)                              |
+| `documentId`   | The document being processed                                         |
+| `userId`       | The user who owns the resource                                       |
+| `*DurationMs`  | Sub-operation timing, e.g. `embedDurationMs`, `upsertDurationMs`     |
+| `*Count`       | Counts, e.g. `chunkCount`, `validChunkCount`, `unembeddedCount`      |
+
+## Currently instrumented functions
+
+| Module           | Function                | Key fields                                                                                    |
+| ---------------- | ----------------------- | --------------------------------------------------------------------------------------------- |
+| `pipeline`       | `startProcessing`       | documentId, fileType, userId, path                                                            |
+| `pipeline`       | `pollDatalabResult`     | documentId, attempt, elapsedMs, pollResult                                                    |
+| `pipeline`       | `chunkAndStore`         | documentId, markdownLength, chunkCount, batchesStored                                         |
+| `pipeline`       | `embedBatch`            | jobId, documentId, chunkCount, validChunkCount, retryCount, embedDurationMs, upsertDurationMs |
+| `pipeline`       | `embedUnembeddedChunks` | documentId, unembeddedCount                                                                   |
+| `pipeline`       | `resumeProcessing`      | documentId, failedAt, resumePath                                                              |
+| `feedGeneration` | `generate`              | userId, readyDocuments, totalChunks, selectedChunks, postsGenerated, model                    |
+| `documents`      | `create`                | documentId, fileType, userId, title                                                           |
+| `documents`      | `retry`                 | documentId, previousStatus, failedAt                                                          |

--- a/.claude/skills/wide-event-logging
+++ b/.claude/skills/wide-event-logging
@@ -1,0 +1,1 @@
+../../.agents/skills/wide-event-logging

--- a/packages/backend/convex/documents.ts
+++ b/packages/backend/convex/documents.ts
@@ -5,6 +5,7 @@ import { internal } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
 import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
 import { authComponent } from "./auth";
+import { WideEvent } from "./logging";
 
 export const generateUploadUrl = mutation({
   args: {},
@@ -24,23 +25,34 @@ export const create = mutation({
     storageId: v.id("_storage"),
   },
   handler: async (ctx, args) => {
-    const user = await authComponent.safeGetAuthUser(ctx as unknown as GenericCtx<DataModel>);
-    if (!user) {
-      throw new Error("Not authenticated");
+    const evt = new WideEvent("documents.create");
+    evt.set({ fileType: args.fileType, title: args.title });
+    try {
+      const user = await authComponent.safeGetAuthUser(ctx as unknown as GenericCtx<DataModel>);
+      if (!user) {
+        throw new Error("Not authenticated");
+      }
+      evt.set("userId", user._id);
+      const documentId = await ctx.db.insert("documents", {
+        title: args.title,
+        fileType: args.fileType,
+        storageId: args.storageId,
+        status: "uploaded",
+        chunkCount: 0,
+        userId: user._id,
+        createdAt: Date.now(),
+      });
+      evt.set("documentId", documentId);
+      await ctx.scheduler.runAfter(0, internal.pipeline.startProcessing, {
+        documentId,
+      });
+      return documentId;
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
     }
-    const documentId = await ctx.db.insert("documents", {
-      title: args.title,
-      fileType: args.fileType,
-      storageId: args.storageId,
-      status: "uploaded",
-      chunkCount: 0,
-      userId: user._id,
-      createdAt: Date.now(),
-    });
-    await ctx.scheduler.runAfter(0, internal.pipeline.startProcessing, {
-      documentId,
-    });
-    return documentId;
   },
 });
 
@@ -127,20 +139,30 @@ export const getInternal = internalQuery({
 export const retry = mutation({
   args: { id: v.id("documents") },
   handler: async (ctx, args) => {
-    const user = await authComponent.safeGetAuthUser(ctx as unknown as GenericCtx<DataModel>);
-    if (!user) {
-      throw new Error("Not authenticated");
+    const evt = new WideEvent("documents.retry");
+    evt.set("documentId", args.id);
+    try {
+      const user = await authComponent.safeGetAuthUser(ctx as unknown as GenericCtx<DataModel>);
+      if (!user) {
+        throw new Error("Not authenticated");
+      }
+      const doc = await ctx.db.get(args.id);
+      if (!doc || doc.userId !== user._id) {
+        throw new Error("Document not found");
+      }
+      if (doc.status !== "error") {
+        throw new Error("Document is not in error state");
+      }
+      evt.set({ previousStatus: doc.status, failedAt: doc.failedAt });
+      await ctx.db.patch(args.id, { errorMessage: undefined });
+      await ctx.scheduler.runAfter(0, internal.pipeline.resumeProcessing, {
+        documentId: args.id,
+      });
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
     }
-    const doc = await ctx.db.get(args.id);
-    if (!doc || doc.userId !== user._id) {
-      throw new Error("Document not found");
-    }
-    if (doc.status !== "error") {
-      throw new Error("Document is not in error state");
-    }
-    await ctx.db.patch(args.id, { errorMessage: undefined });
-    await ctx.scheduler.runAfter(0, internal.pipeline.resumeProcessing, {
-      documentId: args.id,
-    });
   },
 });

--- a/packages/backend/convex/feedGeneration.ts
+++ b/packages/backend/convex/feedGeneration.ts
@@ -7,6 +7,7 @@ import { internal } from "./_generated/api";
 import type { DataModel, Id } from "./_generated/dataModel";
 import { action } from "./_generated/server";
 import { authComponent } from "./auth";
+import { WideEvent } from "./logging";
 
 function getOpenAIClient(): OpenAI {
   const apiKey = process.env.OPENAI_API_KEY;
@@ -19,45 +20,56 @@ function getOpenAIClient(): OpenAI {
 export const generate = action({
   args: {},
   handler: async (ctx) => {
-    const user = await authComponent.safeGetAuthUser(ctx as unknown as GenericCtx<DataModel>);
-    if (!user) {
-      throw new Error("Not authenticated");
-    }
+    const evt = new WideEvent("feedGeneration.generate");
+    try {
+      const user = await authComponent.safeGetAuthUser(ctx as unknown as GenericCtx<DataModel>);
+      if (!user) {
+        throw new Error("Not authenticated");
+      }
 
-    // Get all ready documents for this user
-    const documents = await ctx.runQuery(internal.feed.listReadyDocuments, {
-      userId: user._id,
-    });
+      evt.set("userId", user._id);
 
-    if (documents.length === 0) {
-      throw new Error("No ready documents found. Upload and process a document first.");
-    }
-
-    // Gather chunks from all ready documents
-    const allChunks: { _id: Id<"chunks">; content: string; documentId: Id<"documents"> }[] = [];
-    for (const doc of documents) {
-      const chunks = await ctx.runQuery(internal.feed.listChunksForDocument, {
-        documentId: doc._id,
+      // Get all ready documents for this user
+      const documents = await ctx.runQuery(internal.feed.listReadyDocuments, {
+        userId: user._id,
       });
-      for (const chunk of chunks) {
-        allChunks.push({
-          _id: chunk._id,
-          content: chunk.content,
+
+      evt.set("readyDocuments", documents.length);
+
+      if (documents.length === 0) {
+        throw new Error("No ready documents found. Upload and process a document first.");
+      }
+
+      // Gather chunks from all ready documents
+      const allChunks: { _id: Id<"chunks">; content: string; documentId: Id<"documents"> }[] = [];
+      for (const doc of documents) {
+        const chunks = await ctx.runQuery(internal.feed.listChunksForDocument, {
           documentId: doc._id,
         });
+        for (const chunk of chunks) {
+          allChunks.push({
+            _id: chunk._id,
+            content: chunk.content,
+            documentId: doc._id,
+          });
+        }
       }
-    }
 
-    if (allChunks.length === 0) {
-      throw new Error("No chunks available to generate feed from.");
-    }
+      evt.set("totalChunks", allChunks.length);
 
-    // Pick up to 5 random chunks to base posts on
-    const selected = shuffle(allChunks).slice(0, 5);
+      if (allChunks.length === 0) {
+        throw new Error("No chunks available to generate feed from.");
+      }
 
-    const openai = getOpenAIClient();
+      // Pick up to 5 random chunks to base posts on
+      const selected = shuffle(allChunks).slice(0, 5);
+      evt.set("selectedChunks", selected.length);
 
-    const systemPrompt = `You are an AI learning assistant for Scrollect, a personal learning feed app.
+      const openai = getOpenAIClient();
+      const model = "gpt-4o-mini";
+      evt.set("model", model);
+
+      const systemPrompt = `You are an AI learning assistant for Scrollect, a personal learning feed app.
 Your job is to transform raw text chunks from documents into engaging, bite-sized learning cards.
 
 Each card should:
@@ -68,50 +80,59 @@ Each card should:
 
 Return a JSON object with a "posts" key containing an array of exactly ${selected.length} strings, one for each input chunk.`;
 
-    const userPrompt = selected
-      .map((chunk, i) => `Chunk ${i + 1}:\n${chunk.content}`)
-      .join("\n\n---\n\n");
+      const userPrompt = selected
+        .map((chunk, i) => `Chunk ${i + 1}:\n${chunk.content}`)
+        .join("\n\n---\n\n");
 
-    const response = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userPrompt },
-      ],
-      temperature: 0.7,
-      response_format: { type: "json_object" },
-    });
-
-    const raw = response.choices[0]?.message?.content ?? "{}";
-    let posts: string[];
-    try {
-      const parsed = JSON.parse(raw);
-      // Handle both direct array and wrapped object (e.g. { "posts": [...] })
-      posts = Array.isArray(parsed)
-        ? parsed
-        : Array.isArray(parsed.posts)
-          ? parsed.posts
-          : ((Object.values(parsed).find(Array.isArray) as string[]) ?? []);
-    } catch (error) {
-      console.error("Failed to parse AI response:", raw);
-      throw new Error("Failed to parse AI response");
-    }
-
-    // Store posts in the database
-    const postIds: Id<"posts">[] = [];
-    for (let i = 0; i < posts.length; i++) {
-      const chunk = selected[i]!;
-      const content = posts[i]!;
-      const id = await ctx.runMutation(internal.feed.createPost, {
-        content,
-        sourceChunkId: chunk._id,
-        sourceDocumentId: chunk.documentId,
-        userId: user._id,
+      const response = await openai.chat.completions.create({
+        model,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        temperature: 0.7,
+        response_format: { type: "json_object" },
       });
-      postIds.push(id);
-    }
 
-    return postIds;
+      const raw = response.choices[0]?.message?.content ?? "{}";
+      let posts: string[];
+      try {
+        const parsed = JSON.parse(raw);
+        // Handle both direct array and wrapped object (e.g. { "posts": [...] })
+        posts = Array.isArray(parsed)
+          ? parsed
+          : Array.isArray(parsed.posts)
+            ? parsed.posts
+            : ((Object.values(parsed).find(Array.isArray) as string[]) ?? []);
+      } catch (error) {
+        evt.set("aiRawResponse", raw.substring(0, 500));
+        evt.setError(error);
+        throw new Error("Failed to parse AI response");
+      }
+
+      evt.set("postsGenerated", posts.length);
+
+      // Store posts in the database
+      const postIds: Id<"posts">[] = [];
+      for (let i = 0; i < posts.length; i++) {
+        const chunk = selected[i]!;
+        const content = posts[i]!;
+        const id = await ctx.runMutation(internal.feed.createPost, {
+          content,
+          sourceChunkId: chunk._id,
+          sourceDocumentId: chunk.documentId,
+          userId: user._id,
+        });
+        postIds.push(id);
+      }
+
+      return postIds;
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
+    }
   },
 });
 

--- a/packages/backend/convex/logging.ts
+++ b/packages/backend/convex/logging.ts
@@ -1,0 +1,29 @@
+export class WideEvent {
+  private fields: Record<string, unknown>;
+  private startTime: number;
+
+  constructor(operation: string) {
+    this.fields = { op: operation };
+    this.startTime = Date.now();
+  }
+
+  set(keyOrObj: string | Record<string, unknown>, value?: unknown): this {
+    if (typeof keyOrObj === "string") {
+      this.fields[keyOrObj] = value;
+    } else {
+      Object.assign(this.fields, keyOrObj);
+    }
+    return this;
+  }
+
+  setError(error: unknown): this {
+    this.fields.error = true;
+    this.fields.errorMessage = error instanceof Error ? error.message : String(error);
+    return this;
+  }
+
+  emit(): void {
+    this.fields.durationMs = Date.now() - this.startTime;
+    console.log(JSON.stringify(this.fields));
+  }
+}

--- a/packages/backend/convex/pipeline.ts
+++ b/packages/backend/convex/pipeline.ts
@@ -7,6 +7,7 @@ import type { Id } from "./_generated/dataModel";
 import type { ActionCtx } from "./_generated/server";
 import { internalAction } from "./_generated/server";
 import { chunkMarkdown } from "./chunking";
+import { WideEvent } from "./logging";
 import { DatalabParser } from "./providers/datalab";
 import { OpenAIEmbeddings } from "./providers/openai";
 import { QdrantVectorStore } from "./providers/qdrant";
@@ -43,21 +44,34 @@ function createVectorStore(): VectorStore {
 export const startProcessing = internalAction({
   args: { documentId: v.id("documents") },
   handler: async (ctx, { documentId }) => {
-    const doc = await ctx.runQuery(internal.documents.getInternal, { id: documentId });
-    if (!doc) throw new Error(`Document ${documentId} not found`);
+    const evt = new WideEvent("pipeline.startProcessing");
+    evt.set({ documentId });
+    try {
+      const doc = await ctx.runQuery(internal.documents.getInternal, { id: documentId });
+      if (!doc) throw new Error(`Document ${documentId} not found`);
 
-    if (doc.fileType === "pdf") {
-      await ctx.runMutation(internal.documents.updateStatus, {
-        id: documentId,
-        status: "parsing",
-      });
-      await submitPdfParsingImpl(ctx, documentId, doc.storageId);
-    } else {
-      await ctx.runMutation(internal.documents.updateStatus, {
-        id: documentId,
-        status: "parsing",
-      });
-      await fetchAndParseMarkdownImpl(ctx, documentId, doc.storageId);
+      evt.set({ fileType: doc.fileType, userId: doc.userId });
+
+      if (doc.fileType === "pdf") {
+        evt.set("path", "pdf");
+        await ctx.runMutation(internal.documents.updateStatus, {
+          id: documentId,
+          status: "parsing",
+        });
+        await submitPdfParsingImpl(ctx, documentId, doc.storageId, evt);
+      } else {
+        evt.set("path", "markdown");
+        await ctx.runMutation(internal.documents.updateStatus, {
+          id: documentId,
+          status: "parsing",
+        });
+        await fetchAndParseMarkdownImpl(ctx, documentId, doc.storageId, evt);
+      }
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
     }
   },
 });
@@ -68,6 +82,7 @@ async function submitPdfParsingImpl(
   ctx: ActionCtx,
   documentId: Id<"documents">,
   storageId: Id<"_storage">,
+  evt: WideEvent,
 ) {
   try {
     const apiKey = process.env.DATALAB_API_KEY;
@@ -93,6 +108,7 @@ async function submitPdfParsingImpl(
       startedAt,
     });
   } catch (error) {
+    evt.setError(error);
     const message = error instanceof Error ? error.message : "PDF submission failed";
     await ctx.runMutation(internal.documents.updateStatus, {
       id: documentId,
@@ -111,18 +127,23 @@ export const pollDatalabResult = internalAction({
     startedAt: v.number(),
   },
   handler: async (ctx, { documentId, checkUrl, attempt, startedAt }) => {
-    const elapsed = Date.now() - startedAt;
-    if (elapsed > MAX_POLL_DURATION_MS) {
-      await ctx.runMutation(internal.documents.updateStatus, {
-        id: documentId,
-        status: "error",
-        errorMessage: "PDF parsing timed out after 5 minutes",
-        failedAt: "parsing",
-      });
-      return;
-    }
-
+    const evt = new WideEvent("pipeline.pollDatalabResult");
+    evt.set({ documentId, attempt });
     try {
+      const elapsed = Date.now() - startedAt;
+      evt.set("elapsedMs", elapsed);
+
+      if (elapsed > MAX_POLL_DURATION_MS) {
+        evt.set("pollResult", "timeout");
+        await ctx.runMutation(internal.documents.updateStatus, {
+          id: documentId,
+          status: "error",
+          errorMessage: "PDF parsing timed out after 5 minutes",
+          failedAt: "parsing",
+        });
+        return;
+      }
+
       const apiKey = process.env.DATALAB_API_KEY;
       if (!apiKey) throw new Error("DATALAB_API_KEY environment variable is not set");
 
@@ -130,6 +151,7 @@ export const pollDatalabResult = internalAction({
       const result = await parser.poll(checkUrl);
 
       if (result.status === "complete") {
+        evt.set("pollResult", "complete");
         await ctx.scheduler.runAfter(0, internal.pipeline.chunkAndStore, {
           documentId,
           markdown: result.markdown!,
@@ -138,6 +160,7 @@ export const pollDatalabResult = internalAction({
       }
 
       if (result.status === "error") {
+        evt.set("pollResult", "error");
         await ctx.runMutation(internal.documents.updateStatus, {
           id: documentId,
           status: "error",
@@ -147,6 +170,7 @@ export const pollDatalabResult = internalAction({
         return;
       }
 
+      evt.set("pollResult", "pending");
       // Still pending — schedule next poll with exponential backoff
       const nextDelay = getPollDelay(attempt);
       await ctx.scheduler.runAfter(nextDelay, internal.pipeline.pollDatalabResult, {
@@ -156,6 +180,7 @@ export const pollDatalabResult = internalAction({
         startedAt,
       });
     } catch (error) {
+      evt.setError(error);
       const message = error instanceof Error ? error.message : "Polling failed";
       await ctx.runMutation(internal.documents.updateStatus, {
         id: documentId,
@@ -163,6 +188,8 @@ export const pollDatalabResult = internalAction({
         errorMessage: message,
         failedAt: "parsing",
       });
+    } finally {
+      evt.emit();
     }
   },
 });
@@ -173,6 +200,7 @@ async function fetchAndParseMarkdownImpl(
   ctx: ActionCtx,
   documentId: Id<"documents">,
   storageId: Id<"_storage">,
+  evt: WideEvent,
 ) {
   try {
     const url = await ctx.storage.getUrl(storageId);
@@ -189,6 +217,7 @@ async function fetchAndParseMarkdownImpl(
       markdown: text,
     });
   } catch (error) {
+    evt.setError(error);
     const message = error instanceof Error ? error.message : "Markdown parsing failed";
     await ctx.runMutation(internal.documents.updateStatus, {
       id: documentId,
@@ -207,6 +236,8 @@ export const chunkAndStore = internalAction({
     markdown: v.string(),
   },
   handler: async (ctx, { documentId, markdown }) => {
+    const evt = new WideEvent("pipeline.chunkAndStore");
+    evt.set({ documentId, markdownLength: markdown.length });
     try {
       await ctx.runMutation(internal.documents.updateStatus, {
         id: documentId,
@@ -220,9 +251,10 @@ export const chunkAndStore = internalAction({
         tokenCount: c.tokenCount,
       }));
 
-      console.log(`[chunkAndStore] ${chunks.length} chunks for document ${documentId}`);
+      evt.set("chunkCount", chunks.length);
 
       const allChunkIds: Id<"chunks">[] = [];
+      let batchesStored = 0;
       for (let i = 0; i < chunks.length; i += CHUNK_STORE_BATCH_SIZE) {
         const batch = chunks.slice(i, i + CHUNK_STORE_BATCH_SIZE);
         const ids = await ctx.runMutation(internal.chunks.createBatch, {
@@ -230,7 +262,9 @@ export const chunkAndStore = internalAction({
           chunks: batch,
         });
         allChunkIds.push(...ids);
+        batchesStored++;
       }
+      evt.set("batchesStored", batchesStored);
 
       await ctx.runMutation(internal.documents.updateStatus, {
         id: documentId,
@@ -241,6 +275,7 @@ export const chunkAndStore = internalAction({
       // Fan-out embedding batches
       await fanOutEmbedding(ctx, documentId, allChunkIds);
     } catch (error) {
+      evt.setError(error);
       const message = error instanceof Error ? error.message : "Chunking failed";
       await ctx.runMutation(internal.documents.updateStatus, {
         id: documentId,
@@ -248,6 +283,8 @@ export const chunkAndStore = internalAction({
         errorMessage: message,
         failedAt: "chunking",
       });
+    } finally {
+      evt.emit();
     }
   },
 });
@@ -293,6 +330,8 @@ export const embedBatch = internalAction({
     retryCount: v.number(),
   },
   handler: async (ctx, { jobId, documentId, chunkIds, retryCount }) => {
+    const evt = new WideEvent("pipeline.embedBatch");
+    evt.set({ jobId, documentId, chunkCount: chunkIds.length, retryCount });
     try {
       const embedder = createEmbeddingProvider();
       const vectorStore = createVectorStore();
@@ -310,6 +349,8 @@ export const embedBatch = internalAction({
         (c): c is NonNullable<typeof c> => c !== null && !c.embedded,
       );
 
+      evt.set("validChunkCount", validChunks.length);
+
       if (validChunks.length === 0) {
         // All chunks already embedded — mark batch complete
         const job = await ctx.runMutation(internal.processingJobs.markBatchComplete, {
@@ -321,7 +362,10 @@ export const embedBatch = internalAction({
       }
 
       const texts = validChunks.map((c) => c.content);
+
+      const t0 = Date.now();
       const vectors = await embedder.embed(texts);
+      evt.set("embedDurationMs", Date.now() - t0);
 
       // Build vector points with deterministic IDs
       const points = validChunks.map((chunk, i) => ({
@@ -335,7 +379,9 @@ export const embedBatch = internalAction({
         },
       }));
 
+      const t1 = Date.now();
       await vectorStore.upsert(points);
+      evt.set("upsertDurationMs", Date.now() - t1);
 
       // Mark each chunk as embedded
       for (const chunk of validChunks) {
@@ -352,7 +398,7 @@ export const embedBatch = internalAction({
       });
       await checkCompletion(ctx, job, documentId);
     } catch (error) {
-      console.error(`[embedBatch] Error (attempt ${retryCount}):`, error);
+      evt.setError(error);
 
       if (retryCount < MAX_EMBED_RETRIES) {
         const delayMs = Math.pow(2, retryCount) * 1000;
@@ -371,6 +417,8 @@ export const embedBatch = internalAction({
         failed: true,
       });
       await checkCompletion(ctx, job, documentId);
+    } finally {
+      evt.emit();
     }
   },
 });
@@ -404,38 +452,65 @@ async function checkCompletion(
 export const resumeProcessing = internalAction({
   args: { documentId: v.id("documents") },
   handler: async (ctx, { documentId }) => {
-    const doc = await ctx.runQuery(internal.documents.getInternal, { id: documentId });
-    if (!doc) throw new Error(`Document ${documentId} not found`);
-    if (doc.status !== "error") return;
+    const evt = new WideEvent("pipeline.resumeProcessing");
+    evt.set({ documentId });
+    try {
+      const doc = await ctx.runQuery(internal.documents.getInternal, { id: documentId });
+      if (!doc) throw new Error(`Document ${documentId} not found`);
+      if (doc.status !== "error") return;
 
-    switch (doc.failedAt) {
-      case "parsing":
-        if (doc.datalabCheckUrl) {
-          // Resume polling from saved checkpoint
-          await ctx.runMutation(internal.documents.updateStatus, {
-            id: documentId,
-            status: "parsing",
-          });
-          await ctx.scheduler.runAfter(0, internal.pipeline.pollDatalabResult, {
+      evt.set("failedAt", doc.failedAt);
+
+      switch (doc.failedAt) {
+        case "parsing":
+          if (doc.datalabCheckUrl) {
+            evt.set("resumePath", "pollDatalabResult");
+            // Resume polling from saved checkpoint
+            await ctx.runMutation(internal.documents.updateStatus, {
+              id: documentId,
+              status: "parsing",
+            });
+            await ctx.scheduler.runAfter(0, internal.pipeline.pollDatalabResult, {
+              documentId,
+              checkUrl: doc.datalabCheckUrl,
+              attempt: 0,
+              startedAt: Date.now(),
+            });
+          } else {
+            evt.set("resumePath", "startProcessing");
+            // Re-start processing from scratch
+            await ctx.scheduler.runAfter(0, internal.pipeline.startProcessing, {
+              documentId,
+            });
+          }
+          break;
+
+        case "chunking": {
+          const allChunks = await ctx.runQuery(internal.chunks.listByDocumentInternal, {
             documentId,
-            checkUrl: doc.datalabCheckUrl,
-            attempt: 0,
-            startedAt: Date.now(),
           });
-        } else {
-          // Re-start processing from scratch
-          await ctx.scheduler.runAfter(0, internal.pipeline.startProcessing, {
-            documentId,
-          });
+          if (allChunks.length > 0) {
+            evt.set("resumePath", "embedUnembeddedChunks");
+            // Chunks exist — skip to embedding
+            await ctx.runMutation(internal.documents.updateStatus, {
+              id: documentId,
+              status: "embedding",
+            });
+            await ctx.scheduler.runAfter(0, internal.pipeline.embedUnembeddedChunks, {
+              documentId,
+            });
+          } else {
+            evt.set("resumePath", "startProcessing");
+            // No chunks — re-start from scratch
+            await ctx.scheduler.runAfter(0, internal.pipeline.startProcessing, {
+              documentId,
+            });
+          }
+          break;
         }
-        break;
 
-      case "chunking": {
-        const allChunks = await ctx.runQuery(internal.chunks.listByDocumentInternal, {
-          documentId,
-        });
-        if (allChunks.length > 0) {
-          // Chunks exist — skip to embedding
+        case "embedding":
+          evt.set("resumePath", "embedUnembeddedChunks");
           await ctx.runMutation(internal.documents.updateStatus, {
             id: documentId,
             status: "embedding",
@@ -443,31 +518,21 @@ export const resumeProcessing = internalAction({
           await ctx.scheduler.runAfter(0, internal.pipeline.embedUnembeddedChunks, {
             documentId,
           });
-        } else {
-          // No chunks — re-start from scratch
+          break;
+
+        default:
+          evt.set("resumePath", "startProcessing");
+          // No failedAt — restart from scratch
           await ctx.scheduler.runAfter(0, internal.pipeline.startProcessing, {
             documentId,
           });
-        }
-        break;
+          break;
       }
-
-      case "embedding":
-        await ctx.runMutation(internal.documents.updateStatus, {
-          id: documentId,
-          status: "embedding",
-        });
-        await ctx.scheduler.runAfter(0, internal.pipeline.embedUnembeddedChunks, {
-          documentId,
-        });
-        break;
-
-      default:
-        // No failedAt — restart from scratch
-        await ctx.scheduler.runAfter(0, internal.pipeline.startProcessing, {
-          documentId,
-        });
-        break;
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
     }
   },
 });
@@ -475,20 +540,31 @@ export const resumeProcessing = internalAction({
 export const embedUnembeddedChunks = internalAction({
   args: { documentId: v.id("documents") },
   handler: async (ctx, { documentId }) => {
-    const unembedded = await ctx.runQuery(internal.chunks.listUnembedded, {
-      documentId,
-    });
-
-    if (unembedded.length === 0) {
-      // All chunks already embedded
-      await ctx.runMutation(internal.documents.updateStatus, {
-        id: documentId,
-        status: "ready",
+    const evt = new WideEvent("pipeline.embedUnembeddedChunks");
+    evt.set({ documentId });
+    try {
+      const unembedded = await ctx.runQuery(internal.chunks.listUnembedded, {
+        documentId,
       });
-      return;
-    }
 
-    const chunkIds = unembedded.map((c) => c._id);
-    await fanOutEmbedding(ctx, documentId, chunkIds);
+      evt.set("unembeddedCount", unembedded.length);
+
+      if (unembedded.length === 0) {
+        // All chunks already embedded
+        await ctx.runMutation(internal.documents.updateStatus, {
+          id: documentId,
+          status: "ready",
+        });
+        return;
+      }
+
+      const chunkIds = unembedded.map((c) => c._id);
+      await fanOutEmbedding(ctx, documentId, chunkIds);
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
+    }
   },
 });


### PR DESCRIPTION
## Summary

- Add `WideEvent` class in `convex/logging.ts` for structured, single-line-per-function JSON logging
- Instrument all 7 pipeline actions + 2 helper functions with wide events, including sub-operation timing for embedding
- Instrument `feedGeneration.generate` action and `documents.create` / `documents.retry` mutations
- Remove 3 ad-hoc `console.log`/`console.error` calls replaced by wide events
- Add `wide-event-logging` skill to codify the logging pattern for future development

## Test plan

- [x] `npx convex dev --once` deploys successfully
- [ ] Upload a PDF and MD document — each pipeline step emits one JSON log line in Convex dashboard
- [ ] Trigger an error case — verify wide event includes `error: true` and `errorMessage`
- [ ] Retry a failed document — verify `resumeProcessing` event shows `failedAt` and `resumePath`

🤖 Generated with [Claude Code](https://claude.com/claude-code)