### PR TITLE
feat(#71): add document deletion with cascading cleanup

### DIFF
--- a/apps/e2e/tests/document-deletion.spec.ts
+++ b/apps/e2e/tests/document-deletion.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+import { FIXTURES_DIR, cleanupTestData, signUp } from "./helpers";
+
+test.describe("Document deletion", () => {
+  test.setTimeout(120000);
+
+  let ephemeralEmail: string;
+
+  test.beforeEach(async ({ page }) => {
+    const { email } = await signUp(page);
+    ephemeralEmail = email;
+  });
+
+  test.afterEach(async () => {
+    await cleanupTestData(ephemeralEmail);
+  });
+
+  test("user can delete a document and it no longer appears in library", async ({ page }) => {
+    await page.goto("/upload");
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+
+    await page.locator('input[type="file"]').setInputFiles(path.join(FIXTURES_DIR, "test.md"));
+    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 30000 });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+    const docLink = page.locator("a[href^='/library/']").first();
+    await expect(docLink).toBeVisible({ timeout: 10000 });
+
+    const docTitle = await docLink.textContent();
+    await docLink.click();
+
+    await expect(page).toHaveURL(/\/library\/.+/);
+    await expect(page.getByText(/back to library/i)).toBeVisible({
+      timeout: 10000,
+    });
+
+    await page.getByRole("button", { name: /delete document/i }).click();
+
+    await expect(page.getByRole("heading", { name: /delete document/i })).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: /^delete$/i })
+      .click();
+
+    await expect(page).toHaveURL(/\/library\/?$/, { timeout: 30000 });
+    await page.waitForLoadState("networkidle");
+
+    const remainingLinks = page.locator("a[href^='/library/']");
+    const linkCount = await remainingLinks.count();
+
+    if (linkCount > 0 && docTitle) {
+      for (let i = 0; i < linkCount; i++) {
+        const text = await remainingLinks.nth(i).textContent();
+        expect(text).not.toBe(docTitle);
+      }
+    }
+  });
+});

--- a/apps/web/src/routes/_authenticated/library/$documentId.tsx
+++ b/apps/web/src/routes/_authenticated/library/$documentId.tsx
@@ -2,13 +2,27 @@ import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@scrollect/backend/convex/_generated/api";
 import type { Id } from "@scrollect/backend/convex/_generated/dataModel";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Link, createFileRoute, notFound } from "@tanstack/react-router";
