### PR TITLE
fix: add compound index to prevent byte limit crash in createBatch

### DIFF
--- a/packages/backend/convex/chunks.ts
+++ b/packages/backend/convex/chunks.ts
@@ -40,8 +40,9 @@ export const createBatch = internalMutation({
     for (const chunk of args.chunks) {
       const existing = await ctx.db
         .query("chunks")
-        .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
-        .filter((q) => q.eq(q.field("chunkIndex"), chunk.chunkIndex))
+        .withIndex("by_documentId_chunkIndex", (q) =>
+          q.eq("documentId", args.documentId).eq("chunkIndex", chunk.chunkIndex),
+        )
         .first();
 
       if (existing) {

--- a/packages/backend/convex/pipeline.ts
+++ b/packages/backend/convex/pipeline.ts
@@ -551,9 +551,13 @@ export const embedUnembeddedChunks = internalAction({
 
       if (unembedded.length === 0) {
         // All chunks already embedded
+        const allChunks = await ctx.runQuery(internal.chunks.listByDocumentInternal, {
+          documentId,
+        });
         await ctx.runMutation(internal.documents.updateStatus, {
           id: documentId,
           status: "ready",
+          chunkCount: allChunks.length,
         });
         return;
       }

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -49,6 +49,7 @@ export default defineSchema({
     createdAt: v.number(),
   })
     .index("by_documentId", ["documentId"])
+    .index("by_documentId_chunkIndex", ["documentId", "chunkIndex"])
     .index("by_documentId_unembedded", ["documentId", "embedded"]),
 
   processingJobs: defineTable({


### PR DESCRIPTION
## Summary
- Added compound index `by_documentId_chunkIndex` on `["documentId", "chunkIndex"]` to the chunks table
- Updated `createBatch` to use the new index instead of scanning all chunks with `.filter()`, which was exceeding Convex's 16MB read limit on large documents
- Fixed `embedUnembeddedChunks` to correctly set `chunkCount` when resuming a document that already has all chunks embedded

## Test plan
- [x] Verified fix by resuming document `jd77qvhh6369er1fy7vas39w2582f0dd` ("the lean startup") — successfully reached `ready` status with 150 chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)