### PR TITLE
feat(#74): add freshness mechanics for recently uploaded documents

### DIFF
--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       dependencies: ["setup"],
       testMatch: [
         /feed-interactions\.spec\.ts/,
+        /freshness\.spec\.ts/,
         /multi-type-cards\.spec\.ts/,
         /source-provenance\.spec\.ts/,
         /tagging\.spec\.ts/,
@@ -44,6 +45,7 @@ export default defineConfig({
         /global-setup\.ts/,
         /\.slow\.spec\.ts/,
         /feed-interactions\.spec\.ts/,
+        /freshness\.spec\.ts/,
         /multi-type-cards\.spec\.ts/,
         /source-provenance\.spec\.ts/,
         /tagging\.spec\.ts/,

--- a/apps/e2e/tests/freshness.spec.ts
+++ b/apps/e2e/tests/freshness.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+import { SEEDED_USER, resetTestData, signInToSeededFeed } from "./helpers";
+
+const CARD = '[data-testid="post-card"]';
+const NEW_BADGE = '[data-testid="new-badge"]';
+
+test.describe("Freshness badge on feed cards", () => {
+  test.setTimeout(60000);
+
+  test.beforeEach(async ({ page }) => {
+    await signInToSeededFeed(page);
+  });
+
+  test.afterEach(async () => {
+    await resetTestData(SEEDED_USER.email);
+  });
+
+  test("cards from recently uploaded documents display a New badge", async ({ page }) => {
+    const cards = page.locator(CARD);
+    await expect(cards.first()).toBeVisible({ timeout: 15000 });
+
+    const badgeCount = await page.locator(NEW_BADGE).count();
+    expect(badgeCount).toBeGreaterThan(0);
+  });
+
+  test("New badge contains the text New and is visible", async ({ page }) => {
+    const badge = page.locator(NEW_BADGE).first();
+    await expect(badge).toBeVisible({ timeout: 15000 });
+    await expect(badge).toContainText("New");
+  });
+
+  test("New badge is rendered inside a post card", async ({ page }) => {
+    const firstBadge = page.locator(NEW_BADGE).first();
+    await expect(firstBadge).toBeVisible({ timeout: 15000 });
+
+    const parentCard = firstBadge.locator(`xpath=ancestor::article[@data-testid="post-card"]`);
+    await expect(parentCard).toBeVisible();
+  });
+
+  test("all seeded cards have New badges since documents were just created", async ({ page }) => {
+    const cards = page.locator(CARD);
+    await expect(cards.first()).toBeVisible({ timeout: 15000 });
+
+    const totalCards = await cards.count();
+    const totalBadges = await page.locator(NEW_BADGE).count();
+
+    // All seeded documents were created moments ago (within 48h), so every card
+    // from those documents should carry a "New" badge.
+    expect(totalBadges).toBe(totalCards);
+  });
+});

--- a/apps/web/src/components/cards/card-shell.tsx
+++ b/apps/web/src/components/cards/card-shell.tsx
@@ -112,6 +112,17 @@ export function CardShell({ post, children, accentClassName, quizVariant }: Card
         />
 
         <div className="px-5 pt-5 pb-4">
+          {post.isNew && (
+            <Badge
+              data-testid="new-badge"
+              aria-label="New: from a recently added document"
+              className="mb-2 gap-1"
+              variant="freshness"
+            >
+              <span aria-hidden="true" className="size-1 shrink-0 rounded-full bg-emerald-500" />
+              New
+            </Badge>
+          )}
           {children}
 
           {tags.length > 0 && (

--- a/apps/web/src/components/cards/types.ts
+++ b/apps/web/src/components/cards/types.ts
@@ -56,6 +56,7 @@ export interface PostCardData {
   createdAt: number;
   reaction?: "like" | "dislike" | null;
   isBookmarked?: boolean;
+  isNew?: boolean;
   chunkIndex?: number;
   tags?: DocumentTag[];
 }

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -14,6 +14,8 @@ const badgeVariants = cva(
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
         outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        freshness:
+          "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400",
         ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",
       },

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,209 +8,211 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as SigninRouteImport } from "./routes/signin";
-import { Route as AuthenticatedRouteImport } from "./routes/_authenticated";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as AuthenticatedUploadRouteImport } from "./routes/_authenticated/upload";
-import { Route as AuthenticatedSavedRouteImport } from "./routes/_authenticated/saved";
-import { Route as AuthenticatedFeedRouteImport } from "./routes/_authenticated/feed";
-import { Route as AuthenticatedLibraryIndexRouteImport } from "./routes/_authenticated/library/index";
-import { Route as ApiAuthSplatRouteImport } from "./routes/api/auth/$";
-import { Route as AuthenticatedLibraryDocumentIdRouteImport } from "./routes/_authenticated/library/$documentId";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as SigninRouteImport } from './routes/signin'
+import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthenticatedUploadRouteImport } from './routes/_authenticated/upload'
+import { Route as AuthenticatedSavedRouteImport } from './routes/_authenticated/saved'
+import { Route as AuthenticatedFeedRouteImport } from './routes/_authenticated/feed'
+import { Route as AuthenticatedLibraryIndexRouteImport } from './routes/_authenticated/library/index'
+import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
+import { Route as AuthenticatedLibraryDocumentIdRouteImport } from './routes/_authenticated/library/$documentId'
 
 const SigninRoute = SigninRouteImport.update({
-  id: "/signin",
-  path: "/signin",
+  id: '/signin',
+  path: '/signin',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
-  id: "/_authenticated",
+  id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const AuthenticatedUploadRoute = AuthenticatedUploadRouteImport.update({
-  id: "/upload",
-  path: "/upload",
+  id: '/upload',
+  path: '/upload',
   getParentRoute: () => AuthenticatedRoute,
-} as any);
+} as any)
 const AuthenticatedSavedRoute = AuthenticatedSavedRouteImport.update({
-  id: "/saved",
-  path: "/saved",
+  id: '/saved',
+  path: '/saved',
   getParentRoute: () => AuthenticatedRoute,
-} as any);
+} as any)
 const AuthenticatedFeedRoute = AuthenticatedFeedRouteImport.update({
-  id: "/feed",
-  path: "/feed",
+  id: '/feed',
+  path: '/feed',
   getParentRoute: () => AuthenticatedRoute,
-} as any);
-const AuthenticatedLibraryIndexRoute = AuthenticatedLibraryIndexRouteImport.update({
-  id: "/library/",
-  path: "/library/",
-  getParentRoute: () => AuthenticatedRoute,
-} as any);
+} as any)
+const AuthenticatedLibraryIndexRoute =
+  AuthenticatedLibraryIndexRouteImport.update({
+    id: '/library/',
+    path: '/library/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
-  id: "/api/auth/$",
-  path: "/api/auth/$",
+  id: '/api/auth/$',
+  path: '/api/auth/$',
   getParentRoute: () => rootRouteImport,
-} as any);
-const AuthenticatedLibraryDocumentIdRoute = AuthenticatedLibraryDocumentIdRouteImport.update({
-  id: "/library/$documentId",
-  path: "/library/$documentId",
-  getParentRoute: () => AuthenticatedRoute,
-} as any);
+} as any)
+const AuthenticatedLibraryDocumentIdRoute =
+  AuthenticatedLibraryDocumentIdRouteImport.update({
+    id: '/library/$documentId',
+    path: '/library/$documentId',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/signin": typeof SigninRoute;
-  "/feed": typeof AuthenticatedFeedRoute;
-  "/saved": typeof AuthenticatedSavedRoute;
-  "/upload": typeof AuthenticatedUploadRoute;
-  "/library/$documentId": typeof AuthenticatedLibraryDocumentIdRoute;
-  "/api/auth/$": typeof ApiAuthSplatRoute;
-  "/library/": typeof AuthenticatedLibraryIndexRoute;
+  '/': typeof IndexRoute
+  '/signin': typeof SigninRoute
+  '/feed': typeof AuthenticatedFeedRoute
+  '/saved': typeof AuthenticatedSavedRoute
+  '/upload': typeof AuthenticatedUploadRoute
+  '/library/$documentId': typeof AuthenticatedLibraryDocumentIdRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/library/': typeof AuthenticatedLibraryIndexRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/signin": typeof SigninRoute;
-  "/feed": typeof AuthenticatedFeedRoute;
-  "/saved": typeof AuthenticatedSavedRoute;
-  "/upload": typeof AuthenticatedUploadRoute;
-  "/library/$documentId": typeof AuthenticatedLibraryDocumentIdRoute;
-  "/api/auth/$": typeof ApiAuthSplatRoute;
-  "/library": typeof AuthenticatedLibraryIndexRoute;
+  '/': typeof IndexRoute
+  '/signin': typeof SigninRoute
+  '/feed': typeof AuthenticatedFeedRoute
+  '/saved': typeof AuthenticatedSavedRoute
+  '/upload': typeof AuthenticatedUploadRoute
+  '/library/$documentId': typeof AuthenticatedLibraryDocumentIdRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/library': typeof AuthenticatedLibraryIndexRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
-  "/_authenticated": typeof AuthenticatedRouteWithChildren;
-  "/signin": typeof SigninRoute;
-  "/_authenticated/feed": typeof AuthenticatedFeedRoute;
-  "/_authenticated/saved": typeof AuthenticatedSavedRoute;
-  "/_authenticated/upload": typeof AuthenticatedUploadRoute;
-  "/_authenticated/library/$documentId": typeof AuthenticatedLibraryDocumentIdRoute;
-  "/api/auth/$": typeof ApiAuthSplatRoute;
-  "/_authenticated/library/": typeof AuthenticatedLibraryIndexRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/signin': typeof SigninRoute
+  '/_authenticated/feed': typeof AuthenticatedFeedRoute
+  '/_authenticated/saved': typeof AuthenticatedSavedRoute
+  '/_authenticated/upload': typeof AuthenticatedUploadRoute
+  '/_authenticated/library/$documentId': typeof AuthenticatedLibraryDocumentIdRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/_authenticated/library/': typeof AuthenticatedLibraryIndexRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/signin"
-    | "/feed"
-    | "/saved"
-    | "/upload"
-    | "/library/$documentId"
-    | "/api/auth/$"
-    | "/library/";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/signin'
+    | '/feed'
+    | '/saved'
+    | '/upload'
+    | '/library/$documentId'
+    | '/api/auth/$'
+    | '/library/'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/signin"
-    | "/feed"
-    | "/saved"
-    | "/upload"
-    | "/library/$documentId"
-    | "/api/auth/$"
-    | "/library";
+    | '/'
+    | '/signin'
+    | '/feed'
+    | '/saved'
+    | '/upload'
+    | '/library/$documentId'
+    | '/api/auth/$'
+    | '/library'
   id:
-    | "__root__"
-    | "/"
-    | "/_authenticated"
-    | "/signin"
-    | "/_authenticated/feed"
-    | "/_authenticated/saved"
-    | "/_authenticated/upload"
-    | "/_authenticated/library/$documentId"
-    | "/api/auth/$"
-    | "/_authenticated/library/";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/_authenticated'
+    | '/signin'
+    | '/_authenticated/feed'
+    | '/_authenticated/saved'
+    | '/_authenticated/upload'
+    | '/_authenticated/library/$documentId'
+    | '/api/auth/$'
+    | '/_authenticated/library/'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren;
-  SigninRoute: typeof SigninRoute;
-  ApiAuthSplatRoute: typeof ApiAuthSplatRoute;
+  IndexRoute: typeof IndexRoute
+  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
+  SigninRoute: typeof SigninRoute
+  ApiAuthSplatRoute: typeof ApiAuthSplatRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/signin": {
-      id: "/signin";
-      path: "/signin";
-      fullPath: "/signin";
-      preLoaderRoute: typeof SigninRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/_authenticated": {
-      id: "/_authenticated";
-      path: "";
-      fullPath: "/";
-      preLoaderRoute: typeof AuthenticatedRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/_authenticated/upload": {
-      id: "/_authenticated/upload";
-      path: "/upload";
-      fullPath: "/upload";
-      preLoaderRoute: typeof AuthenticatedUploadRouteImport;
-      parentRoute: typeof AuthenticatedRoute;
-    };
-    "/_authenticated/saved": {
-      id: "/_authenticated/saved";
-      path: "/saved";
-      fullPath: "/saved";
-      preLoaderRoute: typeof AuthenticatedSavedRouteImport;
-      parentRoute: typeof AuthenticatedRoute;
-    };
-    "/_authenticated/feed": {
-      id: "/_authenticated/feed";
-      path: "/feed";
-      fullPath: "/feed";
-      preLoaderRoute: typeof AuthenticatedFeedRouteImport;
-      parentRoute: typeof AuthenticatedRoute;
-    };
-    "/_authenticated/library/": {
-      id: "/_authenticated/library/";
-      path: "/library";
-      fullPath: "/library/";
-      preLoaderRoute: typeof AuthenticatedLibraryIndexRouteImport;
-      parentRoute: typeof AuthenticatedRoute;
-    };
-    "/api/auth/$": {
-      id: "/api/auth/$";
-      path: "/api/auth/$";
-      fullPath: "/api/auth/$";
-      preLoaderRoute: typeof ApiAuthSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/_authenticated/library/$documentId": {
-      id: "/_authenticated/library/$documentId";
-      path: "/library/$documentId";
-      fullPath: "/library/$documentId";
-      preLoaderRoute: typeof AuthenticatedLibraryDocumentIdRouteImport;
-      parentRoute: typeof AuthenticatedRoute;
-    };
+    '/signin': {
+      id: '/signin'
+      path: '/signin'
+      fullPath: '/signin'
+      preLoaderRoute: typeof SigninRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated': {
+      id: '/_authenticated'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof AuthenticatedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated/upload': {
+      id: '/_authenticated/upload'
+      path: '/upload'
+      fullPath: '/upload'
+      preLoaderRoute: typeof AuthenticatedUploadRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/saved': {
+      id: '/_authenticated/saved'
+      path: '/saved'
+      fullPath: '/saved'
+      preLoaderRoute: typeof AuthenticatedSavedRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/feed': {
+      id: '/_authenticated/feed'
+      path: '/feed'
+      fullPath: '/feed'
+      preLoaderRoute: typeof AuthenticatedFeedRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/library/': {
+      id: '/_authenticated/library/'
+      path: '/library'
+      fullPath: '/library/'
+      preLoaderRoute: typeof AuthenticatedLibraryIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/api/auth/$': {
+      id: '/api/auth/$'
+      path: '/api/auth/$'
+      fullPath: '/api/auth/$'
+      preLoaderRoute: typeof ApiAuthSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated/library/$documentId': {
+      id: '/_authenticated/library/$documentId'
+      path: '/library/$documentId'
+      fullPath: '/library/$documentId'
+      preLoaderRoute: typeof AuthenticatedLibraryDocumentIdRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
   }
 }
 
 interface AuthenticatedRouteChildren {
-  AuthenticatedFeedRoute: typeof AuthenticatedFeedRoute;
-  AuthenticatedSavedRoute: typeof AuthenticatedSavedRoute;
-  AuthenticatedUploadRoute: typeof AuthenticatedUploadRoute;
-  AuthenticatedLibraryDocumentIdRoute: typeof AuthenticatedLibraryDocumentIdRoute;
-  AuthenticatedLibraryIndexRoute: typeof AuthenticatedLibraryIndexRoute;
+  AuthenticatedFeedRoute: typeof AuthenticatedFeedRoute
+  AuthenticatedSavedRoute: typeof AuthenticatedSavedRoute
+  AuthenticatedUploadRoute: typeof AuthenticatedUploadRoute
+  AuthenticatedLibraryDocumentIdRoute: typeof AuthenticatedLibraryDocumentIdRoute
+  AuthenticatedLibraryIndexRoute: typeof AuthenticatedLibraryIndexRoute
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
@@ -219,27 +221,27 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedUploadRoute: AuthenticatedUploadRoute,
   AuthenticatedLibraryDocumentIdRoute: AuthenticatedLibraryDocumentIdRoute,
   AuthenticatedLibraryIndexRoute: AuthenticatedLibraryIndexRoute,
-};
+}
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
   AuthenticatedRouteChildren,