+import { Link, createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
+import { useAction } from "convex/react";
 import { formatDistanceToNow } from "date-fns";
-import { ArrowLeft, FileText, Loader2 } from "lucide-react";
+import { ArrowLeft, FileText, Loader2, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 
 import { StatusBadge, fileTypeIcons } from "@/components/document-status";
 import { NotFound } from "@/components/not-found";
 import { DocumentTagSection } from "@/components/tags/document-tag-section";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 
 export const Route = createFileRoute("/_authenticated/library/$documentId")({
   loader: async ({ params: { documentId }, context }) => {
@@ -36,8 +50,25 @@ function DocumentDetailPage() {
   const { data: document } = useSuspenseQuery(
     convexQuery(api.documents.get, { id: documentId as Id<"documents"> }),
   );
+  const navigate = useNavigate();
+  const deleteDocument = useAction(api.documentActions.deleteDocument);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   if (!document) throw notFound();
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteDocument({ documentId: document._id });
+      setDeleteDialogOpen(false);
+      toast.success("Document deleted");
+      await navigate({ to: "/library" });
+    } catch {
+      toast.error("Failed to delete document");
+      setIsDeleting(false);
+    }
+  };
 
   return (
     <div className="container mx-auto max-w-3xl px-4 py-8 md:px-6">
@@ -67,6 +98,52 @@ function DocumentDetailPage() {
               {document.chunkCount} chunk{document.chunkCount !== 1 ? "s" : ""}
             </span>
           )}
+          <Dialog
+            open={deleteDialogOpen}
+            onOpenChange={(open) => {
+              if (!isDeleting) setDeleteDialogOpen(open);
+            }}
+          >
+            <DialogTrigger
+              render={
+                <Button variant="destructive" size="sm" data-testid="delete-document-button" />
+              }
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete document
+            </DialogTrigger>
+            <DialogContent showCloseButton={!isDeleting}>
+              <DialogHeader>
+                <DialogTitle>Delete document</DialogTitle>
+                <DialogDescription>
+                  Delete &ldquo;{document.title}&rdquo;? This will remove the document and all
+                  generated cards. This cannot be undone.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <DialogClose
+                  render={
+                    <Button
+                      variant="outline"
+                      disabled={isDeleting}
+                      data-testid="cancel-delete-button"
+                    />
+                  }
+                >
+                  Cancel
+                </DialogClose>
+                <Button
+                  variant="destructive"
+                  disabled={isDeleting}
+                  onClick={handleDelete}
+                  data-testid="confirm-delete-button"
+                >
+                  {isDeleting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                  Delete
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         </div>
       </div>
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "scrollect",
       "dependencies": {
+        "@convex-dev/react-query": "^0.1.0",
         "@scrollect/env": "workspace:*",
         "convex": "^1.33.1",
         "dotenv": "catalog:",
@@ -106,7 +107,7 @@
         "@convex-dev/better-auth": "^0.10.13",
         "ai": "^6.0.116",
         "better-auth": "catalog:",
-        "convex": "^1.33.1",
+        "convex": "catalog:",
         "dotenv": "catalog:",
         "unpdf": "^1.4.0",
         "zod": "catalog:",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:e2e": "turbo -F @scrollect/e2e test:e2e"
   },
   "dependencies": {
+    "@convex-dev/react-query": "^0.1.0",
     "@scrollect/env": "workspace:*",
     "convex": "^1.33.1",
     "dotenv": "catalog:",

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as auth from "../auth.js";
 import type * as bookmarks from "../bookmarks.js";
 import type * as chunking from "../chunking.js";
 import type * as chunks from "../chunks.js";
+import type * as documentActions from "../documentActions.js";
 import type * as documents from "../documents.js";
 import type * as feed_generation from "../feed/generation.js";
 import type * as feed_queries from "../feed/queries.js";
@@ -64,6 +65,7 @@ declare const fullApi: ApiFromModules<{
   bookmarks: typeof bookmarks;
   chunking: typeof chunking;
   chunks: typeof chunks;
+  documentActions: typeof documentActions;
   documents: typeof documents;
   "feed/generation": typeof feed_generation;
   "feed/queries": typeof feed_queries;

--- a/packages/backend/convex/documentActions.ts
+++ b/packages/backend/convex/documentActions.ts
@@ -1,0 +1,65 @@
+"use node";
+
+import { v } from "convex/values";
+
+import { internal } from "./_generated/api";
+import { action } from "./_generated/server";
+import { requireAuth } from "./lib/functions";
+import { WideEvent } from "./lib/logging";
+import { createSummaryVectorStore, createVectorStore } from "./pipeline/helpers";
+
+export const deleteDocument = action({
+  args: { documentId: v.id("documents") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const evt = new WideEvent("documentActions.deleteDocument");
+    evt.set({ documentId: args.documentId });
+
+    try {
+      const user = await requireAuth(ctx);
+      evt.set("userId", user._id);
+
+      const data = await ctx.runQuery(internal.documents.getDocumentDeletionData, {
+        documentId: args.documentId,
+      });
+
+      if (!data) {
+        throw new Error("Document not found");
+      }
+
+      if (data.document.userId !== user._id) {
+        throw new Error("Document not found");
+      }
+
+      const summaryVectorIds = [
+        ...data.sectionSummaryEmbeddingIds,
+        ...(data.document.summaryEmbeddingId ? [data.document.summaryEmbeddingId] : []),
+      ];
+
+      evt.set({
+        chunkVectorCount: data.chunkEmbeddingIds.length,
+        summaryVectorCount: summaryVectorIds.length,
+      });
+
+      const vectorStore = createVectorStore();
+      const summaryVectorStore = createSummaryVectorStore();
+
+      await Promise.all([
+        vectorStore.delete(data.chunkEmbeddingIds),
+        summaryVectorStore.delete(summaryVectorIds),
+      ]);
+
+      await ctx.runMutation(internal.documents.cascadeDelete, {
+        documentId: args.documentId,
+        userId: user._id,
+      });
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
+    }
+
+    return null;
+  },
+});

--- a/packages/backend/convex/documents.ts
+++ b/packages/backend/convex/documents.ts
@@ -214,6 +214,177 @@ export const getInternal = internalQuery({
   },
 });
 
+export const getDocumentDeletionData = internalQuery({
+  args: { documentId: v.id("documents") },
+  returns: v.union(
+    v.object({
+      document: v.object({
+        _id: v.id("documents"),
+        userId: v.string(),
+        storageId: v.optional(v.id("_storage")),
+        summaryEmbeddingId: v.optional(v.string()),
+      }),
+      chunkEmbeddingIds: v.array(v.string()),
+      sectionSummaryEmbeddingIds: v.array(v.string()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const document = await ctx.db.get(args.documentId);
+    if (!document) return null;
+
+    const chunks = await ctx.db
+      .query("chunks")
+      .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+      .collect();
+
+    const chunkEmbeddingIds = chunks
+      .map((c) => c.embeddingId)
+      .filter((id): id is string => id !== undefined);
+
+    const sectionSummaries = await ctx.db
+      .query("sectionSummaries")
+      .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+      .collect();
+
+    const sectionSummaryEmbeddingIds = sectionSummaries.map((s) => s.embeddingId);
+
+    return {
+      document: {
+        _id: document._id,
+        userId: document.userId,
+        storageId: document.storageId,
+        summaryEmbeddingId: document.summaryEmbeddingId,
+      },
+      chunkEmbeddingIds,
+      sectionSummaryEmbeddingIds,
+    };
+  },
+});
+
+export const cascadeDelete = internalMutation({
+  args: {
+    documentId: v.id("documents"),
+    userId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const evt = new WideEvent("documents.cascadeDelete");
+    evt.set({ documentId: args.documentId });
+
+    try {
+      const postSources = await ctx.db
+        .query("postSources")
+        .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+        .collect();
+
+      const postIds = [...new Set(postSources.map((ps) => ps.postId))];
+
+      for (const ps of postSources) {
+        await ctx.db.delete(ps._id);
+      }
+
+      let deletedPosts = 0;
+      let deletedBookmarks = 0;
+      let deletedPostSources = postSources.length;
+
+      for (const postId of postIds) {
+        const post = await ctx.db.get(postId);
+        if (!post) continue;
+
+        if (post.primarySourceDocumentId === args.documentId) {
+          const remainingPostSources = await ctx.db
+            .query("postSources")
+            .withIndex("by_postId", (q) => q.eq("postId", postId))
+            .collect();
+
+          for (const rps of remainingPostSources) {
+            await ctx.db.delete(rps._id);
+            deletedPostSources++;
+          }
+
+          const bookmarks = await ctx.db
+            .query("bookmarks")
+            .withIndex("by_userId_post", (q) => q.eq("userId", args.userId).eq("postId", postId))
+            .collect();
+
+          for (const bookmark of bookmarks) {
+            await ctx.db.delete(bookmark._id);
+            deletedBookmarks++;
+          }
+
+          if (post.assetStorageId) {
+            try {
+              await ctx.storage.delete(post.assetStorageId);
+            } catch {
+              // Storage file may already be deleted
+            }
+          }
+
+          await ctx.db.delete(postId);
+          deletedPosts++;
+        }
+      }
+
+      const chunks = await ctx.db
+        .query("chunks")
+        .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+        .collect();
+
+      for (const chunk of chunks) {
+        await ctx.db.delete(chunk._id);
+      }
+
+      const sectionSummaries = await ctx.db
+        .query("sectionSummaries")
+        .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+        .collect();
+
+      for (const ss of sectionSummaries) {
+        await ctx.db.delete(ss._id);
+      }
+
+      const processingJobs = await ctx.db
+        .query("processingJobs")
+        .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+        .collect();
+
+      for (const job of processingJobs) {
+        await ctx.db.delete(job._id);
+      }
+
+      const document = await ctx.db.get(args.documentId);
+      if (document?.storageId) {
+        try {
+          await ctx.storage.delete(document.storageId);
+        } catch {
+          // Storage file may already be deleted
+        }
+      }
+
+      await ctx.db.delete(args.documentId);
+
+      evt.set({
+        deleted: {
+          posts: deletedPosts,
+          postSources: deletedPostSources,
+          bookmarks: deletedBookmarks,
+          chunks: chunks.length,
+          sectionSummaries: sectionSummaries.length,
+          processingJobs: processingJobs.length,
+        },
+      });
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
+    }
+
+    return null;
+  },
+});
+
 export const retry = mutation({
   args: { id: v.id("documents") },
   handler: async (ctx, args) => {


### PR DESCRIPTION
## Summary
- **Backend**: Convex action (`deleteDocument`) orchestrates Qdrant vector cleanup then calls an internal mutation (`cascadeDelete`) for cascading DB record deletion — posts, post sources, bookmarks, chunks, section summaries, processing jobs, storage files, and the document itself
- **Frontend**: "Delete document" button with confirmation dialog on the document detail page, with loading state, error handling, and redirect to library after deletion
- **E2E test**: Upload a document, navigate to detail page, delete it, verify it no longer appears in the library
- **Fix**: Updated `convex` to 1.33.1 to resolve a duplicate package TypeScript error in the build

Closes #71

## Test plan
- [x] E2E test: `document-deletion.spec.ts` — upload → delete → verify removal (passes locally)
- [x] Existing upload/library E2E tests still pass
- [x] Lint (`oxlint` + `oxfmt`) passes
- [x] Build (`bun turbo run build`) passes