### PR TITLE
fix: stabilize flaky tagging test and stream e2e logs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,8 @@ jobs:
         run: cd apps/e2e && npx playwright install chromium --with-deps
 
       - name: Run E2E tests (fast)
-        run: bun run test:e2e
+        working-directory: apps/e2e
+        run: npx playwright test --project=setup --project=seeded --project=chromium
         env:
           NEXT_PUBLIC_CONVEX_URL: ${{ steps.convex-preview.outputs.preview_url }}
           NEXT_PUBLIC_CONVEX_SITE_URL: ${{ steps.convex-preview.outputs.preview_site_url }}

--- a/apps/e2e/tests/tagging.spec.ts
+++ b/apps/e2e/tests/tagging.spec.ts
@@ -35,12 +35,11 @@ test.describe("Tagging — document detail: AI tags (seeded account)", () => {
   test("document detail page shows AI-suggested tags with sparkle indicator", async ({ page }) => {
     await navigateToFirstDocument(page);
 
-    await expect(page.locator('[data-testid="document-tag-section"]')).toBeVisible({
-      timeout: 15000,
-    });
-
-    const aiTag = page.locator('[data-tag-source="ai"]').first();
-    await expect(aiTag).toBeVisible({ timeout: 15000 });
+    // First test after global setup may hit a cold Convex connection — use generous timeout
+    const aiTag = page
+      .locator('[data-testid="document-tag-section"] [data-tag-source="ai"]')
+      .first();
+    await expect(aiTag).toBeVisible({ timeout: 30000 });
   });
 
   // AI vs manual visual distinction


### PR DESCRIPTION
## Summary
- Stabilize flaky `document detail page shows AI-suggested tags with sparkle indicator` test by increasing timeout to 30s (cold Convex connection after global setup) and combining two assertions into a single scoped locator
- Run Playwright directly from `apps/e2e` instead of via turbo so e2e logs stream in GitHub Actions

## Test plan
- [x] Verify CI runs e2e tests with streamed output
- [x] Flaky test passes consistently with increased timeout