### PR TITLE
feat: multi-type card system (#61, #62, #63)

### DIFF
--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright test --project=setup --project=seeded --project=chromium",
+    "test:e2e:slow": "playwright test --project=setup --project=slow",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed",
     "test:report": "playwright show-report",

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -20,10 +20,27 @@ export default defineConfig({
       testMatch: /global-setup\.ts/,
     },
     {
+      name: "seeded",
+      use: { ...devices["Desktop Chrome"] },
+      dependencies: ["setup"],
+      testMatch: [
+        /feed-interactions\.spec\.ts/,
+        /multi-type-cards\.spec\.ts/,
+        /source-provenance\.spec\.ts/,
+      ],
+      fullyParallel: false,
+    },
+    {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
       dependencies: ["setup"],
-      testIgnore: [/global-setup\.ts/, /\.slow\.spec\.ts/],
+      testIgnore: [
+        /global-setup\.ts/,
+        /\.slow\.spec\.ts/,
+        /feed-interactions\.spec\.ts/,
+        /multi-type-cards\.spec\.ts/,
+        /source-provenance\.spec\.ts/,
+      ],
     },
     {
       name: "slow",

--- a/apps/e2e/tests/feed-interactions.spec.ts
+++ b/apps/e2e/tests/feed-interactions.spec.ts
@@ -47,7 +47,7 @@ test.describe("Feed interactions and pagination", () => {
     await page.getByRole("navigation").getByRole("button", { name: /saved/i }).click();
     await page.waitForURL(/\/saved/);
     await expect(page.getByRole("heading", { name: /saved/i })).toBeVisible({ timeout: 15000 });
-    await expect(page.locator('[data-testid="post-card"]').first()).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('[data-testid="post-card"]').first()).toBeVisible({ timeout: 30000 });
 
     // Back to /feed → scroll to bottom → verify "all caught up"
     await page.goto("/feed?noAutoGenerate");

--- a/apps/e2e/tests/global-setup.ts
+++ b/apps/e2e/tests/global-setup.ts
@@ -1,8 +1,6 @@
 import { test as setup, expect } from "@playwright/test";
 
-import { SEEDED_USER, seedTestData } from "./helpers";
-
-const AUTH_FILE = "tests/.auth/seeded-user.json";
+import { SEEDED_USER, cleanupTestData, seedTestData } from "./helpers";
 
 setup("create and seed E2E account", async ({ page }) => {
   // Try sign-in first (account may exist from previous run)
@@ -31,9 +29,7 @@ setup("create and seed E2E account", async ({ page }) => {
     await expect(page).toHaveURL(/\/(library|feed)/, { timeout: 15000 });
   }
 
-  // Seed test data (idempotent)
+  // Clean up stale data from previous schema, then re-seed
+  await cleanupTestData(page);
   await seedTestData(page);
-
-  // Save auth state
-  await page.context().storageState({ path: AUTH_FILE });
 });

--- a/apps/e2e/tests/multi-type-cards.spec.ts
+++ b/apps/e2e/tests/multi-type-cards.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect } from "@playwright/test";
+
+import { SEEDED_USER, resetTestData, signIn } from "./helpers";
+
+const CARD = '[data-testid="post-card"]';
+
+function cardOfType(type: string) {
+  return `${CARD}[data-card-type="${type}"]`;
+}
+
+test.describe("Multi-type card rendering", () => {
+  test.setTimeout(60000);
+
+  test.beforeEach(async ({ page }) => {
+    await signIn(page, SEEDED_USER.email, SEEDED_USER.password);
+    await page.goto("/feed?noAutoGenerate");
+    await expect(page.locator(CARD).first()).toBeVisible({ timeout: 15000 });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await resetTestData(page);
+  });
+
+  test("feed contains all 5 card types", async ({ page }) => {
+    const cards = page.locator(CARD);
+    await expect(cards).toHaveCount(7, { timeout: 15000 });
+
+    const types = await cards.evaluateAll((els) => [
+      ...new Set(els.map((el) => el.getAttribute("data-card-type"))),
+    ]);
+
+    for (const expected of ["insight", "quiz", "quote", "summary", "connection"]) {
+      expect(types, `missing card type: ${expected}`).toContain(expected);
+    }
+  });
+
+  test("insight card has source badge and action buttons", async ({ page }) => {
+    const card = page.locator(cardOfType("insight")).first();
+    await expect(card).toBeVisible();
+
+    await expect(card.locator('[data-testid="source-badge"]')).toBeVisible();
+    await expect(card.locator('[data-testid="like-button"]')).toBeVisible();
+    await expect(card.locator('[data-testid="dislike-button"]')).toBeVisible();
+    await expect(card.locator('[data-testid="save-button"]')).toBeVisible();
+  });
+
+  test("quote card displays quoted text and source badge", async ({ page }) => {
+    const card = page.locator(cardOfType("quote")).first();
+    await expect(card).toBeVisible();
+
+    await expect(card.locator('[data-testid="quoted-text"]')).toBeVisible();
+    await expect(card.locator('[data-testid="source-badge"]')).toBeVisible();
+  });
+
+  test("summary card displays bullet points", async ({ page }) => {
+    const card = page.locator(cardOfType("summary")).first();
+    await expect(card).toBeVisible();
+
+    const bullets = card.locator('[data-testid="summary-bullets"] li');
+    await expect(bullets.first()).toBeVisible();
+    expect(await bullets.count()).toBeGreaterThanOrEqual(2);
+
+    await expect(card.locator('[data-testid="source-badge"]')).toBeVisible();
+  });
+});
+
+test.describe("Quiz card interactions", () => {
+  test.setTimeout(60000);
+
+  test.beforeEach(async ({ page }) => {
+    await signIn(page, SEEDED_USER.email, SEEDED_USER.password);
+    await page.goto("/feed?noAutoGenerate");
+    await expect(page.locator(CARD).first()).toBeVisible({ timeout: 15000 });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await resetTestData(page);
+  });
+
+  test("reveal quiz: answer hidden until tap", async ({ page }) => {
+    const card = page.locator(`${cardOfType("quiz")}[data-quiz-variant="true_false"]`).first();
+    await expect(card).toBeVisible();
+
+    await expect(card.locator('[data-testid="quiz-question"]')).toBeVisible();
+    await expect(card.locator('[data-testid="quiz-answer"]')).not.toBeVisible();
+
+    await card.locator('[data-testid="quiz-reveal-button"]').click();
+
+    await expect(card.locator('[data-testid="quiz-answer"]')).toBeVisible({ timeout: 5000 });
+    await expect(card.locator('[data-testid="quiz-explanation"]')).toBeVisible();
+  });
+
+  test("multiple-choice quiz: correct answer highlights green", async ({ page }) => {
+    const card = page.locator(`${cardOfType("quiz")}[data-quiz-variant="multiple_choice"]`).first();
+    await expect(card).toBeVisible();
+
+    await expect(card.locator('[data-testid="quiz-question"]')).toBeVisible();
+
+    const options = card.locator('[data-testid="quiz-option"]');
+    await expect(options).toHaveCount(4);
+
+    // Seed data: correct answer is index 0
+    await options.first().click();
+
+    await expect(options.first()).toHaveAttribute("data-option-state", "correct");
+    await expect(card.locator('[data-testid="quiz-explanation"]')).toBeVisible({ timeout: 5000 });
+  });
+
+  test("multiple-choice quiz: wrong answer marks both incorrect and correct", async ({ page }) => {
+    const card = page.locator(`${cardOfType("quiz")}[data-quiz-variant="multiple_choice"]`).first();
+    await expect(card).toBeVisible();
+
+    const options = card.locator('[data-testid="quiz-option"]');
+
+    // Tap wrong answer (index 1); correct is index 0
+    await options.nth(1).click();
+
+    await expect(options.nth(1)).toHaveAttribute("data-option-state", "incorrect");
+    await expect(options.first()).toHaveAttribute("data-option-state", "correct");
+    await expect(card.locator('[data-testid="quiz-explanation"]')).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe("Source provenance", () => {
+  test.setTimeout(60000);
+
+  test.beforeEach(async ({ page }) => {
+    await signIn(page, SEEDED_USER.email, SEEDED_USER.password);
+    await page.goto("/feed?noAutoGenerate");
+    await expect(page.locator(CARD).first()).toBeVisible({ timeout: 15000 });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await resetTestData(page);
+  });
+
+  test("every card has a source badge", async ({ page }) => {
+    const cards = page.locator(CARD);
+    const count = await cards.count();
+
+    for (let i = 0; i < count; i++) {
+      const card = cards.nth(i);
+      const type = await card.getAttribute("data-card-type");
+      // Connection cards render their own dual-title badge
+      const selector =
+        type === "connection"
+          ? '[data-testid="connection-source-badge"]'
+          : '[data-testid="source-badge"]';
+      await expect(card.locator(selector)).toBeVisible({ timeout: 5000 });
+    }
+  });
+
+  test("connection card badge contains both document titles", async ({ page }) => {
+    const card = page.locator(cardOfType("connection")).first();
+    await expect(card).toBeVisible();
+
+    const badge = card.locator('[data-testid="connection-source-badge"]');
+    await expect(badge).toBeVisible();
+    await expect(badge).toContainText("E2E Seed Document");
+    await expect(badge).toContainText("E2E Seed Document 2");
+  });
+
+  test("expand sheet shows source chunks with primary marker", async ({ page }) => {
+    // Use an insight card for deterministic single-source sheet
+    const card = page.locator(cardOfType("insight")).first();
+    await expect(card).toBeVisible();
+
+    await card.locator('[data-testid="expand-button"]').click();
+
+    const sheet = page.locator('[data-testid="source-sheet"]');
+    await expect(sheet).toBeVisible({ timeout: 10000 });
+
+    const primary = sheet.locator('[data-testid="source-chunk"][data-primary="true"]');
+    await expect(primary).toBeVisible({ timeout: 10000 });
+
+    const chunks = sheet.locator('[data-testid="source-chunk"]');
+    expect(await chunks.count()).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/src/app/saved/saved-content.tsx
+++ b/apps/web/src/app/saved/saved-content.tsx
@@ -63,17 +63,8 @@ export function SavedContent() {
               <PostCard
                 key={bookmark._id}
                 post={{
-                  _id: bookmark.post._id,
-                  content: bookmark.post.content,
-                  sourceDocumentTitle: bookmark.post.sourceDocumentTitle,
-                  createdAt: bookmark.post.createdAt,
-                  reaction: bookmark.post.reaction,
+                  ...bookmark.post,
                   isBookmarked: true,
-                  sourceChunkId: bookmark.post.sourceChunkId,
-                  sourceDocumentId: bookmark.post.sourceDocumentId,
-                  sectionTitle: bookmark.post.sectionTitle,
-                  pageNumber: bookmark.post.pageNumber,
-                  chunkIndex: bookmark.post.chunkIndex,
                 }}
               />
             );

--- a/apps/web/src/components/cards/card-shell.tsx
+++ b/apps/web/src/components/cards/card-shell.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { api } from "@scrollect/backend/convex/_generated/api";
+import type { OptimisticLocalStore } from "convex/browser";
+import { useMutation } from "convex/react";
+import { formatDistanceToNow } from "date-fns";
+import { Bookmark, BookmarkCheck, Maximize2, ThumbsDown, ThumbsUp } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+import { ChunkContextSheetContent } from "@/components/chunk-context-sheet";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+import type { PostCardData } from "./types";
+import { formatSourceLocation } from "./utils";
+
+function updatePostInPaginatedPages(
+  localStore: OptimisticLocalStore,
+  postId: PostCardData["_id"],
+  updater: (post: Record<string, unknown>) => Record<string, unknown>,
+) {
+  const allPages = localStore.getAllQueries(api.feed.queries.list);
+  for (const { args, value } of allPages) {
+    if (value === undefined) continue;
+    const hasMatch = value.page.some((p) => p._id === postId);
+    if (!hasMatch) continue;
+    localStore.setQuery(api.feed.queries.list, args, {
+      ...value,
+      page: value.page.map((p) => (p._id === postId ? { ...p, ...updater(p) } : p)),
+    });
+  }
+}
+
+function getSourceLabel(post: PostCardData): string {
+  return formatSourceLocation(
+    post.primarySourceDocumentTitle ?? "Untitled",
+    post.primarySourceSectionTitle,
+    post.primarySourcePageNumber,
+  );
+}
+
+export function SourceBadge({ post, className }: { post: PostCardData; className?: string }) {
+  return (
+    <div className={cn("mb-3", className)}>
+      <Link href={`/library/${post.primarySourceDocumentId}`} data-testid="source-badge">
+        <Badge
+          variant="outline"
+          className="gap-1.5 border-primary/15 bg-primary/[0.03] font-normal text-muted-foreground transition-all hover:border-primary/25 hover:bg-primary/[0.06]"
+        >
+          <span className="size-1.5 shrink-0 rounded-full bg-primary/60" />
+          <span className="max-w-52 truncate">{getSourceLabel(post)}</span>
+        </Badge>
+      </Link>
+    </div>
+  );
+}
+
+interface CardShellProps {
+  post: PostCardData;
+  children: ReactNode;
+  accentClassName?: string;
+  quizVariant?: "multiple_choice" | "true_false";
+}
+
+export function CardShell({ post, children, accentClassName, quizVariant }: CardShellProps) {
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const toggleBookmark = useMutation(api.bookmarks.toggle).withOptimisticUpdate(
+    (localStore, args) => {
+      updatePostInPaginatedPages(localStore, args.postId, (p) => ({
+        isBookmarked: !p.isBookmarked,
+      }));
+    },
+  );
+
+  const setReaction = useMutation(api.feed.queries.setReaction).withOptimisticUpdate(
+    (localStore, args) => {
+      updatePostInPaginatedPages(localStore, args.postId, () => ({
+        reaction: args.reaction === "none" ? undefined : args.reaction,
+      }));
+    },
+  );
+
+  return (
+    <>
+      <article
+        data-testid="post-card"
+        data-card-type={post.postType}
+        data-quiz-variant={quizVariant}
+        className="group/card relative overflow-hidden rounded-xl bg-card text-card-foreground ring-1 ring-foreground/[0.06] transition-all duration-300 hover:-translate-y-0.5 hover:ring-primary/15 hover:shadow-lg hover:shadow-primary/[0.06]"
+      >
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/30 to-transparent transition-all duration-300 group-hover/card:h-0.5 group-hover/card:via-primary/60",
+            accentClassName,
+          )}
+        />
+
+        <div className="px-5 pt-5 pb-4">
+          {children}
+
+          <div className="mt-4 flex items-center justify-between border-t border-border/40 pt-3">
+            <time className="text-xs tracking-wide text-muted-foreground/70">
+              {formatDistanceToNow(post.createdAt, { addSuffix: true })}
+            </time>
+
+            <div className="flex items-center gap-0.5">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="transition-all duration-200 active:scale-90"
+                onClick={() => setSheetOpen(true)}
+                data-testid="expand-button"
+                title="View source context"
+              >
+                <Maximize2 className="size-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className={cn(
+                  "transition-all duration-200 active:scale-90",
+                  post.isBookmarked &&
+                    "bg-primary/10 text-primary hover:bg-primary/15 dark:bg-primary/20 dark:hover:bg-primary/25",
+                )}
+                onClick={() => toggleBookmark({ postId: post._id })}
+                data-testid="save-button"
+                aria-pressed={!!post.isBookmarked}
+                title="Save"
+              >
+                {post.isBookmarked ? (
+                  <BookmarkCheck className="size-3.5" />
+                ) : (
+                  <Bookmark className="size-3.5" />
+                )}
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className={cn(
+                  "transition-all duration-200 active:scale-90",
+                  post.reaction === "like" &&
+                    "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/15 dark:bg-emerald-500/20 dark:text-emerald-400 dark:hover:bg-emerald-500/25",
+                )}
+                onClick={() =>
+                  setReaction({
+                    postId: post._id,
+                    reaction: post.reaction === "like" ? "none" : "like",
+                  })
+                }
+                data-testid="like-button"
+                aria-pressed={post.reaction === "like"}
+                title="Like"
+              >
+                <ThumbsUp className={cn("size-3.5", post.reaction === "like" && "fill-current")} />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className={cn(
+                  "transition-all duration-200 active:scale-90",
+                  post.reaction === "dislike" &&
+                    "bg-red-500/10 text-red-500 hover:bg-red-500/15 dark:bg-red-500/20 dark:text-red-400 dark:hover:bg-red-500/25",
+                )}
+                onClick={() =>
+                  setReaction({
+                    postId: post._id,
+                    reaction: post.reaction === "dislike" ? "none" : "dislike",
+                  })
+                }
+                data-testid="dislike-button"
+                aria-pressed={post.reaction === "dislike"}
+                title="Dislike"
+              >
+                <ThumbsDown
+                  className={cn("size-3.5", post.reaction === "dislike" && "fill-current")}
+                />
+              </Button>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent side="right" className="overflow-y-auto sm:max-w-2xl">
+          <SheetHeader>
+            <SheetTitle>Source Context</SheetTitle>
+            <SheetDescription>
+              View the original source chunk with surrounding context.
+            </SheetDescription>
+          </SheetHeader>
+          <ChunkContextSheetContent
+            postId={post._id}
+            sourceChunkId={post.primarySourceChunkId}
+            sourceDocumentTitle={post.primarySourceDocumentTitle}
+            sectionTitle={post.primarySourceSectionTitle ?? null}
+            pageNumber={post.primarySourcePageNumber ?? null}
+            chunkIndex={post.chunkIndex ?? 0}
+            isOpen={sheetOpen}
+            postType={post.postType}
+          />
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/apps/web/src/components/cards/connection-card.tsx
+++ b/apps/web/src/components/cards/connection-card.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { ArrowLeftRight } from "lucide-react";
+import Link from "next/link";
+import Markdown from "react-markdown";
+
+import { Badge } from "@/components/ui/badge";
+
+import { CardShell } from "./card-shell";
+import type { ConnectionTypeData, PostCardData } from "./types";
+
+interface ConnectionCardProps {
+  post: PostCardData & { typeData: ConnectionTypeData };
+}
+
+export function ConnectionCard({ post }: ConnectionCardProps) {
+  const { sourceATitleHint, sourceBTitleHint } = post.typeData;
+
+  return (
+    <CardShell post={post} accentClassName="via-violet-500/30 group-hover/card:via-violet-500/60">
+      <div className="mb-3" data-testid="connection-source-badge">
+        <Link href={`/library/${post.primarySourceDocumentId}`}>
+          <Badge
+            variant="outline"
+            className="gap-1.5 border-violet-500/15 bg-violet-500/[0.03] font-normal text-muted-foreground transition-all hover:border-violet-500/25 hover:bg-violet-500/[0.06]"
+          >
+            <span className="max-w-28 truncate">{sourceATitleHint}</span>
+            <ArrowLeftRight className="size-3 shrink-0 text-violet-500/60" />
+            <span className="max-w-28 truncate">{sourceBTitleHint}</span>
+          </Badge>
+        </Link>
+      </div>
+      <div
+        data-testid="connection-content"
+        className="prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+      >
+        <Markdown>{post.content}</Markdown>
+      </div>
+    </CardShell>
+  );
+}

--- a/apps/web/src/components/cards/index.ts
+++ b/apps/web/src/components/cards/index.ts
@@ -1,0 +1,7 @@
+export { ConnectionCard } from "./connection-card";
+export { InsightCard } from "./insight-card";
+export { QuizMcCard } from "./quiz-mc-card";
+export { QuizRevealCard } from "./quiz-reveal-card";
+export { QuoteCard } from "./quote-card";
+export { SummaryCard } from "./summary-card";
+export type { PostCardData, PostType, TypeData } from "./types";

--- a/apps/web/src/components/cards/insight-card.tsx
+++ b/apps/web/src/components/cards/insight-card.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Markdown from "react-markdown";
+
+import { CardShell, SourceBadge } from "./card-shell";
+import type { PostCardData } from "./types";
+
+interface InsightCardProps {
+  post: PostCardData;
+}
+
+export function InsightCard({ post }: InsightCardProps) {
+  return (
+    <CardShell post={post}>
+      <SourceBadge post={post} />
+      <div
+        data-testid="insight-content"
+        className="prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+      >
+        <Markdown>{post.content}</Markdown>
+      </div>
+    </CardShell>
+  );
+}

--- a/apps/web/src/components/cards/quiz-mc-card.tsx
+++ b/apps/web/src/components/cards/quiz-mc-card.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { CheckCircle2, XCircle } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { CardShell, SourceBadge } from "./card-shell";
+import type { PostCardData, QuizTypeData } from "./types";
+
+interface QuizMcCardProps {
+  post: PostCardData & { typeData: QuizTypeData };
+}
+
+export function QuizMcCard({ post }: QuizMcCardProps) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const { question, options, correctIndex, explanation } = post.typeData;
+  const answered = selectedIndex !== null;
+
+  function getOptionState(index: number): "correct" | "incorrect" | undefined {
+    if (!answered) return undefined;
+    if (index === correctIndex) return "correct";
+    if (index === selectedIndex) return "incorrect";
+    return undefined;
+  }
+
+  return (
+    <CardShell
+      post={post}
+      accentClassName="via-emerald-500/30 group-hover/card:via-emerald-500/60"
+      quizVariant={post.typeData.variant}
+    >
+      <SourceBadge post={post} />
+      <div data-testid="quiz-question" className="mb-3 text-sm font-medium text-foreground">
+        {question}
+      </div>
+      <div className="space-y-2">
+        {options.map((option, index) => {
+          const isCorrect = index === correctIndex;
+          const isSelected = index === selectedIndex;
+          const optionState = getOptionState(index);
+
+          return (
+            <Button
+              key={index}
+              variant="outline"
+              className={cn(
+                "h-auto w-full justify-start whitespace-normal px-3 py-2.5 text-left text-sm transition-all",
+                !answered && "hover:border-primary/30 hover:bg-primary/[0.04]",
+                answered &&
+                  isCorrect &&
+                  "border-emerald-500/40 bg-emerald-500/[0.06] text-emerald-700 dark:text-emerald-400",
+                answered &&
+                  isSelected &&
+                  !isCorrect &&
+                  "border-red-500/40 bg-red-500/[0.06] text-red-700 dark:text-red-400",
+                answered && !isSelected && !isCorrect && "opacity-50",
+              )}
+              onClick={() => !answered && setSelectedIndex(index)}
+              disabled={answered}
+              data-testid="quiz-option"
+              data-option-state={optionState}
+            >
+              <span className="flex items-center gap-2">
+                {answered && isCorrect && (
+                  <CheckCircle2 className="size-4 shrink-0 text-emerald-500" />
+                )}
+                {answered && isSelected && !isCorrect && (
+                  <XCircle className="size-4 shrink-0 text-red-500" />
+                )}
+                {option}
+              </span>
+            </Button>
+          );
+        })}
+      </div>
+      {answered && (
+        <div
+          data-testid="quiz-explanation"
+          className={cn(
+            "mt-3 rounded-lg border p-3 text-sm leading-relaxed text-muted-foreground",
+            selectedIndex === correctIndex
+              ? "border-emerald-500/20 bg-emerald-500/[0.04]"
+              : "border-red-500/20 bg-red-500/[0.04]",
+            "animate-in fade-in slide-in-from-top-1 duration-200",
+          )}
+        >
+          {explanation}
+        </div>
+      )}
+    </CardShell>
+  );
+}

--- a/apps/web/src/components/cards/quiz-reveal-card.tsx
+++ b/apps/web/src/components/cards/quiz-reveal-card.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Eye } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { CardShell, SourceBadge } from "./card-shell";
+import type { PostCardData, QuizTypeData } from "./types";
+
+interface QuizRevealCardProps {
+  post: PostCardData & { typeData: QuizTypeData };
+}
+
+export function QuizRevealCard({ post }: QuizRevealCardProps) {
+  const [revealed, setRevealed] = useState(false);
+  const { question, options, correctIndex, explanation } = post.typeData;
+
+  return (
+    <CardShell
+      post={post}
+      accentClassName="via-emerald-500/30 group-hover/card:via-emerald-500/60"
+      quizVariant={post.typeData.variant}
+    >
+      <SourceBadge post={post} />
+      <div data-testid="quiz-question" className="mb-3 text-sm font-medium text-foreground">
+        {question}
+      </div>
+      {!revealed ? (
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full gap-2 border-emerald-500/20 text-emerald-600 transition-all hover:border-emerald-500/40 hover:bg-emerald-500/5 dark:text-emerald-400"
+          onClick={() => setRevealed(true)}
+          data-testid="quiz-reveal-button"
+        >
+          <Eye className="size-3.5" />
+          Reveal answer
+        </Button>
+      ) : (
+        <div
+          data-testid="quiz-answer"
+          className={cn(
+            "space-y-2 rounded-lg border border-emerald-500/20 bg-emerald-500/[0.04] p-3",
+            "animate-in fade-in slide-in-from-top-1 duration-200",
+          )}
+        >
+          <p className="text-sm font-medium text-emerald-600 dark:text-emerald-400">
+            {options[correctIndex] ?? "Answer unavailable"}
+          </p>
+          <p
+            data-testid="quiz-explanation"
+            className="text-sm leading-relaxed text-muted-foreground"
+          >
+            {explanation}
+          </p>
+        </div>
+      )}
+    </CardShell>
+  );
+}

--- a/apps/web/src/components/cards/quote-card.tsx
+++ b/apps/web/src/components/cards/quote-card.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { CardShell, SourceBadge } from "./card-shell";
+import type { PostCardData, QuoteTypeData } from "./types";
+
+interface QuoteCardProps {
+  post: PostCardData & { typeData: QuoteTypeData };
+}
+
+export function QuoteCard({ post }: QuoteCardProps) {
+  const { quotedText, attribution } = post.typeData;
+
+  return (
+    <CardShell post={post} accentClassName="via-amber-500/30 group-hover/card:via-amber-500/60">
+      <SourceBadge post={post} />
+      <div className="relative pl-4">
+        <div className="absolute left-0 top-0 bottom-0 w-[3px] rounded-full bg-amber-500/40" />
+        <span
+          className="pointer-events-none absolute -left-1 -top-3 font-serif text-4xl leading-none text-amber-500/20 select-none"
+          aria-hidden="true"
+        >
+          &ldquo;
+        </span>
+        <blockquote
+          data-testid="quoted-text"
+          className="text-base leading-relaxed italic text-foreground/90"
+        >
+          {quotedText}
+        </blockquote>
+        {attribution && (
+          <p data-testid="quote-attribution" className="mt-2 text-sm text-muted-foreground/70">
+            &mdash; {attribution}
+          </p>
+        )}
+      </div>
+    </CardShell>
+  );
+}

--- a/apps/web/src/components/cards/summary-card.tsx
+++ b/apps/web/src/components/cards/summary-card.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Markdown from "react-markdown";
+
+import { Badge } from "@/components/ui/badge";
+
+import { CardShell, SourceBadge } from "./card-shell";
+import type { PostCardData, SummaryTypeData } from "./types";
+
+interface SummaryCardProps {
+  post: PostCardData & { typeData: SummaryTypeData };
+}
+
+export function SummaryCard({ post }: SummaryCardProps) {
+  const { bulletPoints } = post.typeData;
+
+  return (
+    <CardShell post={post} accentClassName="via-blue-500/30 group-hover/card:via-blue-500/60">
+      <div className="mb-3 flex items-center gap-2">
+        <SourceBadge post={post} className="mb-0" />
+        <Badge
+          data-testid="summary-badge"
+          className="bg-blue-500/10 text-blue-600 dark:bg-blue-500/20 dark:text-blue-400"
+        >
+          Summary
+        </Badge>
+      </div>
+      {bulletPoints.length > 0 ? (
+        <ul data-testid="summary-bullets" className="space-y-1.5 text-sm text-foreground/80">
+          {bulletPoints.map((point, index) => (
+            <li key={index} className="flex gap-2">
+              <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-blue-500/40" />
+              <span>{point}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div
+          data-testid="summary-content"
+          className="prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+        >
+          <Markdown>{post.content}</Markdown>
+        </div>
+      )}
+    </CardShell>
+  );
+}

--- a/apps/web/src/components/cards/types.ts
+++ b/apps/web/src/components/cards/types.ts
@@ -1,0 +1,56 @@
+import type { Id } from "@scrollect/backend/convex/_generated/dataModel";
+
+export type PostType = "insight" | "quiz" | "quote" | "summary" | "connection";
+
+export type InsightTypeData = {
+  type: "insight";
+};
+
+export type QuizTypeData = {
+  type: "quiz";
+  variant: "multiple_choice" | "true_false";
+  question: string;
+  options: string[];
+  correctIndex: number;
+  explanation: string;
+};
+
+export type QuoteTypeData = {
+  type: "quote";
+  quotedText: string;
+  attribution?: string;
+};
+
+export type SummaryTypeData = {
+  type: "summary";
+  bulletPoints: string[];
+};
+
+export type ConnectionTypeData = {
+  type: "connection";
+  sourceATitleHint: string;
+  sourceBTitleHint: string;
+};
+
+export type TypeData =
+  | InsightTypeData
+  | QuizTypeData
+  | QuoteTypeData
+  | SummaryTypeData
+  | ConnectionTypeData;
+
+export interface PostCardData {
+  _id: Id<"posts">;
+  content: string;
+  postType: PostType;
+  typeData: TypeData;
+  primarySourceDocumentTitle: string;
+  primarySourceDocumentId: Id<"documents">;
+  primarySourceChunkId: Id<"chunks">;
+  primarySourceSectionTitle?: string | null;
+  primarySourcePageNumber?: number | null;
+  createdAt: number;
+  reaction?: "like" | "dislike" | null;
+  isBookmarked?: boolean;
+  chunkIndex?: number;
+}

--- a/apps/web/src/components/cards/utils.ts
+++ b/apps/web/src/components/cards/utils.ts
@@ -1,0 +1,9 @@
+export function formatSourceLocation(
+  title: string,
+  sectionTitle?: string | null,
+  pageNumber?: number | null,
+): string {
+  if (sectionTitle) return `${title} · ${sectionTitle}`;
+  if (pageNumber != null) return `${title} · Page ${pageNumber}`;
+  return title;
+}

--- a/apps/web/src/components/chunk-context-sheet.tsx
+++ b/apps/web/src/components/chunk-context-sheet.tsx
@@ -7,6 +7,8 @@ import { FileText, Loader2 } from "lucide-react";
 import { useState } from "react";
 import Markdown from "react-markdown";
 
+import { formatSourceLocation } from "@/components/cards/utils";
+import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 const PREVIEW_LENGTH = 100;
@@ -22,26 +24,64 @@ function stripMarkdown(md: string): string {
     .trim();
 }
 
-function ContextChunk({ content, label }: { content: string; label: "Previous" | "Next" }) {
+function ContextChunk({
+  content,
+  label,
+  isPrimary = false,
+}: {
+  content: string;
+  label: string;
+  isPrimary?: boolean;
+}) {
   const [expanded, setExpanded] = useState(false);
   const plain = stripMarkdown(content);
   const needsTruncation = plain.length > PREVIEW_LENGTH;
 
   return (
-    <div className="relative mb-4 last:mb-0">
+    <div
+      className="relative mb-4 last:mb-0"
+      data-testid="source-chunk"
+      data-primary={isPrimary || undefined}
+    >
       <div className="absolute -left-7 top-[13px] flex w-[19px] items-center justify-center">
-        <div className="size-1.5 rounded-full bg-muted-foreground/25" />
+        {isPrimary ? (
+          <div className="size-2.5 rounded-full bg-primary ring-[3px] ring-primary/15" />
+        ) : (
+          <div className="size-1.5 rounded-full bg-muted-foreground/25" />
+        )}
       </div>
-      <span className="mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/40">
+      <span
+        className={cn(
+          "mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.1em]",
+          isPrimary ? "text-primary/60" : "text-muted-foreground/40",
+        )}
+      >
         {label}
       </span>
-      <div className="rounded-lg border border-border/30 bg-muted/20 p-3">
+      <div
+        className={cn(
+          "rounded-lg border p-3",
+          isPrimary
+            ? "border-primary/20 bg-primary/[0.04] ring-1 ring-primary/10"
+            : "border-border/30 bg-muted/20",
+        )}
+      >
         {expanded ? (
-          <div className="prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed text-muted-foreground/60 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+          <div
+            className={cn(
+              "prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+              !isPrimary && "text-muted-foreground/60",
+            )}
+          >
             <Markdown>{content}</Markdown>
           </div>
         ) : (
-          <p className="text-sm leading-relaxed text-muted-foreground/60">
+          <p
+            className={cn(
+              "text-sm leading-relaxed",
+              isPrimary ? "text-foreground" : "text-muted-foreground/60",
+            )}
+          >
             {needsTruncation ? `${plain.slice(0, PREVIEW_LENGTH)}...` : plain}
           </p>
         )}
@@ -59,48 +99,68 @@ function ContextChunk({ content, label }: { content: string; label: "Previous" |
   );
 }
 
+function getLocationLabel(
+  documentTitle: string | null,
+  sectionTitle: string | null,
+  pageNumber: number | null,
+): string {
+  return formatSourceLocation(documentTitle ?? "Untitled", sectionTitle, pageNumber);
+}
+
 interface ChunkContextSheetContentProps {
+  postId: Id<"posts">;
   sourceChunkId: Id<"chunks">;
   sourceDocumentTitle: string | null;
   sectionTitle: string | null;
   pageNumber: number | null;
   chunkIndex: number;
   isOpen: boolean;
+  postType?: string;
 }
 
 export function ChunkContextSheetContent({
+  postId,
   sourceChunkId,
   sourceDocumentTitle,
   sectionTitle,
   pageNumber,
   chunkIndex,
   isOpen,
+  postType,
 }: ChunkContextSheetContentProps) {
   const chunkContext = useQuery(
     api.chunks.getWithContext,
     isOpen ? { chunkId: sourceChunkId } : "skip",
   );
 
-  const locationLabel = sectionTitle
-    ? `${sourceDocumentTitle ?? "Untitled"} · ${sectionTitle}`
-    : pageNumber != null
-      ? `${sourceDocumentTitle ?? "Untitled"} · Page ${pageNumber}`
-      : (sourceDocumentTitle ?? "Untitled");
+  const postSources = useQuery(api.feed.queries.listSourcesByPostId, isOpen ? { postId } : "skip");
 
+  const locationLabel = getLocationLabel(sourceDocumentTitle, sectionTitle, pageNumber);
   const hasContext = chunkContext?.previousChunk || chunkContext?.nextChunk;
+  const supportingSources = postSources?.filter((s) => s.chunkId !== sourceChunkId) ?? [];
+  const hasMultipleSources = supportingSources.length > 0;
 
   return (
     <div data-testid="source-sheet" className="flex flex-col gap-4 overflow-y-auto px-4 pb-4">
-      {/* Header info */}
       <div className="flex items-center gap-2 rounded-lg bg-muted/50 p-2.5 text-sm text-muted-foreground">
         <FileText className="size-4 shrink-0 text-primary/50" />
         <span className="truncate font-medium">{locationLabel}</span>
-        <span className="ml-auto shrink-0 rounded-md bg-background px-1.5 py-0.5 font-mono text-[11px] ring-1 ring-border/60">
-          #{chunkIndex + 1}
-        </span>
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          {postType && (
+            <Badge
+              data-testid="sheet-post-type-badge"
+              variant="outline"
+              className="text-[10px] capitalize"
+            >
+              {postType}
+            </Badge>
+          )}
+          <span className="rounded-md bg-background px-1.5 py-0.5 font-mono text-[11px] ring-1 ring-border/60">
+            #{chunkIndex + 1}
+          </span>
+        </div>
       </div>
 
-      {/* Loading state */}
       {!chunkContext && isOpen && (
         <div className="flex flex-col items-center justify-center gap-2 py-12">
           <Loader2 className="size-5 animate-spin text-primary/60" />
@@ -108,41 +168,42 @@ export function ChunkContextSheetContent({
         </div>
       )}
 
-      {/* Chunk context with timeline */}
       {chunkContext && (
         <div className="relative pl-7">
-          {/* Timeline vertical line */}
           {hasContext && <div className="absolute left-[9px] top-4 bottom-4 w-px bg-border/60" />}
 
-          {/* Previous chunk */}
           {chunkContext.previousChunk && (
             <ContextChunk content={chunkContext.previousChunk.content} label="Previous" />
           )}
 
-          {/* Source chunk (highlighted) */}
-          <div className="relative mb-4">
-            <div className="absolute -left-7 top-[13px] flex w-[19px] items-center justify-center">
-              <div className="size-2.5 rounded-full bg-primary ring-[3px] ring-primary/15" />
-            </div>
-            <span className="mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.1em] text-primary/60">
-              Source
-            </span>
-            <div
-              className={cn(
-                "rounded-lg border border-primary/20 bg-primary/[0.04] p-3",
-                "ring-1 ring-primary/10",
-              )}
-            >
-              <div className="prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-                <Markdown>{chunkContext.chunk.content}</Markdown>
-              </div>
-            </div>
-          </div>
+          <ContextChunk content={chunkContext.chunk.content} label="Primary source" isPrimary />
 
-          {/* Next chunk */}
           {chunkContext.nextChunk && (
             <ContextChunk content={chunkContext.nextChunk.content} label="Next" />
           )}
+        </div>
+      )}
+
+      {hasMultipleSources && (
+        <div className="mt-2">
+          <h4 className="mb-3 text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/60">
+            Supporting sources
+          </h4>
+          <div className="relative pl-7">
+            {supportingSources.length > 1 && (
+              <div className="absolute left-[9px] top-4 bottom-4 w-px bg-border/60" />
+            )}
+            {supportingSources.map((source) => {
+              const label = getLocationLabel(
+                source.documentTitle,
+                source.sectionTitle,
+                source.pageNumber,
+              );
+              return (
+                <ContextChunk key={source._id} content={source.chunkContent ?? ""} label={label} />
+              );
+            })}
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -1,246 +1,41 @@
 "use client";
 
-import { api } from "@scrollect/backend/convex/_generated/api";
-import type { Id } from "@scrollect/backend/convex/_generated/dataModel";
-import type { OptimisticLocalStore } from "convex/browser";
-import { useMutation } from "convex/react";
-import { formatDistanceToNow } from "date-fns";
-import { Bookmark, BookmarkCheck, Maximize2, ThumbsDown, ThumbsUp } from "lucide-react";
-import Link from "next/link";
-import { useState } from "react";
-import Markdown from "react-markdown";
-
-import { ChunkContextSheetContent } from "@/components/chunk-context-sheet";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { cn } from "@/lib/utils";
+  ConnectionCard,
+  InsightCard,
+  QuizMcCard,
+  QuizRevealCard,
+  QuoteCard,
+  SummaryCard,
+} from "@/components/cards";
+import type { PostCardData } from "@/components/cards/types";
 
-export interface PostCardData {
-  _id: Id<"posts">;
-  content: string;
-  sourceDocumentTitle: string | null;
-  createdAt: number;
-  reaction?: "like" | "dislike" | null;
-  isBookmarked?: boolean;
-  sourceChunkId?: Id<"chunks">;
-  sourceDocumentId?: Id<"documents">;
-  sectionTitle?: string | null;
-  pageNumber?: number | null;
-  chunkIndex?: number;
-}
+export type { PostCardData };
 
 interface PostCardProps {
   post: PostCardData;
 }
 
-/**
- * Update a post across all cached paginated pages of the feed query.
- * Uses getAllQueries to find every loaded page, then patches the matching post.
- */
-function updatePostInPaginatedPages(
-  localStore: OptimisticLocalStore,
-  postId: Id<"posts">,
-  updater: (post: Record<string, unknown>) => Record<string, unknown>,
-) {
-  const allPages = localStore.getAllQueries(api.feed.queries.list);
-  for (const { args, value } of allPages) {
-    if (value === undefined) continue;
-    const hasMatch = value.page.some((p) => p._id === postId);
-    if (!hasMatch) continue;
-    localStore.setQuery(api.feed.queries.list, args, {
-      ...value,
-      page: value.page.map((p) => (p._id === postId ? { ...p, ...updater(p) } : p)),
-    });
-  }
-}
-
-/**
- * Build a human-readable source location label from the post metadata.
- */
-function getSourceLabel(post: PostCardData): string {
-  const title = post.sourceDocumentTitle ?? "Untitled";
-  if (post.sectionTitle) return `${title} · ${post.sectionTitle}`;
-  if (post.pageNumber != null) return `${title} · Page ${post.pageNumber}`;
-  return title;
-}
-
 export function PostCard({ post }: PostCardProps) {
-  const [sheetOpen, setSheetOpen] = useState(false);
+  const { typeData } = post;
 
-  const toggleBookmark = useMutation(api.bookmarks.toggle).withOptimisticUpdate(
-    (localStore, args) => {
-      updatePostInPaginatedPages(localStore, args.postId, (p) => ({
-        isBookmarked: !p.isBookmarked,
-      }));
-    },
-  );
-
-  const setReaction = useMutation(api.feed.queries.setReaction).withOptimisticUpdate(
-    (localStore, args) => {
-      updatePostInPaginatedPages(localStore, args.postId, () => ({
-        reaction: args.reaction === "none" ? undefined : args.reaction,
-      }));
-    },
-  );
-
-  const hasSourceDetails = post.sourceDocumentId != null && post.sourceChunkId != null;
-
-  const sourceBadge = post.sourceDocumentTitle && (
-    <div className="mb-3">
-      {post.sourceDocumentId ? (
-        <Link href={`/library/${post.sourceDocumentId}`} data-testid="source-badge">
-          <Badge
-            variant="outline"
-            className="gap-1.5 border-primary/15 bg-primary/[0.03] font-normal text-muted-foreground transition-all hover:border-primary/25 hover:bg-primary/[0.06]"
-          >
-            <span className="size-1.5 shrink-0 rounded-full bg-primary/60" />
-            <span className="max-w-52 truncate">{getSourceLabel(post)}</span>
-          </Badge>
-        </Link>
-      ) : (
-        <Badge
-          variant="outline"
-          className="gap-1.5 border-border/60 font-normal text-muted-foreground"
-          data-testid="source-badge"
-        >
-          <span className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
-          <span className="max-w-52 truncate">{getSourceLabel(post)}</span>
-        </Badge>
-      )}
-    </div>
-  );
-
-  return (
-    <>
-      <article
-        data-testid="post-card"
-        className="group/card relative overflow-hidden rounded-xl bg-card text-card-foreground ring-1 ring-foreground/[0.06] transition-all duration-300 hover:-translate-y-0.5 hover:ring-primary/15 hover:shadow-lg hover:shadow-primary/[0.06]"
-      >
-        {/* Top accent gradient */}
-        <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/30 to-transparent transition-all duration-300 group-hover/card:h-0.5 group-hover/card:via-primary/60" />
-
-        <div className="px-5 pt-5 pb-4">
-          {/* Source badge */}
-          {sourceBadge}
-
-          {/* Content */}
-          <div className="prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-            <Markdown>{post.content}</Markdown>
-          </div>
-
-          {/* Footer */}
-          <div className="mt-4 flex items-center justify-between border-t border-border/40 pt-3">
-            <time className="text-xs tracking-wide text-muted-foreground/70">
-              {formatDistanceToNow(post.createdAt, { addSuffix: true })}
-            </time>
-
-            <div className="flex items-center gap-0.5">
-              {hasSourceDetails && post.sourceChunkId && (
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  className="transition-all duration-200 active:scale-90"
-                  onClick={() => setSheetOpen(true)}
-                  data-testid="expand-button"
-                  title="View source context"
-                >
-                  <Maximize2 className="size-3.5" />
-                </Button>
-              )}
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className={cn(
-                  "transition-all duration-200 active:scale-90",
-                  post.isBookmarked &&
-                    "bg-primary/10 text-primary hover:bg-primary/15 dark:bg-primary/20 dark:hover:bg-primary/25",
-                )}
-                onClick={() => toggleBookmark({ postId: post._id })}
-                data-testid="save-button"
-                aria-pressed={!!post.isBookmarked}
-                title="Save"
-              >
-                {post.isBookmarked ? (
-                  <BookmarkCheck className="size-3.5" />
-                ) : (
-                  <Bookmark className="size-3.5" />
-                )}
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className={cn(
-                  "transition-all duration-200 active:scale-90",
-                  post.reaction === "like" &&
-                    "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/15 dark:bg-emerald-500/20 dark:text-emerald-400 dark:hover:bg-emerald-500/25",
-                )}
-                onClick={() =>
-                  setReaction({
-                    postId: post._id,
-                    reaction: post.reaction === "like" ? "none" : "like",
-                  })
-                }
-                data-testid="like-button"
-                aria-pressed={post.reaction === "like"}
-                title="Like"
-              >
-                <ThumbsUp className={cn("size-3.5", post.reaction === "like" && "fill-current")} />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className={cn(
-                  "transition-all duration-200 active:scale-90",
-                  post.reaction === "dislike" &&
-                    "bg-red-500/10 text-red-500 hover:bg-red-500/15 dark:bg-red-500/20 dark:text-red-400 dark:hover:bg-red-500/25",
-                )}
-                onClick={() =>
-                  setReaction({
-                    postId: post._id,
-                    reaction: post.reaction === "dislike" ? "none" : "dislike",
-                  })
-                }
-                data-testid="dislike-button"
-                aria-pressed={post.reaction === "dislike"}
-                title="Dislike"
-              >
-                <ThumbsDown
-                  className={cn("size-3.5", post.reaction === "dislike" && "fill-current")}
-                />
-              </Button>
-            </div>
-          </div>
-        </div>
-      </article>
-
-      {/* Source context sheet */}
-      {hasSourceDetails && post.sourceChunkId && (
-        <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
-          <SheetContent side="right" className="overflow-y-auto sm:max-w-2xl">
-            <SheetHeader>
-              <SheetTitle>Source Context</SheetTitle>
-              <SheetDescription>
-                View the original source chunk with surrounding context.
-              </SheetDescription>
-            </SheetHeader>
-            <ChunkContextSheetContent
-              sourceChunkId={post.sourceChunkId}
-              sourceDocumentTitle={post.sourceDocumentTitle}
-              sectionTitle={post.sectionTitle ?? null}
-              pageNumber={post.pageNumber ?? null}
-              chunkIndex={post.chunkIndex!}
-              isOpen={sheetOpen}
-            />
-          </SheetContent>
-        </Sheet>
-      )}
-    </>
-  );
+  switch (typeData.type) {
+    case "insight":
+      return <InsightCard post={post} />;
+    case "quiz":
+      if (typeData.variant === "multiple_choice") {
+        return <QuizMcCard post={{ ...post, typeData }} />;
+      }
+      return <QuizRevealCard post={{ ...post, typeData }} />;
+    case "quote":
+      return <QuoteCard post={{ ...post, typeData }} />;
+    case "summary":
+      return <SummaryCard post={{ ...post, typeData }} />;
+    case "connection":
+      return <ConnectionCard post={{ ...post, typeData }} />;
+    default: {
+      const _exhaustive: never = typeData;
+      return null;
+    }
+  }
 }

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -15,6 +15,8 @@ import type * as chunks from "../chunks.js";
 import type * as documents from "../documents.js";
 import type * as feed_generation from "../feed/generation.js";
 import type * as feed_queries from "../feed/queries.js";
+import type * as feed_sampling from "../feed/sampling.js";
+import type * as feed_validation from "../feed/validation.js";
 import type * as healthCheck from "../healthCheck.js";
 import type * as http from "../http.js";
 import type * as lib_functions from "../lib/functions.js";
@@ -58,6 +60,8 @@ declare const fullApi: ApiFromModules<{
   documents: typeof documents;
   "feed/generation": typeof feed_generation;
   "feed/queries": typeof feed_queries;
+  "feed/sampling": typeof feed_sampling;
+  "feed/validation": typeof feed_validation;
   healthCheck: typeof healthCheck;
   http: typeof http;
   "lib/functions": typeof lib_functions;

--- a/packages/backend/convex/bookmarks.ts
+++ b/packages/backend/convex/bookmarks.ts
@@ -1,7 +1,6 @@
 import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 
-import type { Id } from "./_generated/dataModel";
 import { mutation, query } from "./_generated/server";
 import { requireAuth, optionalAuth } from "./lib/functions";
 
@@ -86,32 +85,20 @@ export const listSaved = query({
     const enrichedPage = await Promise.all(
       result.page.map(async (bookmark) => {
         const post = await ctx.db.get(bookmark.postId);
-        let sourceDocumentTitle: string | null = null;
-        let sourceChunkId: Id<"chunks"> | null = null;
-        let sectionTitle: string | null = null;
-        let pageNumber: number | null = null;
-        let chunkIndex = 0;
-        if (post) {
-          const doc = await ctx.db.get(post.sourceDocumentId);
-          sourceDocumentTitle = doc?.title ?? null;
-          sourceChunkId = post.sourceChunkId;
-          const chunk = await ctx.db.get(post.sourceChunkId);
-          sectionTitle = chunk?.sectionTitle ?? null;
-          pageNumber = chunk?.pageNumber ?? null;
-          chunkIndex = chunk?.chunkIndex ?? 0;
+        if (!post) {
+          return { ...bookmark, post: null };
         }
+        const chunk = await ctx.db.get(post.primarySourceChunkId);
         return {
           ...bookmark,
-          post: post
-            ? {
-                ...post,
-                sourceDocumentTitle,
-                sourceChunkId: sourceChunkId!,
-                sectionTitle,
-                pageNumber,
-                chunkIndex,
-              }
-            : null,
+          post: {
+            ...post,
+            sourceDocumentTitle: post.primarySourceDocumentTitle,
+            sourceChunkId: post.primarySourceChunkId,
+            sectionTitle: post.primarySourceSectionTitle ?? null,
+            pageNumber: post.primarySourcePageNumber ?? null,
+            chunkIndex: chunk?.chunkIndex ?? 0,
+          },
         };
       }),
     );

--- a/packages/backend/convex/feed/generation.ts
+++ b/packages/backend/convex/feed/generation.ts
@@ -5,9 +5,21 @@ import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
+import type { ActionCtx } from "../_generated/server";
 import { action } from "../_generated/server";
 import { requireAuth } from "../lib/functions";
+import type { TypeData } from "../lib/validators";
 import { WideEvent } from "../lib/logging";
+import type { ChunkInfo, PostSourceRecord } from "./sampling";
+import { buildChunkUsageMap, buildTypeCoverageHint, shuffle, weightedSample } from "./sampling";
+import type { RawCard } from "./validation";
+import { validateCard } from "./validation";
+
+const MAX_GENERATION_RETRIES = 2;
+const RETRY_BASE_DELAY_MS = 2000;
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const SATURATION_THRESHOLD = 0.8;
 
 function getOpenAIClient(): OpenAI {
   const apiKey = process.env.OPENAI_API_KEY;
@@ -17,28 +29,114 @@ function getOpenAIClient(): OpenAI {
   return new OpenAI({ apiKey });
 }
 
+function buildMultiTypePrompt(chunkCount: number, cardCount: number): string {
+  return `You are an AI learning assistant for Scrollect, a personal learning feed app.
+Your job is to transform raw text chunks from documents into engaging, bite-sized learning cards of MIXED types.
+
+Card types you MUST produce (aim for variety — use at least 3 different types):
+
+1. **insight** — A concise insight or key takeaway (2-4 sentences). Use **bold** for key terms.
+2. **quiz** — A question testing understanding. Include:
+   - variant: "multiple_choice" or "true_false"
+   - question: the question text
+   - options: array of 4 choices (or 2 for true_false: ["True", "False"])
+   - correctIndex: 0-based index of the correct option
+   - explanation: brief explanation of the correct answer
+3. **quote** — A notable quote from the source. Include:
+   - quotedText: the exact quoted text
+   - attribution: (optional) author or source name
+4. **summary** — A bullet-point summary combining ideas from MULTIPLE chunks. Include:
+   - bulletPoints: array of 2-5 bullet point strings
+   - IMPORTANT: summaries MUST reference at least 2 different chunks via sourceChunkIndices
+5. **connection** — Links concepts across DIFFERENT documents. Include:
+   - sourceATitleHint: title/topic of the first source
+   - sourceBTitleHint: title/topic of the second source
+   - IMPORTANT: connections MUST reference chunks from at least 2 different documents via sourceChunkIndices
+
+For ALL cards:
+- content: 2-4 sentences of engaging text (the main card body)
+- sourceChunkIndices: array of 0-based indices into the provided chunks that this card draws from
+
+Return a JSON object: { "cards": [ { type, content, sourceChunkIndices, ...type-specific fields } ] }
+
+Produce exactly ${cardCount} cards from the ${chunkCount} chunks provided. Ensure variety in types.`;
+}
+
+function buildLegacyPrompt(chunkCount: number): string {
+  return `You are an AI learning assistant for Scrollect, a personal learning feed app.
+Your job is to transform raw text chunks from documents into engaging, bite-sized learning cards.
+
+Each card should:
+- Be concise (2-4 sentences)
+- Highlight one key insight, fact, or concept
+- Be written in a clear, engaging tone
+- Stand on its own without needing additional context
+- Use light Markdown formatting: **bold** for key terms, and occasional bullet points when listing related ideas
+
+Return a JSON object with a "posts" key containing an array of exactly ${chunkCount} strings, one for each input chunk.`;
+}
+
+async function callWithRetry(
+  openai: OpenAI,
+  messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[],
+  model: string,
+  evt: WideEvent,
+): Promise<string> {
+  for (let attempt = 0; attempt <= MAX_GENERATION_RETRIES; attempt++) {
+    try {
+      const response = await openai.chat.completions.create({
+        model,
+        messages,
+        temperature: 0.7,
+        response_format: { type: "json_object" },
+      });
+      return response.choices[0]?.message?.content ?? "{}";
+    } catch (error: unknown) {
+      const status = (error as { status?: number }).status ?? 0;
+      const isRetryable =
+        error instanceof Error &&
+        (error.message.includes("rate_limit") ||
+          error.message.includes("timeout") ||
+          status === 429 ||
+          status >= 500);
+
+      if (!isRetryable || attempt === MAX_GENERATION_RETRIES) {
+        throw error;
+      }
+
+      const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+      evt.set(`retry_${attempt}`, delay);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw new Error("Exhausted retries");
+}
+
 export const generate = action({
   args: { count: v.optional(v.number()) },
-  handler: async (ctx, args) => {
-    const postCount = args.count ?? 5;
+  handler: async (ctx, args): Promise<Id<"posts">[]> => {
+    const cardCount = args.count ?? 5;
     const evt = new WideEvent("feedGeneration.generate");
+    const useMultiType = process.env.MULTI_TYPE_GENERATION !== "false";
+    evt.set("multiTypeEnabled", useMultiType);
+
     try {
       const user = await requireAuth(ctx);
       evt.set("userId", user._id);
 
-      // Get all ready documents for this user
-      const documents = await ctx.runQuery(internal.feed.queries.listReadyDocuments, {
-        userId: user._id,
-      });
-
+      const documents: { _id: Id<"documents">; title: string; createdAt: number }[] =
+        await ctx.runQuery(internal.feed.queries.listReadyDocuments, { userId: user._id });
       evt.set("readyDocuments", documents.length);
 
       if (documents.length === 0) {
         throw new Error("No ready documents found. Upload and process a document first.");
       }
 
-      // Gather chunks from all ready documents
-      const allChunks: { _id: Id<"chunks">; content: string; documentId: Id<"documents"> }[] = [];
+      const now = Date.now();
+      const docMap = new Map<string, string>(documents.map((d) => [d._id, d.title]));
+      const docCreatedAtMap = new Map<string, number>(documents.map((d) => [d._id, d.createdAt]));
+
+      const allChunks: ChunkInfo[] = [];
       for (const doc of documents) {
         const chunks = await ctx.runQuery(internal.feed.queries.listChunksForDocument, {
           documentId: doc._id,
@@ -48,6 +146,9 @@ export const generate = action({
             _id: chunk._id,
             content: chunk.content,
             documentId: doc._id,
+            documentTitle: doc.title,
+            sectionTitle: chunk.sectionTitle,
+            pageNumber: chunk.pageNumber,
           });
         }
       }
@@ -58,71 +159,146 @@ export const generate = action({
         throw new Error("No chunks available to generate feed from.");
       }
 
-      // Pick random chunks to base posts on
-      const selected = shuffle(allChunks).slice(0, postCount);
+      const recentSources: PostSourceRecord[] = await ctx.runQuery(
+        internal.feed.queries.listRecentPostSources,
+        { userId: user._id, sinceTs: now - NINETY_DAYS_MS },
+      );
+
+      const recentPosts: { _id: Id<"posts">; postType: string }[] = await ctx.runQuery(
+        internal.feed.queries.listRecentPosts,
+        {
+          userId: user._id,
+          sinceTs: now - NINETY_DAYS_MS,
+        },
+      );
+
+      const chunkUsageMap = buildChunkUsageMap(recentSources, recentPosts);
+
+      const usedChunkCount = chunkUsageMap.size;
+      const saturationRatio = allChunks.length > 0 ? usedChunkCount / allChunks.length : 0;
+      evt.set("saturationRatio", saturationRatio);
+      if (saturationRatio > SATURATION_THRESHOLD) {
+        evt.set("saturationWarning", true);
+      }
+
+      const recentHashes = new Set(
+        await ctx.runQuery(internal.feed.queries.listRecentChunkHashes, {
+          userId: user._id,
+          sinceTs: now - THIRTY_DAYS_MS,
+        }),
+      );
+
+      const sampleSize = Math.max(cardCount * 2, 10);
+      const selected = useMultiType
+        ? weightedSample(allChunks, chunkUsageMap, docCreatedAtMap, sampleSize, now)
+        : shuffle(allChunks).slice(0, sampleSize);
       evt.set("selectedChunks", selected.length);
 
       const openai = getOpenAIClient();
       const model = "gpt-4o-mini";
       evt.set("model", model);
 
-      const systemPrompt = `You are an AI learning assistant for Scrollect, a personal learning feed app.
-Your job is to transform raw text chunks from documents into engaging, bite-sized learning cards.
-
-Each card should:
-- Be concise (2-4 sentences)
-- Highlight one key insight, fact, or concept
-- Be written in a clear, engaging tone
-- Stand on its own without needing additional context
-- Use light Markdown formatting: **bold** for key terms, and occasional bullet points when listing related ideas
-
-Return a JSON object with a "posts" key containing an array of exactly ${selected.length} strings, one for each input chunk.`;
-
-      const userPrompt = selected
-        .map((chunk, i) => `Chunk ${i + 1}:\n${chunk.content}`)
-        .join("\n\n---\n\n");
-
-      const response = await openai.chat.completions.create({
-        model,
-        messages: [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: userPrompt },
-        ],
-        temperature: 0.7,
-        response_format: { type: "json_object" },
-      });
-
-      const raw = response.choices[0]?.message?.content ?? "{}";
-      let posts: string[];
-      try {
-        const parsed = JSON.parse(raw);
-        // Handle both direct array and wrapped object (e.g. { "posts": [...] })
-        posts = Array.isArray(parsed)
-          ? parsed
-          : Array.isArray(parsed.posts)
-            ? parsed.posts
-            : ((Object.values(parsed).find(Array.isArray) as string[]) ?? []);
-      } catch (error) {
-        evt.set("aiRawResponse", raw.substring(0, 500));
-        evt.setError(error);
-        throw new Error("Failed to parse AI response");
+      if (!useMultiType) {
+        return await generateLegacy(
+          ctx,
+          openai,
+          model,
+          selected,
+          documents,
+          user._id,
+          cardCount,
+          evt,
+        );
       }
 
-      evt.set("postsGenerated", posts.length);
+      const typeCoverageHint = buildTypeCoverageHint(chunkUsageMap);
+      const systemPrompt = buildMultiTypePrompt(selected.length, cardCount) + typeCoverageHint;
+      const userPrompt = selected
+        .map((chunk, i) => `Chunk ${i} (from "${chunk.documentTitle}"):\n${chunk.content}`)
+        .join("\n\n---\n\n");
 
-      // Store posts in the database
+      let validCards: { card: RawCard; chunks: ChunkInfo[] }[] = [];
+      let generationAttempts = 0;
+      const maxBatchRetries = 2;
+
+      while (validCards.length < cardCount && generationAttempts <= maxBatchRetries) {
+        generationAttempts++;
+        const raw = await callWithRetry(
+          openai,
+          [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: userPrompt },
+          ],
+          model,
+          evt,
+        );
+
+        let cards: RawCard[];
+        try {
+          const parsed = JSON.parse(raw);
+          cards = Array.isArray(parsed) ? parsed : (parsed.cards ?? []);
+        } catch {
+          evt.set("parseError", raw.substring(0, 500));
+          continue;
+        }
+
+        const validated: { card: RawCard; chunks: ChunkInfo[] }[] = [];
+        const dropped: string[] = [];
+        for (const card of cards) {
+          if (validateCard(card, selected)) {
+            const cardChunks = card.sourceChunkIndices.map((i) => selected[i]!);
+            validated.push({ card, chunks: cardChunks });
+          } else {
+            dropped.push(`${card.type ?? "unknown"}: missing fields`);
+          }
+        }
+
+        evt.set(`attempt_${generationAttempts}_total`, cards.length);
+        evt.set(`attempt_${generationAttempts}_valid`, validated.length);
+        evt.set(`attempt_${generationAttempts}_dropped`, dropped.length);
+
+        if (validated.length > 0 && dropped.length / cards.length <= 0.5) {
+          validCards = validated;
+          break;
+        }
+
+        if (validated.length > validCards.length) {
+          validCards = validated;
+        }
+      }
+
+      evt.set("finalCardCount", validCards.length);
+
       const postIds: Id<"posts">[] = [];
-      for (let i = 0; i < posts.length; i++) {
-        const chunk = selected[i]!;
-        const content = posts[i]!;
-        const id = await ctx.runMutation(internal.feed.queries.createPost, {
-          content,
-          sourceChunkId: chunk._id,
-          sourceDocumentId: chunk.documentId,
+      let dedupSkipped = 0;
+      for (const { card, chunks: cardChunks } of validCards.slice(0, cardCount)) {
+        const candidateHash = cardChunks
+          .map((c) => c._id)
+          .sort()
+          .join("+");
+        if (recentHashes.has(candidateHash)) {
+          dedupSkipped++;
+          continue;
+        }
+        recentHashes.add(candidateHash);
+
+        const primaryChunk = cardChunks[0]!;
+        const id = await ctx.runMutation(internal.feed.queries.insertPost, {
+          content: card.content,
+          postType: card.type,
+          typeData: buildTypeData(card),
+          primarySourceDocumentId: primaryChunk.documentId as Id<"documents">,
+          primarySourceDocumentTitle: docMap.get(primaryChunk.documentId) ?? "Unknown",
+          primarySourceChunkId: primaryChunk._id as Id<"chunks">,
+          primarySourceSectionTitle: primaryChunk.sectionTitle,
+          primarySourcePageNumber: primaryChunk.pageNumber,
+          sourceChunkIds: cardChunks.map((c) => c._id as Id<"chunks">),
+          sourceDocumentIds: cardChunks.map((c) => c.documentId as Id<"documents">),
           userId: user._id,
         });
         postIds.push(id);
       }
+      evt.set("dedupSkipped", dedupSkipped);
 
       return postIds;
     } catch (error) {
@@ -134,11 +310,100 @@ Return a JSON object with a "posts" key containing an array of exactly ${selecte
   },
 });
 
-function shuffle<T>(arr: T[]): T[] {
-  const a = [...arr];
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [a[i], a[j]] = [a[j]!, a[i]!];
+// Only valid after validateCard — assumes all type-specific fields are present.
+function buildTypeData(card: RawCard): TypeData {
+  switch (card.type) {
+    case "insight":
+      return { type: "insight" };
+    case "quiz":
+      return {
+        type: "quiz",
+        variant: (card.variant ?? "multiple_choice") as "multiple_choice" | "true_false",
+        question: card.question!,
+        options: card.options!,
+        correctIndex: card.correctIndex!,
+        explanation: card.explanation!,
+      };
+    case "quote":
+      return {
+        type: "quote",
+        quotedText: card.quotedText!,
+        ...(card.attribution ? { attribution: card.attribution } : {}),
+      };
+    case "summary":
+      return {
+        type: "summary",
+        bulletPoints: card.bulletPoints!,
+      };
+    case "connection":
+      return {
+        type: "connection",
+        sourceATitleHint: card.sourceATitleHint!,
+        sourceBTitleHint: card.sourceBTitleHint!,
+      };
   }
-  return a;
+}
+
+async function generateLegacy(
+  ctx: ActionCtx,
+  openai: OpenAI,
+  model: string,
+  selected: ChunkInfo[],
+  documents: { _id: Id<"documents">; title: string }[],
+  userId: string,
+  cardCount: number,
+  evt: WideEvent,
+): Promise<Id<"posts">[]> {
+  const systemPrompt = buildLegacyPrompt(Math.min(selected.length, cardCount));
+  const subset = selected.slice(0, cardCount);
+  const userPrompt = subset
+    .map((chunk, i) => `Chunk ${i + 1}:\n${chunk.content}`)
+    .join("\n\n---\n\n");
+
+  const raw = await callWithRetry(
+    openai,
+    [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userPrompt },
+    ],
+    model,
+    evt,
+  );
+
+  let posts: string[];
+  try {
+    const parsed = JSON.parse(raw);
+    posts = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed.posts)
+        ? parsed.posts
+        : ((Object.values(parsed).find(Array.isArray) as string[]) ?? []);
+  } catch {
+    throw new Error("Failed to parse AI response");
+  }
+
+  evt.set("postsGenerated", posts.length);
+
+  const postIds: Id<"posts">[] = [];
+  for (let i = 0; i < posts.length; i++) {
+    const chunk = subset[i]!;
+    const content = posts[i]!;
+    const doc = documents.find((d) => d._id === chunk.documentId);
+    const id = await ctx.runMutation(internal.feed.queries.insertPost, {
+      content,
+      postType: "insight",
+      typeData: { type: "insight" },
+      primarySourceDocumentId: chunk.documentId as Id<"documents">,
+      primarySourceDocumentTitle: doc?.title ?? "Unknown",
+      primarySourceChunkId: chunk._id as Id<"chunks">,
+      primarySourceSectionTitle: chunk.sectionTitle,
+      primarySourcePageNumber: chunk.pageNumber,
+      sourceChunkIds: [chunk._id as Id<"chunks">],
+      sourceDocumentIds: [chunk.documentId as Id<"documents">],
+      userId,
+    });
+    postIds.push(id);
+  }
+
+  return postIds;
 }

--- a/packages/backend/convex/feed/queries.ts
+++ b/packages/backend/convex/feed/queries.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 
 import { internalMutation, internalQuery, mutation, query } from "../_generated/server";
 import { requireAuth, optionalAuth } from "../lib/functions";
-import { reactionInput } from "../lib/validators";
+import { postType, reactionInput, typeData } from "../lib/validators";
 
 export const list = query({
   args: { paginationOpts: paginationOptsValidator },
@@ -25,19 +25,18 @@ export const list = query({
 
     const enrichedPage = await Promise.all(
       result.page.map(async (post) => {
-        const doc = await ctx.db.get(post.sourceDocumentId);
         const bookmark = await ctx.db
           .query("bookmarks")
           .withIndex("by_userId_post", (q) => q.eq("userId", user._id).eq("postId", post._id))
           .first();
-        const chunk = await ctx.db.get(post.sourceChunkId);
+        const chunk = await ctx.db.get(post.primarySourceChunkId);
         return {
           ...post,
-          sourceDocumentTitle: doc?.title ?? null,
+          sourceDocumentTitle: post.primarySourceDocumentTitle,
           isBookmarked: bookmark !== null,
-          sourceChunkId: post.sourceChunkId,
-          sectionTitle: chunk?.sectionTitle ?? null,
-          pageNumber: chunk?.pageNumber ?? null,
+          sourceChunkId: post.primarySourceChunkId,
+          sectionTitle: post.primarySourceSectionTitle ?? null,
+          pageNumber: post.primarySourcePageNumber ?? null,
           chunkIndex: chunk?.chunkIndex ?? 0,
         };
       }),
@@ -70,6 +69,40 @@ export const setReaction = mutation({
   },
 });
 
+export const listSourcesByPostId = query({
+  args: { postId: v.id("posts") },
+  handler: async (ctx, args) => {
+    const user = await requireAuth(ctx);
+
+    const post = await ctx.db.get(args.postId);
+    if (!post || post.userId !== user._id) {
+      throw new Error("Post not found");
+    }
+
+    const sources = await ctx.db
+      .query("postSources")
+      .withIndex("by_postId", (q) => q.eq("postId", args.postId))
+      .collect();
+
+    return await Promise.all(
+      sources.map(async (source) => {
+        const chunk = await ctx.db.get(source.chunkId);
+        const doc = await ctx.db.get(source.documentId);
+        return {
+          _id: source._id,
+          chunkId: source.chunkId,
+          documentId: source.documentId,
+          documentTitle: doc?.title ?? null,
+          chunkContent: chunk?.content ?? null,
+          chunkIndex: chunk?.chunkIndex ?? 0,
+          sectionTitle: chunk?.sectionTitle ?? null,
+          pageNumber: chunk?.pageNumber ?? null,
+        };
+      }),
+    );
+  },
+});
+
 export const getLastGeneratedAt = query({
   args: {},
   handler: async (ctx) => {
@@ -89,11 +122,10 @@ export const getLastGeneratedAt = query({
 export const listReadyDocuments = internalQuery({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
-    const docs = await ctx.db
+    return await ctx.db
       .query("documents")
-      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .withIndex("by_userId_status", (q) => q.eq("userId", args.userId).eq("status", "ready"))
       .collect();
-    return docs.filter((d) => d.status === "ready");
   },
 });
 
@@ -107,20 +139,103 @@ export const listChunksForDocument = internalQuery({
   },
 });
 
-export const createPost = internalMutation({
+export const listRecentPostSources = internalQuery({
+  args: { userId: v.string(), sinceTs: v.number() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("postSources")
+      .withIndex("by_userId_createdAt", (q) =>
+        q.eq("userId", args.userId).gte("createdAt", args.sinceTs),
+      )
+      .collect();
+  },
+});
+
+export const listRecentPosts = internalQuery({
+  args: { userId: v.string(), sinceTs: v.number() },
+  handler: async (ctx, args) => {
+    const posts = await ctx.db
+      .query("posts")
+      .withIndex("by_userId_createdAt", (q) =>
+        q.eq("userId", args.userId).gte("createdAt", args.sinceTs),
+      )
+      .collect();
+    return posts.map((p) => ({ _id: p._id, postType: p.postType }));
+  },
+});
+
+export const listRecentChunkHashes = internalQuery({
+  args: { userId: v.string(), sinceTs: v.number() },
+  handler: async (ctx, args) => {
+    const posts = await ctx.db
+      .query("posts")
+      .withIndex("by_userId_createdAt", (q) =>
+        q.eq("userId", args.userId).gte("createdAt", args.sinceTs),
+      )
+      .collect();
+    return posts.map((p) => p.sourceChunkHash);
+  },
+});
+
+export const insertPost = internalMutation({
   args: {
     content: v.string(),
-    sourceChunkId: v.id("chunks"),
-    sourceDocumentId: v.id("documents"),
+    postType,
+    typeData,
+    primarySourceDocumentId: v.id("documents"),
+    primarySourceDocumentTitle: v.string(),
+    primarySourceChunkId: v.id("chunks"),
+    primarySourceSectionTitle: v.optional(v.string()),
+    primarySourcePageNumber: v.optional(v.number()),
+    sourceChunkIds: v.array(v.id("chunks")),
+    sourceDocumentIds: v.array(v.id("documents")),
     userId: v.string(),
   },
   handler: async (ctx, args) => {
-    return await ctx.db.insert("posts", {
+    const now = Date.now();
+
+    if (args.postType !== args.typeData.type) {
+      throw new Error(
+        `postType "${args.postType}" does not match typeData.type "${args.typeData.type}"`,
+      );
+    }
+
+    if (args.sourceChunkIds.length !== args.sourceDocumentIds.length) {
+      throw new Error(
+        `sourceChunkIds length (${args.sourceChunkIds.length}) must match sourceDocumentIds length (${args.sourceDocumentIds.length})`,
+      );
+    }
+
+    if (args.sourceChunkIds.length === 0) {
+      throw new Error("At least one source chunk is required");
+    }
+
+    const sourceChunkHash = [...args.sourceChunkIds].sort().join("+");
+
+    const postId = await ctx.db.insert("posts", {
       content: args.content,
-      sourceChunkId: args.sourceChunkId,
-      sourceDocumentId: args.sourceDocumentId,
+      postType: args.postType,
+      typeData: args.typeData,
+      primarySourceDocumentId: args.primarySourceDocumentId,
+      primarySourceDocumentTitle: args.primarySourceDocumentTitle,
+      primarySourceChunkId: args.primarySourceChunkId,
+      primarySourceSectionTitle: args.primarySourceSectionTitle,
+      primarySourcePageNumber: args.primarySourcePageNumber,
+      sourceChunkHash,
       userId: args.userId,
-      createdAt: Date.now(),
+      createdAt: now,
     });
+
+    for (let i = 0; i < args.sourceChunkIds.length; i++) {
+      await ctx.db.insert("postSources", {
+        postId,
+        chunkId: args.sourceChunkIds[i]!,
+        documentId: args.sourceDocumentIds[i]!,
+        userId: args.userId,
+        createdAt: now,
+      });
+    }
+
+    return postId;
   },
 });

--- a/packages/backend/convex/feed/sampling.ts
+++ b/packages/backend/convex/feed/sampling.ts
@@ -1,0 +1,144 @@
+import { ALL_POST_TYPES } from "../lib/validators";
+
+const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type ChunkInfo = {
+  _id: string;
+  content: string;
+  documentId: string;
+  documentTitle: string;
+  sectionTitle?: string;
+  pageNumber?: number;
+};
+
+export type ChunkUsage = {
+  types: Set<string>;
+  totalCount: number;
+};
+
+export type PostSourceRecord = {
+  chunkId: string;
+  postId: string;
+  createdAt: number;
+};
+
+export function computeRecencyBoost(docCreatedAt: number, now: number): number {
+  const age = now - docCreatedAt;
+  if (age < FORTY_EIGHT_HOURS_MS) return 2.0;
+  if (age < SEVEN_DAYS_MS) {
+    return 1.0 + (1.0 * (SEVEN_DAYS_MS - age)) / (SEVEN_DAYS_MS - FORTY_EIGHT_HOURS_MS);
+  }
+  return 1.0;
+}
+
+export function buildChunkUsageMap(
+  postSources: PostSourceRecord[],
+  posts: { _id: string; postType: string }[],
+): Map<string, ChunkUsage> {
+  const postTypeMap = new Map(posts.map((p) => [p._id, p.postType]));
+  const chunkUsageMap = new Map<string, ChunkUsage>();
+
+  for (const src of postSources) {
+    const type = postTypeMap.get(src.postId);
+    if (!type) continue;
+    const existing = chunkUsageMap.get(src.chunkId) ?? { types: new Set<string>(), totalCount: 0 };
+    existing.types.add(type);
+    existing.totalCount++;
+    chunkUsageMap.set(src.chunkId, existing);
+  }
+
+  return chunkUsageMap;
+}
+
+export function weightedSample(
+  chunks: ChunkInfo[],
+  chunkUsageMap: Map<string, ChunkUsage>,
+  docCreatedAtMap: Map<string, number>,
+  count: number,
+  now: number,
+): ChunkInfo[] {
+  const base = 1.0;
+  const weights = chunks.map((chunk) => {
+    const usage = chunkUsageMap.get(chunk._id);
+    const typesUsed = usage?.types.size ?? 0;
+    const totalUsage = usage?.totalCount ?? 0;
+    const docCreatedAt = docCreatedAtMap.get(chunk.documentId) ?? 0;
+    const recencyBoost = computeRecencyBoost(docCreatedAt, now);
+    return (
+      base * recencyBoost * (1 / (1 + totalUsage)) * (1 + (ALL_POST_TYPES.length - typesUsed) * 0.3)
+    );
+  });
+
+  const selected: ChunkInfo[] = [];
+  const usedIndices = new Set<number>();
+  const docCounts = new Map<string, number>();
+
+  for (let pick = 0; pick < Math.min(count, chunks.length); pick++) {
+    const totalWeight = weights.reduce((sum, w, i) => (usedIndices.has(i) ? sum : sum + w), 0);
+    if (totalWeight <= 0) break;
+
+    let rand = Math.random() * totalWeight;
+    let chosenIdx = -1;
+    for (let i = 0; i < weights.length; i++) {
+      if (usedIndices.has(i)) continue;
+      rand -= weights[i]!;
+      if (rand <= 0) {
+        chosenIdx = i;
+        break;
+      }
+    }
+    if (chosenIdx === -1) {
+      for (let i = weights.length - 1; i >= 0; i--) {
+        if (!usedIndices.has(i)) {
+          chosenIdx = i;
+          break;
+        }
+      }
+    }
+    if (chosenIdx === -1) break;
+
+    selected.push(chunks[chosenIdx]!);
+    usedIndices.add(chosenIdx);
+    docCounts.set(
+      chunks[chosenIdx]!.documentId,
+      (docCounts.get(chunks[chosenIdx]!.documentId) ?? 0) + 1,
+    );
+  }
+
+  if (selected.length >= 2 && docCounts.size < 2) {
+    const chunkIndexMap = new Map(chunks.map((c, i) => [c._id, i]));
+    const otherDocChunks = chunks.filter(
+      (c) =>
+        !usedIndices.has(chunkIndexMap.get(c._id)!) && c.documentId !== selected[0]!.documentId,
+    );
+    if (otherDocChunks.length > 0) {
+      selected[selected.length - 1] =
+        otherDocChunks[Math.floor(Math.random() * otherDocChunks.length)]!;
+    }
+  }
+
+  return selected;
+}
+
+export function buildTypeCoverageHint(chunkUsageMap: Map<string, ChunkUsage>): string {
+  const coverage = new Map<string, number>();
+  for (const usage of chunkUsageMap.values()) {
+    for (const t of usage.types) {
+      coverage.set(t, (coverage.get(t) ?? 0) + 1);
+    }
+  }
+
+  const underused = ALL_POST_TYPES.filter((t) => (coverage.get(t) ?? 0) < 2);
+  if (underused.length === 0) return "";
+  return `\n\nType coverage hint: The following types have been used least recently and should be preferred: ${underused.join(", ")}.`;
+}
+
+export function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j]!, a[i]!];
+  }
+  return a;
+}

--- a/packages/backend/convex/feed/validation.ts
+++ b/packages/backend/convex/feed/validation.ts
@@ -1,0 +1,65 @@
+import type { ChunkInfo } from "./sampling";
+
+export type RawCard = {
+  type: "insight" | "quiz" | "quote" | "summary" | "connection";
+  content: string;
+  sourceChunkIndices: number[];
+  question?: string;
+  options?: string[];
+  correctIndex?: number;
+  explanation?: string;
+  variant?: "multiple_choice" | "true_false";
+  quotedText?: string;
+  attribution?: string;
+  bulletPoints?: string[];
+  sourceATitleHint?: string;
+  sourceBTitleHint?: string;
+};
+
+export function validateCard(card: RawCard, chunks: ChunkInfo[]): boolean {
+  if (!card.type || !card.content || !Array.isArray(card.sourceChunkIndices)) {
+    return false;
+  }
+
+  if (card.sourceChunkIndices.some((i) => i < 0 || i >= chunks.length)) {
+    return false;
+  }
+
+  if (card.sourceChunkIndices.length === 0) {
+    return false;
+  }
+
+  switch (card.type) {
+    case "quiz": {
+      if (!card.question || !Array.isArray(card.options) || card.options.length < 2) return false;
+      if (
+        card.correctIndex === undefined ||
+        card.correctIndex < 0 ||
+        card.correctIndex >= card.options.length
+      )
+        return false;
+      if (!card.explanation) return false;
+      const questionLower = card.question.toLowerCase();
+      if (card.options.some((opt) => questionLower.includes(opt.toLowerCase()) && opt.length > 3))
+        return false;
+      return true;
+    }
+    case "quote":
+      return !!card.quotedText;
+    case "summary": {
+      if (!Array.isArray(card.bulletPoints) || card.bulletPoints.length < 2) return false;
+      if (card.sourceChunkIndices.length < 2) return false;
+      return true;
+    }
+    case "connection": {
+      if (!card.sourceATitleHint || !card.sourceBTitleHint) return false;
+      const docIds = new Set(card.sourceChunkIndices.map((i) => chunks[i]!.documentId));
+      if (docIds.size < 2) return false;
+      return true;
+    }
+    case "insight":
+      return true;
+    default:
+      return false;
+  }
+}

--- a/packages/backend/convex/lib/validators.ts
+++ b/packages/backend/convex/lib/validators.ts
@@ -1,3 +1,4 @@
+import type { Infer } from "convex/values";
 import { v } from "convex/values";
 
 export const fileType = v.union(
@@ -28,3 +29,48 @@ export const failedAtStage = v.union(
 export const reactionType = v.union(v.literal("like"), v.literal("dislike"));
 
 export const reactionInput = v.union(v.literal("like"), v.literal("dislike"), v.literal("none"));
+
+export const postType = v.union(
+  v.literal("insight"),
+  v.literal("quiz"),
+  v.literal("quote"),
+  v.literal("summary"),
+  v.literal("connection"),
+);
+
+export const quizVariant = v.union(v.literal("multiple_choice"), v.literal("true_false"));
+
+export const typeData = v.union(
+  v.object({
+    type: v.literal("insight"),
+  }),
+  v.object({
+    type: v.literal("quiz"),
+    variant: quizVariant,
+    question: v.string(),
+    options: v.array(v.string()),
+    correctIndex: v.number(),
+    explanation: v.string(),
+  }),
+  v.object({
+    type: v.literal("quote"),
+    quotedText: v.string(),
+    attribution: v.optional(v.string()),
+  }),
+  v.object({
+    type: v.literal("summary"),
+    bulletPoints: v.array(v.string()),
+  }),
+  v.object({
+    type: v.literal("connection"),
+    sourceATitleHint: v.string(),
+    sourceBTitleHint: v.string(),
+  }),
+);
+
+export type PostType = Infer<typeof postType>;
+export type QuizVariant = Infer<typeof quizVariant>;
+export type TypeData = Infer<typeof typeData>;
+
+// Must be kept in sync with the postType union above.
+export const ALL_POST_TYPES: PostType[] = ["insight", "quiz", "quote", "summary", "connection"];

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -1,7 +1,14 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
-import { documentStatus, failedAtStage, fileType, reactionType } from "./lib/validators";
+import {
+  documentStatus,
+  failedAtStage,
+  fileType,
+  postType,
+  reactionType,
+  typeData,
+} from "./lib/validators";
 
 export default defineSchema({
   documents: defineTable({
@@ -18,17 +25,41 @@ export default defineSchema({
     createdAt: v.number(),
   })
     .index("by_userId", ["userId"])
-    .index("by_status", ["status"]),
+    .index("by_status", ["status"])
+    .index("by_userId_status", ["userId", "status"]),
 
   posts: defineTable({
     content: v.string(),
-    sourceChunkId: v.id("chunks"),
-    sourceDocumentId: v.id("documents"),
+    postType,
+    typeData,
+    primarySourceDocumentId: v.id("documents"),
+    primarySourceDocumentTitle: v.string(),
+    primarySourceChunkId: v.id("chunks"),
+    primarySourceSectionTitle: v.optional(v.string()),
+    primarySourcePageNumber: v.optional(v.number()),
+    sourceChunkHash: v.string(),
     userId: v.string(),
     assetStorageId: v.optional(v.id("_storage")),
     reaction: v.optional(reactionType),
     createdAt: v.number(),
-  }).index("by_userId", ["userId"]),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_userId_type", ["userId", "postType"])
+    .index("by_userId_createdAt", ["userId", "createdAt"])
+    .index("by_userId_sourceChunkHash", ["userId", "sourceChunkHash"]),
+
+  postSources: defineTable({
+    postId: v.id("posts"),
+    chunkId: v.id("chunks"),
+    documentId: v.id("documents"),
+    userId: v.string(),
+    createdAt: v.number(),
+  })
+    .index("by_postId", ["postId"])
+    .index("by_chunkId", ["chunkId"])
+    .index("by_documentId", ["documentId"])
+    .index("by_userId", ["userId"])
+    .index("by_userId_createdAt", ["userId", "createdAt"]),
 
   bookmarkLists: defineTable({
     userId: v.string(),

--- a/packages/backend/convex/testing.ts
+++ b/packages/backend/convex/testing.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 
 import { internalMutation, internalQuery, mutation } from "./_generated/server";
 import { requireAuth } from "./lib/functions";
+import type { PostType, TypeData } from "./lib/validators";
 
 const E2E_EMAIL_PATTERN = /^e2e-.*@test\.scrollect\.dev$/;
 
@@ -64,12 +65,19 @@ export const cleanupCurrentUser = mutation({
       await ctx.db.delete(doc._id);
     }
 
-    // 3. Delete all posts for this user
+    // 3. Delete all posts and postSources for this user
     const posts = await ctx.db
       .query("posts")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .collect();
     for (const post of posts) {
+      const sources = await ctx.db
+        .query("postSources")
+        .withIndex("by_postId", (q) => q.eq("postId", post._id))
+        .collect();
+      for (const source of sources) {
+        await ctx.db.delete(source._id);
+      }
       if (post.assetStorageId) {
         await ctx.storage.delete(post.assetStorageId);
       }
@@ -107,7 +115,7 @@ export const insertSeededData = internalMutation({
     const { userId, storageId } = args;
     const now = Date.now();
 
-    // Create document
+    // Create first document
     const documentId = await ctx.db.insert("documents", {
       title: "E2E Seed Document",
       fileType: "md",
@@ -118,7 +126,7 @@ export const insertSeededData = internalMutation({
       createdAt: now,
     });
 
-    // Create 3 chunks
+    // Create 3 chunks for first document
     const chunkContents = [
       "Lorem ipsum is a placeholder text commonly used in the printing and typesetting industry. It has been the industry standard dummy text since the 1500s.",
       "Good UX design focuses on reducing cognitive load by breaking complex information into digestible chunks. Users process information better in smaller pieces.",
@@ -138,24 +146,173 @@ export const insertSeededData = internalMutation({
       chunkIds.push(chunkId);
     }
 
-    // Create 5 posts
-    const postContents = [
-      "**Key Insight:** Lorem ipsum is a placeholder text commonly used in design.",
-      "**Design Principle:** Good UX reduces cognitive load with digestible chunks.",
-      "**Software Pattern:** The observer pattern establishes one-to-many dependencies.",
-      "**Learning Tip:** Spaced repetition improves long-term memory retention.",
-      "**Architecture:** Event-driven systems decouple producers from consumers.",
+    // Create second document (for connection card) — no storageId (simulates URL-based doc)
+    const documentId2 = await ctx.db.insert("documents", {
+      title: "E2E Seed Document 2",
+      fileType: "article",
+      sourceUrl: "https://example.com/e2e-seed-2",
+      status: "ready",
+      chunkCount: 2,
+      userId,
+      createdAt: now - 1000,
+    });
+
+    const chunkIds2 = [];
+    const chunkContents2 = [
+      "Event-driven architecture decouples components by using events as the primary communication mechanism between services.",
+      "Microservices communicate through message queues, enabling independent deployment and scaling of each service.",
+    ];
+    for (let i = 0; i < chunkContents2.length; i++) {
+      const chunkId = await ctx.db.insert("chunks", {
+        documentId: documentId2,
+        content: chunkContents2[i]!,
+        chunkIndex: i,
+        tokenCount: 50,
+        embedded: true,
+        createdAt: now - 1000,
+      });
+      chunkIds2.push(chunkId);
+    }
+
+    // Create 7 posts covering all card types
+    const postDefs: Array<{
+      content: string;
+      postType: PostType;
+      typeData: TypeData;
+      docId: typeof documentId;
+      docTitle: string;
+      chunkId: (typeof chunkIds)[0];
+      extraSources?: Array<{ chunkId: (typeof chunkIds)[0]; documentId: typeof documentId }>;
+    }> = [
+      {
+        content: "**Key Insight:** Lorem ipsum is a placeholder text commonly used in design.",
+        postType: "insight",
+        typeData: { type: "insight" },
+        docId: documentId,
+        docTitle: "E2E Seed Document",
+        chunkId: chunkIds[0]!,
+      },
+      {
+        content: "**Design Principle:** Good UX reduces cognitive load with digestible chunks.",
+        postType: "quiz",
+        typeData: {
+          type: "quiz",
+          variant: "multiple_choice",
+          question: "What does good UX design focus on?",
+          options: [
+            "Reducing cognitive load",
+            "Adding more features",
+            "Using bright colors",
+            "Complex navigation",
+          ],
+          correctIndex: 0,
+          explanation:
+            "Good UX design focuses on reducing cognitive load by breaking complex information into digestible chunks.",
+        },
+        docId: documentId,
+        docTitle: "E2E Seed Document",
+        chunkId: chunkIds[1]!,
+      },
+      {
+        content: "The observer pattern notifies dependents when state changes.",
+        postType: "quiz",
+        typeData: {
+          type: "quiz",
+          variant: "true_false",
+          question:
+            "True or false: The observer pattern establishes a many-to-many dependency between objects.",
+          options: ["True", "False"],
+          correctIndex: 1,
+          explanation:
+            "The observer pattern establishes a one-to-many dependency, not many-to-many.",
+        },
+        docId: documentId,
+        docTitle: "E2E Seed Document",
+        chunkId: chunkIds[2]!,
+      },
+      {
+        content: "**Software Pattern:** The observer pattern establishes one-to-many dependencies.",
+        postType: "quote",
+        typeData: {
+          type: "quote",
+          quotedText: "The observer pattern establishes a one-to-many dependency between objects.",
+        },
+        docId: documentId,
+        docTitle: "E2E Seed Document",
+        chunkId: chunkIds[2]!,
+      },
+      {
+        content: "**Learning Tip:** Spaced repetition improves long-term memory retention.",
+        postType: "summary",
+        typeData: {
+          type: "summary",
+          bulletPoints: [
+            "Spaced repetition improves retention",
+            "Active recall strengthens memory",
+          ],
+        },
+        docId: documentId,
+        docTitle: "E2E Seed Document",
+        chunkId: chunkIds[0]!,
+        extraSources: [{ chunkId: chunkIds[1]!, documentId }],
+      },
+      {
+        content:
+          "Both documents discuss patterns of decoupling: the observer pattern separates subject from observers, while event-driven architecture separates producers from consumers.",
+        postType: "connection",
+        typeData: {
+          type: "connection",
+          sourceATitleHint: "E2E Seed Document",
+          sourceBTitleHint: "E2E Seed Document 2",
+        },
+        docId: documentId,
+        docTitle: "E2E Seed Document",
+        chunkId: chunkIds[2]!,
+        extraSources: [{ chunkId: chunkIds2[0]!, documentId: documentId2 }],
+      },
+      {
+        content: "**Architecture:** Event-driven systems decouple producers from consumers.",
+        postType: "insight",
+        typeData: { type: "insight" },
+        docId: documentId2,
+        docTitle: "E2E Seed Document 2",
+        chunkId: chunkIds2[0]!,
+      },
     ];
 
     let postCount = 0;
-    for (const content of postContents) {
-      await ctx.db.insert("posts", {
-        content,
-        sourceChunkId: chunkIds[postCount % chunkIds.length]!,
-        sourceDocumentId: documentId,
+    for (const def of postDefs) {
+      const createdAt = now - (postDefs.length - postCount) * 1000;
+      const chunkHash = `seed-hash-${postCount}`;
+      const postId = await ctx.db.insert("posts", {
+        content: def.content,
+        postType: def.postType,
+        typeData: def.typeData,
+        primarySourceDocumentId: def.docId,
+        primarySourceDocumentTitle: def.docTitle,
+        primarySourceChunkId: def.chunkId,
+        sourceChunkHash: chunkHash,
         userId,
-        createdAt: now - (postContents.length - postCount) * 1000,
+        createdAt,
       });
+      await ctx.db.insert("postSources", {
+        postId,
+        chunkId: def.chunkId,
+        documentId: def.docId,
+        userId,
+        createdAt,
+      });
+      if (def.extraSources) {
+        for (const extra of def.extraSources) {
+          await ctx.db.insert("postSources", {
+            postId,
+            chunkId: extra.chunkId,
+            documentId: extra.documentId,
+            userId,
+            createdAt,
+          });
+        }
+      }
       postCount++;
     }
 


### PR DESCRIPTION
## Summary

- **Schema (#61):** Discriminated union `typeData` for 5 card types (insight, quiz, quote, summary, connection), `postSources` junction table for multi-chunk provenance, canonical `insertPost` mutation with `sourceChunkHash` dedup
- **Generation (#62):** Multi-type prompt producing mixed card types per LLM call, type-aware usage-weighted chunk sampling with recency boost, post-generation validation, `MULTI_TYPE_GENERATION` feature flag, exponential backoff retry, saturation detection
- **Frontend (#63):** 6 card components with type-specific layouts (quiz tap-to-reveal, quiz multiple-choice, quote with blockquote styling, summary with bullet points, connection with dual-source badge), PostCard router with exhaustive type check, multi-source expand sheet

### Additional improvements
- Extracted `sampling.ts` and `validation.ts` shared modules from generation pipeline
- Added `by_userId_status` compound index for efficient document queries
- Fixed `generateLegacy` type safety (removed `any` casts)
- Seeded-account E2E tests run serial to prevent shared-state conflicts
- Separated Tier 1/Tier 2 test scripts (`test:e2e` excludes slow external-API tests)

## Test plan

- [x] `bun run check` — 0 warnings, 0 errors
- [x] `bun turbo run build` — all packages build
- [x] `npx convex dev --once --typecheck enable` — clean deploy
- [x] E2E: 46 passed, 0 failed, 1 skipped (pre-existing placeholder)
- [x] 11 new multi-type card tests covering all 5 card types, quiz interactions, source provenance
- [x] Code reviewed: backend (12 findings fixed), frontend (5 findings fixed), tests (3 findings fixed)

Closes #61, closes #62, closes #63