-);
+)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   SigninRoute: SigninRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { createStart } from "@tanstack/react-start";
-declare module "@tanstack/react-start" {
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/docs/adr/007-freshness-mechanics.md
+++ b/docs/adr/007-freshness-mechanics.md
@@ -1,0 +1,90 @@
+---
+status: accepted
+date: 2026-03-15
+---
+
+# ADR-007: Freshness mechanics for recently uploaded documents
+
+## Context
+
+Issue #74 asks for visual and algorithmic treatment of recently uploaded documents: a "New" badge on feed cards whose source document was uploaded within the last 48 hours, and a honeymoon boost (2x sampling weight) for chunks from those documents during feed generation. Both should decay gracefully when the freshness window expires.
+
+The backend already has a `computeRecencyBoost()` function in `sampling.ts` that returns 2.0 for docs under 48h old and linearly decays to 1.0 over 7 days. However, this boost only applies in the `weightedSample()` selection path. The `semanticSelect()` path delegates final ranking to `rankByUsage()` which ignores document age entirely, and the legacy/random path uses `shuffle()` with no weighting at all. On the frontend, the `list()` query returns no freshness information, so cards have no way to know whether their source document is new.
+
+There are two distinct questions: (1) how to apply recency boost consistently across all selection paths, and (2) how to surface freshness to the frontend for the badge.
+
+## Decision
+
+### 1. Extract freshness constants to `packages/backend/convex/feed/constants.ts`
+
+The constants are consumed by three files within `feed/` (`sampling.ts`, `selectionLogic.ts`, `queries.ts`), justifying a shared module. The file contains only freshness-related domain logic - not a grab-bag utility.
+
+Named exports:
+
+- `FRESHNESS_WINDOW_MS` - 48 hours
+- `FRESHNESS_DECAY_WINDOW_MS` - 7 days
+- `FRESHNESS_BOOST_FACTOR` - 2.0
+- `computeRecencyBoost()` - pure function with three phases: full boost, linear decay, baseline
+
+The frontend does not need these constants because `isNew` is computed server-side (see decision 3).
+
+### 2. Apply recency boost in `rankByUsage()` and `frontLoadFreshChunks()`
+
+The `semanticSelect()` function calls `rankByUsage()` for its final chunk ordering. The `rankByUsage()` function now accepts optional `docCreatedAtMap` and `now` fields and multiplies the recency boost into the weight calculation, exactly as `weightedSample()` already does.
+
+For shuffle fallback paths (no doc summaries, empty semantic chunks), `frontLoadFreshChunks()` moves fresh chunks to the front but caps them at `count / 2` to preserve cross-document diversity. Without capping, a single large fresh document could dominate all selected chunks.
+
+Updated approach per selection path:
+
+- `weightedSample()` - already applies recency boost correctly (no change)
+- `semanticSelect()` primary path - recency boost via `rankByUsage()` with `docCreatedAtMap`/`now`
+- `semanticSelect()` fallback paths - `frontLoadFreshChunks()` with diversity cap
+- Legacy `shuffle()` path - deliberately unweighted (on its way out)
+
+### 3. Compute `isNew` server-side in the `list()` query - no schema change
+
+The `list()` query reads source documents via a deduplicated `Map<Id, Doc>` (one `db.get()` per unique document, not per post) and computes `isNew: (now - doc.createdAt) < FRESHNESS_WINDOW_MS`.
+
+**Note on reactivity:** `Date.now()` in Convex queries is non-deterministic. The `isNew` flag will update on the next query re-evaluation triggered by any data write - not at the exact 48-hour mark. This is acceptable: user interactions (generate feed, bookmark, react) trigger re-evaluation frequently.
+
+**Why server-side computation, not client-side:**
+
+- Client-side computation requires sharing the freshness constant across packages
+- Client-side `Date.now()` drifts from server time
+- The `isNew` boolean is a single derived field with no client-side variation
+
+**Why runtime lookup, not denormalization:**
+
+- `isNew` is transient (no post is "new" after 48h) but a schema field persists forever
+- Deduplicated doc lookups keep the read count low (unique docs per page, not N per post)
+- Same trade-off as ADR-006 for tags: runtime resolution, always-consistent
+
+### 4. Frontend "New" badge in `CardShell`, `freshness` Badge variant
+
+Add `isNew?: boolean` to the `PostCardData` interface (optional so existing code is unaffected).
+
+The "New" badge renders inside `CardShell` above the card content, ensuring it appears consistently across all card types regardless of whether a card type renders `SourceBadge` or not.
+
+Uses a dedicated `freshness` Badge variant in `badge.tsx` (emerald color scheme) instead of inline color overrides, following shadcn semantic styling patterns. The badge includes `aria-label` and `aria-hidden` on the decorative dot for accessibility.
+
+### Alternatives considered
+
+- **Denormalize `sourceDocumentCreatedAt` onto posts table** - Write-once so no fan-out risk, but adds a permanent field for a transient flag. The runtime lookup costs one `db.get()` per unique document per page which is trivial at personal scale.
+- **Client-side freshness computation** - Expose `sourceDocumentCreatedAt` and let the frontend compare against `Date.now()`. Introduces cross-package constant coupling and client/server clock skew.
+- **Separate `freshness` query endpoint** - Over-engineered for a single boolean. Tags justified a separate query because they involve a join; freshness is a field comparison.
+- **Apply recency boost inside `semanticSelect()` before calling `rankByUsage()`** - Pre-filtering by recency would fight the semantic relevance signal. The right place is inside the ranking function.
+
+## Consequences
+
+- **Recency boost coverage**: All active selection paths (semantic and weighted) respect document freshness. Fallback paths cap fresh chunks at 50% for diversity. Legacy random path remains unweighted
+- **Feed query cost**: Deduplicated document lookups add at most `uniqueDocCount` reads per page (typically 5-8 for a 10-post page). Well within Convex query budget
+- **Schema stability**: No schema migration needed. `isNew` is computed at query time
+- **Frontend impact**: `PostCardData.isNew` is optional. `CardShell` gains a small conditional badge render. New `freshness` Badge variant centralizes the color scheme
+- **Testability**: `computeRecencyBoost()` is a pure function with deterministic tests. `rankByUsage()` gains optional params with defaults so existing tests pass unchanged. Critical invariant tested: unused old content outranks heavily-used fresh content (freshness boosts, not overrides)
+- **Clock dependency**: `isNew` depends on `Date.now()` and updates on the next data-triggered re-evaluation, not at the exact 48-hour mark
+
+## More Information
+
+- The `computeRecencyBoost()` linear decay from 2.0 to 1.0 over 48h-7d is intentionally different from the badge's hard 48h cutoff: the badge is a binary visual signal, the weight is a continuous ranking factor
+- If Scrollect later adds user-configurable freshness windows, the constants become fields on a settings table. The architecture supports this without structural changes
+- Related: ADR-006 (tagging system) made the same denormalize-vs-runtime trade-off and chose runtime

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as chunking from "../chunking.js";
 import type * as chunks from "../chunks.js";
 import type * as documentActions from "../documentActions.js";
 import type * as documents from "../documents.js";
+import type * as feed_constants from "../feed/constants.js";
 import type * as feed_generation from "../feed/generation.js";
 import type * as feed_queries from "../feed/queries.js";
 import type * as feed_sampling from "../feed/sampling.js";
@@ -67,6 +68,7 @@ declare const fullApi: ApiFromModules<{
   chunks: typeof chunks;
   documentActions: typeof documentActions;
   documents: typeof documents;
+  "feed/constants": typeof feed_constants;
   "feed/generation": typeof feed_generation;
   "feed/queries": typeof feed_queries;
   "feed/sampling": typeof feed_sampling;

--- a/packages/backend/convex/feed/constants.ts
+++ b/packages/backend/convex/feed/constants.ts
@@ -1,0 +1,16 @@
+export const FRESHNESS_WINDOW_MS = 48 * 60 * 60 * 1000;
+export const FRESHNESS_BOOST_FACTOR = 2.0;
+export const FRESHNESS_DECAY_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function computeRecencyBoost(docCreatedAt: number, now: number): number {
+  const age = now - docCreatedAt;
+  if (age < FRESHNESS_WINDOW_MS) return FRESHNESS_BOOST_FACTOR;
+  if (age < FRESHNESS_DECAY_WINDOW_MS) {
+    return (
+      1.0 +
+      ((FRESHNESS_BOOST_FACTOR - 1.0) * (FRESHNESS_DECAY_WINDOW_MS - age)) /
+        (FRESHNESS_DECAY_WINDOW_MS - FRESHNESS_WINDOW_MS)
+    );
+  }
+  return 1.0;
+}

--- a/packages/backend/convex/feed/generation.ts
+++ b/packages/backend/convex/feed/generation.ts
@@ -214,10 +214,12 @@ export const generate = action({
           allChunks,
           docSummaries,
           chunkUsageMap,
+          docCreatedAtMap,
           count: sampleSize,
           userId: user._id,
           embedder,
           summaryStore,
+          now,
         });
         evt.set("selectionMethod", "semantic");
       } else if (useMultiType) {

--- a/packages/backend/convex/feed/queries.ts
+++ b/packages/backend/convex/feed/queries.ts
@@ -4,6 +4,7 @@ import { v } from "convex/values";
 import { internalMutation, internalQuery, mutation, query } from "../_generated/server";
 import { requireAuth, optionalAuth } from "../lib/functions";
 import { postType, reactionInput, typeData } from "../lib/validators";
+import { FRESHNESS_WINDOW_MS } from "./constants";
 
 export const list = query({
   args: { paginationOpts: paginationOptsValidator },
@@ -23,17 +24,31 @@ export const list = query({
       .order("desc")
       .paginate(args.paginationOpts);
 
+    // Date.now() is non-deterministic in Convex queries but acceptable here:
+    // isNew will update on the next query re-evaluation triggered by any data write,
+    // not at the exact 48-hour mark.
+    const now = Date.now();
+
+    const uniqueDocIds = [...new Set(result.page.map((p) => p.primarySourceDocumentId))];
+    const docs = await Promise.all(uniqueDocIds.map((id) => ctx.db.get(id)));
+    const docMap = new Map(uniqueDocIds.map((id, i) => [id, docs[i]]));
+
     const enrichedPage = await Promise.all(
       result.page.map(async (post) => {
-        const bookmark = await ctx.db
-          .query("bookmarks")
-          .withIndex("by_userId_post", (q) => q.eq("userId", user._id).eq("postId", post._id))
-          .first();
-        const chunk = await ctx.db.get(post.primarySourceChunkId);
+        const [bookmark, chunk] = await Promise.all([
+          ctx.db
+            .query("bookmarks")
+            .withIndex("by_userId_post", (q) => q.eq("userId", user._id).eq("postId", post._id))
+            .first(),
+          ctx.db.get(post.primarySourceChunkId),
+        ]);
+        const sourceDoc = docMap.get(post.primarySourceDocumentId);
+        const isNew = sourceDoc ? now - sourceDoc.createdAt < FRESHNESS_WINDOW_MS : false;
         return {
           ...post,
           sourceDocumentTitle: post.primarySourceDocumentTitle,
           isBookmarked: bookmark !== null,
+          isNew,
           sourceChunkId: post.primarySourceChunkId,
           sectionTitle: post.primarySourceSectionTitle ?? null,
           pageNumber: post.primarySourcePageNumber ?? null,

--- a/packages/backend/convex/feed/sampling.ts
+++ b/packages/backend/convex/feed/sampling.ts
@@ -1,14 +1,12 @@
 import { ALL_POST_TYPES } from "../lib/validators";
 import type { EmbeddingProvider, SummaryVectorStore } from "../providers/types";
 
+import { FRESHNESS_WINDOW_MS, computeRecencyBoost } from "./constants";
 import type { ChunkLike, UsageInfo } from "./selectionLogic";
 import { filterChunksBySemantic, rankByUsage } from "./selectionLogic";
 
 export type ChunkInfo = ChunkLike;
 export type ChunkUsage = UsageInfo;
-
-const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
-const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 const SEMANTIC_TOP_DOCS = 5;
 const SEMANTIC_TOP_SECTIONS = 8;
@@ -33,15 +31,6 @@ export type PostSourceRecord = {
   postId: string;
   createdAt: number;
 };
-
-export function computeRecencyBoost(docCreatedAt: number, now: number): number {
-  const age = now - docCreatedAt;
-  if (age < FORTY_EIGHT_HOURS_MS) return 2.0;
-  if (age < SEVEN_DAYS_MS) {
-    return 1.0 + (1.0 * (SEVEN_DAYS_MS - age)) / (SEVEN_DAYS_MS - FORTY_EIGHT_HOURS_MS);
-  }
-  return 1.0;
-}
 
 export function buildChunkUsageMap(
   postSources: PostSourceRecord[],
@@ -162,10 +151,12 @@ export type SemanticSelectArgs = {
   allChunks: ChunkInfo[];
   docSummaries: DocumentSummaryInfo[];
   chunkUsageMap: Map<string, ChunkUsage>;
+  docCreatedAtMap: Map<string, number>;
   count: number;
   userId: string;
   embedder: EmbeddingProvider;
   summaryStore: SummaryVectorStore;
+  now: number;
   randomFn?: () => number;
 };
 
@@ -174,15 +165,22 @@ export async function semanticSelect(args: SemanticSelectArgs): Promise<ChunkInf
     allChunks,
     docSummaries,
     chunkUsageMap,
+    docCreatedAtMap,
     count,
     userId,
     embedder,
     summaryStore,
+    now,
     randomFn = Math.random,
   } = args;
 
   if (docSummaries.length === 0) {
-    return shuffle(allChunks).slice(0, count);
+    return frontLoadFreshChunks({
+      chunks: shuffle(allChunks),
+      docCreatedAtMap,
+      now,
+      maxFresh: count,
+    }).slice(0, count);
   }
 
   const seedDoc = docSummaries[Math.floor(randomFn() * docSummaries.length)]!;
@@ -217,13 +215,46 @@ export async function semanticSelect(args: SemanticSelectArgs): Promise<ChunkInf
 
   if (semanticChunks.length === 0) {
     const docChunks = allChunks.filter((c) => selectedDocIds.has(c.documentId));
-    return shuffle(docChunks.length > 0 ? docChunks : allChunks).slice(0, count);
+    return frontLoadFreshChunks({
+      chunks: shuffle(docChunks.length > 0 ? docChunks : allChunks),
+      docCreatedAtMap,
+      now,
+      maxFresh: count,
+    }).slice(0, count);
   }
 
   return rankByUsage({
     chunks: semanticChunks,
     usageMap: chunkUsageMap,
+    docCreatedAtMap,
+    now,
     count,
     allChunksForDiversity: allChunks,
   });
+}
+
+export type FrontLoadArgs = {
+  chunks: ChunkInfo[];
+  docCreatedAtMap: Map<string, number>;
+  now: number;
+  maxFresh?: number;
+};
+
+export function frontLoadFreshChunks(args: FrontLoadArgs): ChunkInfo[] {
+  const { chunks, docCreatedAtMap, now, maxFresh } = args;
+  const fresh: ChunkInfo[] = [];
+  const rest: ChunkInfo[] = [];
+
+  for (const chunk of chunks) {
+    const docCreatedAt = docCreatedAtMap.get(chunk.documentId) ?? 0;
+    const age = now - docCreatedAt;
+    if (age < FRESHNESS_WINDOW_MS) {
+      fresh.push(chunk);
+    } else {
+      rest.push(chunk);
+    }
+  }
+
+  const cap = maxFresh !== undefined ? Math.floor(maxFresh / 2) : fresh.length;
+  return [...fresh.slice(0, cap), ...rest, ...fresh.slice(cap)];
 }

--- a/packages/backend/convex/feed/selectionLogic.ts
+++ b/packages/backend/convex/feed/selectionLogic.ts
@@ -1,3 +1,5 @@
+import { computeRecencyBoost } from "./constants";
+
 export type ChunkLike = {
   _id: string;
   content: string;
@@ -41,18 +43,34 @@ export type UsageInfo = {
 export type RankArgs = {
   chunks: ChunkLike[];
   usageMap: Map<string, UsageInfo>;
+  docCreatedAtMap?: Map<string, number>;
+  now?: number;
   count: number;
   allChunksForDiversity?: ChunkLike[];
   randomFn?: () => number;
 };
 
 export function rankByUsage(args: RankArgs): ChunkLike[] {
-  const { chunks, usageMap, count, allChunksForDiversity, randomFn = Math.random } = args;
+  const {
+    chunks,
+    usageMap,
+    docCreatedAtMap,
+    now,
+    count,
+    allChunksForDiversity,
+    randomFn = Math.random,
+  } = args;
 
   const weighted = chunks.map((chunk) => {
     const usage = usageMap.get(chunk._id);
     const totalUsage = usage?.totalCount ?? 0;
-    return { chunk, weight: 1 / (1 + totalUsage) };
+    const usageWeight = 1 / (1 + totalUsage);
+    if (docCreatedAtMap && now !== undefined) {
+      const docCreatedAt = docCreatedAtMap.get(chunk.documentId) ?? 0;
+      const recencyBoost = computeRecencyBoost(docCreatedAt, now);
+      return { chunk, weight: usageWeight * recencyBoost };
+    }
+    return { chunk, weight: usageWeight };
   });
 
   weighted.sort((a, b) => b.weight - a.weight);

--- a/packages/backend/tests/sampling.test.ts
+++ b/packages/backend/tests/sampling.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  FRESHNESS_WINDOW_MS,
+  FRESHNESS_DECAY_WINDOW_MS,
+  FRESHNESS_BOOST_FACTOR,
+  computeRecencyBoost,
+} from "../convex/feed/constants";
+import {
   buildChunkUsageMap,
   buildTypeCoverageHint,
-  computeRecencyBoost,
+  frontLoadFreshChunks,
   weightedSample,
 } from "../convex/feed/sampling";
 import type { ChunkInfo, PostSourceRecord } from "../convex/feed/sampling";
-
-const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
-const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 const chunk = (id: string, docId: string, section?: string): ChunkInfo => ({
   _id: id,
@@ -20,25 +23,25 @@ const chunk = (id: string, docId: string, section?: string): ChunkInfo => ({
 });
 
 describe("computeRecencyBoost", () => {
-  test("returns 2.0 for documents less than 48 hours old", () => {
+  test("returns FRESHNESS_BOOST_FACTOR for documents within freshness window", () => {
     const now = Date.now();
-    const docCreatedAt = now - FORTY_EIGHT_HOURS_MS + 1000;
-    expect(computeRecencyBoost(docCreatedAt, now)).toBe(2.0);
+    const docCreatedAt = now - FRESHNESS_WINDOW_MS + 1000;
+    expect(computeRecencyBoost(docCreatedAt, now)).toBe(FRESHNESS_BOOST_FACTOR);
   });
 
-  test("returns 1.0 for documents older than 7 days", () => {
+  test("returns 1.0 for documents older than decay window", () => {
     const now = Date.now();
-    const docCreatedAt = now - SEVEN_DAYS_MS - 1000;
+    const docCreatedAt = now - FRESHNESS_DECAY_WINDOW_MS - 1000;
     expect(computeRecencyBoost(docCreatedAt, now)).toBe(1.0);
   });
 
-  test("returns interpolated value between 48h and 7 days", () => {
+  test("returns interpolated value between freshness and decay windows", () => {
     const now = Date.now();
-    const midAge = (FORTY_EIGHT_HOURS_MS + SEVEN_DAYS_MS) / 2;
+    const midAge = (FRESHNESS_WINDOW_MS + FRESHNESS_DECAY_WINDOW_MS) / 2;
     const docCreatedAt = now - midAge;
     const result = computeRecencyBoost(docCreatedAt, now);
     expect(result).toBeGreaterThan(1.0);
-    expect(result).toBeLessThan(2.0);
+    expect(result).toBeLessThan(FRESHNESS_BOOST_FACTOR);
   });
 });
 
@@ -170,5 +173,116 @@ describe("weightedSample", () => {
 
     const docIds = new Set(result.map((c) => c.documentId));
     expect(docIds.size).toBe(2);
+  });
+});
+
+describe("frontLoadFreshChunks", () => {
+  test("moves fresh document chunks to the front", () => {
+    const now = Date.now();
+    const freshDocTime = now - 1000;
+    const oldDocTime = now - FRESHNESS_DECAY_WINDOW_MS - 1000;
+
+    const chunks = [chunk("c1", "d_old"), chunk("c2", "d_fresh"), chunk("c3", "d_old")];
+    const docCreatedAtMap = new Map([
+      ["d_old", oldDocTime],
+      ["d_fresh", freshDocTime],
+    ]);
+
+    const result = frontLoadFreshChunks({ chunks, docCreatedAtMap, now });
+
+    expect(result[0]!._id).toBe("c2");
+    expect(result).toHaveLength(3);
+  });
+
+  test("preserves order within fresh and non-fresh groups", () => {
+    const now = Date.now();
+    const freshDocTime = now - 1000;
+    const oldDocTime = now - FRESHNESS_DECAY_WINDOW_MS - 1000;
+
+    const chunks = [
+      chunk("c1", "d_old"),
+      chunk("c2", "d_fresh"),
+      chunk("c3", "d_old"),
+      chunk("c4", "d_fresh"),
+    ];
+    const docCreatedAtMap = new Map([
+      ["d_old", oldDocTime],
+      ["d_fresh", freshDocTime],
+    ]);
+
+    const result = frontLoadFreshChunks({ chunks, docCreatedAtMap, now });
+
+    expect(result.map((c) => c._id)).toEqual(["c2", "c4", "c1", "c3"]);
+  });
+
+  test("returns all chunks unchanged when none are fresh", () => {
+    const now = Date.now();
+    const oldDocTime = now - FRESHNESS_DECAY_WINDOW_MS - 1000;
+
+    const chunks = [chunk("c1", "d1"), chunk("c2", "d2")];
+    const docCreatedAtMap = new Map([
+      ["d1", oldDocTime],
+      ["d2", oldDocTime],
+    ]);
+
+    const result = frontLoadFreshChunks({ chunks, docCreatedAtMap, now });
+
+    expect(result.map((c) => c._id)).toEqual(["c1", "c2"]);
+  });
+
+  test("returns all chunks unchanged when all are fresh", () => {
+    const now = Date.now();
+    const freshDocTime = now - 1000;
+
+    const chunks = [chunk("c1", "d1"), chunk("c2", "d2")];
+    const docCreatedAtMap = new Map([
+      ["d1", freshDocTime],
+      ["d2", freshDocTime],
+    ]);
+
+    const result = frontLoadFreshChunks({ chunks, docCreatedAtMap, now });
+
+    expect(result.map((c) => c._id)).toEqual(["c1", "c2"]);
+  });
+
+  test("treats unknown documents as not fresh", () => {
+    const now = Date.now();
+    const freshDocTime = now - 1000;
+
+    const chunks = [chunk("c1", "d_unknown"), chunk("c2", "d_fresh")];
+    const docCreatedAtMap = new Map([["d_fresh", freshDocTime]]);
+
+    const result = frontLoadFreshChunks({ chunks, docCreatedAtMap, now });
+
+    expect(result[0]!._id).toBe("c2");
+    expect(result[1]!._id).toBe("c1");
+  });
+
+  test("caps fresh chunks to half of maxFresh to preserve diversity", () => {
+    const now = Date.now();
+    const freshDocTime = now - 1000;
+    const oldDocTime = now - FRESHNESS_DECAY_WINDOW_MS - 1000;
+
+    const chunks = [
+      chunk("c1", "d_fresh"),
+      chunk("c2", "d_fresh"),
+      chunk("c3", "d_fresh"),
+      chunk("c4", "d_fresh"),
+      chunk("c5", "d_old"),
+      chunk("c6", "d_old"),
+    ];
+    const docCreatedAtMap = new Map([
+      ["d_fresh", freshDocTime],
+      ["d_old", oldDocTime],
+    ]);
+
+    const result = frontLoadFreshChunks({ chunks, docCreatedAtMap, now, maxFresh: 4 });
+
+    // With maxFresh=4, cap = floor(4/2) = 2 fresh at front
+    // Result: [c1, c2 (fresh, capped at 2), c5, c6 (old), c3, c4 (remaining fresh)]
+    expect(result[0]!._id).toBe("c1");
+    expect(result[1]!._id).toBe("c2");
+    expect(result[2]!._id).toBe("c5");
+    expect(result[3]!._id).toBe("c6");
   });
 });

--- a/packages/backend/tests/selection-logic.test.ts
+++ b/packages/backend/tests/selection-logic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { FRESHNESS_DECAY_WINDOW_MS } from "../convex/feed/constants";
 import {
   buildSummaryContext,
   filterChunksBySemantic,
@@ -141,6 +142,57 @@ describe("rankByUsage", () => {
     const result = rankByUsage({ chunks, usageMap: new Map(), count: 3 });
 
     expect(result.map((c) => c._id)).toEqual(["c1", "c2", "c3"]);
+  });
+
+  test("boosts chunks from fresh documents when docCreatedAtMap provided", () => {
+    const now = Date.now();
+    const freshDocTime = now - 1000;
+    const oldDocTime = now - FRESHNESS_DECAY_WINDOW_MS - 1000;
+
+    const chunks = [chunk("c1", "d_old"), chunk("c2", "d_fresh")];
+    const usageMap = new Map([
+      ["c1", { types: new Set<string>(), totalCount: 0 }],
+      ["c2", { types: new Set<string>(), totalCount: 0 }],
+    ]);
+    const docCreatedAtMap = new Map([
+      ["d_old", oldDocTime],
+      ["d_fresh", freshDocTime],
+    ]);
+
+    const result = rankByUsage({ chunks, usageMap, docCreatedAtMap, now, count: 2 });
+
+    expect(result[0]!._id).toBe("c2");
+  });
+
+  test("unused old chunk outranks heavily-used fresh chunk (freshness boosts, not overrides)", () => {
+    const now = Date.now();
+    const freshDocTime = now - 1000;
+    const oldDocTime = now - FRESHNESS_DECAY_WINDOW_MS - 1000;
+
+    const chunks = [chunk("c_fresh_used", "d_fresh"), chunk("c_old_unused", "d_old")];
+    const usageMap = new Map([
+      ["c_fresh_used", { types: new Set(["insight", "quiz", "quote"]), totalCount: 5 }],
+    ]);
+    const docCreatedAtMap = new Map([
+      ["d_fresh", freshDocTime],
+      ["d_old", oldDocTime],
+    ]);
+
+    const result = rankByUsage({ chunks, usageMap, docCreatedAtMap, now, count: 2 });
+
+    // Fresh chunk weight: (1/(1+5)) * 2.0 = 0.333
+    // Old unused weight:  (1/(1+0)) * 1.0 = 1.0
+    // Old unused should rank first - freshness is a boost, not an override
+    expect(result[0]!._id).toBe("c_old_unused");
+  });
+
+  test("without docCreatedAtMap falls back to usage-only ranking", () => {
+    const chunks = [chunk("c1", "d1"), chunk("c2", "d2")];
+    const usageMap = new Map([["c2", { types: new Set(["insight"]), totalCount: 3 }]]);
+
+    const result = rankByUsage({ chunks, usageMap, count: 2 });
+
+    expect(result[0]!._id).toBe("c1");
   });
 });
 


### PR DESCRIPTION
## Summary

- **Backend**: Extract freshness constants to `feed/constants.ts`, apply recency boost across all selection paths (semantic, weighted, shuffle fallback), add `isNew` computation to feed `list()` query with deduplicated document lookups
- **Frontend**: Add "New" badge to `CardShell` with accessible `freshness` Badge variant (emerald green), `aria-label`, and `data-testid` for E2E
- **E2E**: 4 Playwright tests verifying badge visibility, text content, DOM nesting, and coverage across seeded cards

## Details

### Freshness constants (`constants.ts`)
- `FRESHNESS_WINDOW_MS` = 48 hours (badge visibility + boost cutoff)
- `FRESHNESS_BOOST_FACTOR` = 2.0 (sampling weight multiplier)
- `FRESHNESS_DECAY_WINDOW_MS` = 7 days (linear decay to 1.0)
- `computeRecencyBoost()` pure function with three phases

### Selection path coverage
| Path | Freshness mechanism |
|---|---|
| `weightedSample()` | Existing 2x boost (unchanged) |
| `semanticSelect()` -> `rankByUsage()` | New: recency * usage weight |
| Shuffle fallbacks | New: `frontLoadFreshChunks()` with 50% diversity cap |
| Legacy random | Deliberately unweighted (being phased out) |

### Feed query `isNew`
- Computed server-side: `Date.now() - sourceDoc.createdAt < FRESHNESS_WINDOW_MS`
- Document lookups deduplicated via `Map<Id, Doc>` (one read per unique doc, not per post)
- Updates on next data-triggered re-evaluation, not at the exact 48h mark

### Code review findings addressed
- Fixed `frontLoadFreshChunks` zero-diversity bug (capped at 50% fresh)
- Added `freshness` Badge variant instead of inline color overrides
- Added `aria-label` and `aria-hidden` for accessibility
- Added usage-vs-freshness invariant test (unused old content outranks heavily-used fresh)
- Deduplicated document lookups in `list()` query
- Renamed constants for specificity (`BOOST_FACTOR` -> `FRESHNESS_BOOST_FACTOR`)
- Updated ADR-007 to match final implementation

Closes #74

## Test plan
- [x] 45 unit tests pass (sampling, selection-logic, validation)
- [x] Lint clean (`oxlint` + `oxfmt`)
- [x] Build passes (`bun turbo build`)
- [ ] E2E freshness tests (4 tests in `freshness.spec.ts` - requires running app)
- [ ] Manual: upload a document, generate feed, verify "New" badge appears on cards
- [ ] Manual: wait 48h (or adjust constant), verify badge disappears