### PR TITLE
fix(#92): address code review findings for rate limiting

### DIFF
--- a/apps/web/src/components/upload/upload-file-tab.tsx
+++ b/apps/web/src/components/upload/upload-file-tab.tsx
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { getRateLimitMessage } from "@/lib/rate-limit-error";
+import { toastRateLimitOrFallback } from "@/lib/rate-limit-error";
 
 const UPLOAD_FILE_TYPES = ["pdf", "epub", "md"] as const;
 type UploadFileType = (typeof UPLOAD_FILE_TYPES)[number];
@@ -82,12 +82,7 @@ export function UploadFileTab() {
         setUploads((prev) =>
           prev.map((u) => (u.file === file ? { ...u, status: "error" as const } : u)),
         );
-        const rateLimitMsg = getRateLimitMessage(error);
-        if (rateLimitMsg) {
-          toast.error(rateLimitMsg);
-        } else {
-          toast.error(`Failed to upload ${file.name}`);
-        }
+        toastRateLimitOrFallback(error, `Failed to upload ${file.name}`);
       }
     },
     [generateUploadUrl, createDocument],

--- a/apps/web/src/components/upload/upload-text-tab.tsx
+++ b/apps/web/src/components/upload/upload-text-tab.tsx
@@ -9,7 +9,7 @@ import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { getRateLimitMessage } from "@/lib/rate-limit-error";
+import { toastRateLimitOrFallback } from "@/lib/rate-limit-error";
 
 export function UploadTextTab() {
   const [title, setTitle] = useState("");
@@ -69,12 +69,10 @@ export function UploadTextTab() {
           </span>,
         );
       } catch (error) {
-        const rateLimitMsg = getRateLimitMessage(error);
-        if (rateLimitMsg) {
-          toast.error(rateLimitMsg);
-        } else {
-          toast.error("Something went wrong while saving your text. Please try again.");
-        }
+        toastRateLimitOrFallback(
+          error,
+          "Something went wrong while saving your text. Please try again.",
+        );
       } finally {
         setSubmitting(false);
       }

--- a/apps/web/src/components/upload/upload-url-tab.tsx
+++ b/apps/web/src/components/upload/upload-url-tab.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { getRateLimitMessage } from "@/lib/rate-limit-error";
+import { toastRateLimitOrFallback } from "@/lib/rate-limit-error";
 
 export function detectUrlType(url: string): "youtube" | "article" {
   try {
@@ -63,12 +63,10 @@ export function UploadUrlTab() {
         );
         setUrl("");
       } catch (error) {
-        const rateLimitMsg = getRateLimitMessage(error);
-        if (rateLimitMsg) {
-          toast.error(rateLimitMsg);
-        } else {
-          toast.error("Something went wrong while processing this URL. Please try again.");
-        }
+        toastRateLimitOrFallback(
+          error,
+          "Something went wrong while processing this URL. Please try again.",
+        );
       } finally {
         setSubmitting(false);
       }

--- a/apps/web/src/hooks/use-auto-generate.ts
+++ b/apps/web/src/hooks/use-auto-generate.ts
@@ -18,6 +18,16 @@ export function useAutoGenerate(
   const [rateLimitedUntil, setRateLimitedUntil] = useState<number | null>(null);
   const triggered = useRef(false);
 
+  function handleError(e: unknown) {
+    if (isRateLimitError(e)) {
+      const msg = getRateLimitMessage(e);
+      setError(msg);
+      setRateLimitedUntil(Date.now() + e.data.retryAfter);
+    } else {
+      setError(e instanceof Error ? e.message : "Failed to generate feed");
+    }
+  }
+
   useEffect(() => {
     if (options?.disabled) return;
     if (triggered.current) return;
@@ -30,16 +40,10 @@ export function useAutoGenerate(
       setGenerating(true);
       setError(null);
       generateFeed(options?.count ? { count: options.count } : {})
-        .catch((e: unknown) => {
-          if (isRateLimitError(e)) {
-            setError(getRateLimitMessage(e)!);
-            setRateLimitedUntil(Date.now() + e.data.retryAfter);
-          } else {
-            setError(e instanceof Error ? e.message : "Failed to generate feed");
-          }
-        })
+        .catch(handleError)
         .finally(() => setGenerating(false));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- handleError uses only stable setters
   }, [lastGeneratedAt, generateFeed, options?.disabled, options?.count]);
 
   useEffect(() => {
@@ -63,12 +67,7 @@ export function useAutoGenerate(
     try {
       await generateFeed(options?.count ? { count: options.count } : {});
     } catch (e) {
-      if (isRateLimitError(e)) {
-        setError(getRateLimitMessage(e)!);
-        setRateLimitedUntil(Date.now() + e.data.retryAfter);
-      } else {
-        setError(e instanceof Error ? e.message : "Failed to generate feed");
-      }
+      handleError(e);
     } finally {
       setGenerating(false);
     }

--- a/apps/web/src/lib/rate-limit-error.ts
+++ b/apps/web/src/lib/rate-limit-error.ts
@@ -1,8 +1,11 @@
 import { ConvexError } from "convex/values";
+import { toast } from "sonner";
+
+type RateLimitErrorData = { kind: "RateLimited"; name: string; retryAfter: number };
 
 export function isRateLimitError(
   error: unknown,
-): error is { data: { kind: "RateLimited"; name: string; retryAfter: number } } {
+): error is ConvexError<string> & { data: RateLimitErrorData } {
   return (
     error instanceof ConvexError &&
     typeof error.data === "object" &&
@@ -12,9 +15,9 @@ export function isRateLimitError(
 }
 
 export function formatRetryAfter(ms: number): string {
-  const seconds = Math.ceil(ms / 1000);
-  if (seconds < 60) return `${seconds} second${seconds !== 1 ? "s" : ""}`;
-  const minutes = Math.ceil(seconds / 60);
+  const totalSeconds = Math.ceil(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds} second${totalSeconds !== 1 ? "s" : ""}`;
+  const minutes = Math.ceil(ms / 60_000);
   return `${minutes} minute${minutes !== 1 ? "s" : ""}`;
 }
 
@@ -22,4 +25,9 @@ export function getRateLimitMessage(error: unknown): string | null {
   if (!isRateLimitError(error)) return null;
   const wait = formatRetryAfter(error.data.retryAfter);
   return `You've hit the rate limit. Please try again in ${wait}.`;
+}
+
+export function toastRateLimitOrFallback(error: unknown, fallbackMessage: string) {
+  const rateLimitMsg = getRateLimitMessage(error);
+  toast.error(rateLimitMsg ?? fallbackMessage);
 }

--- a/packages/backend/convex/documents.ts
+++ b/packages/backend/convex/documents.ts
@@ -9,13 +9,13 @@ import { rateLimiter } from "./lib/rateLimitConfig";
 import { documentStatus, failedAtStage, fileType, urlFileType } from "./lib/validators";
 
 async function enforceDocumentUploadLimit(ctx: MutationCtx, userId: string, evt: WideEvent) {
-  const { ok, retryAfter } = await rateLimiter.limit(ctx, "documentUpload", { key: userId });
-  if (!ok) {
-    evt.set({ rateLimited: true, endpoint: "documentUpload", retryAfterMs: retryAfter });
+  const result = await rateLimiter.limit(ctx, "documentUpload", { key: userId });
+  if (!result.ok) {
+    evt.set({ rateLimited: true, endpoint: "documentUpload", retryAfterMs: result.retryAfter });
     throw new ConvexError({
       kind: "RateLimited" as const,
       name: "documentUpload",
-      retryAfter: retryAfter!,
+      retryAfter: result.retryAfter,
     });
   }
 }
@@ -23,7 +23,15 @@ async function enforceDocumentUploadLimit(ctx: MutationCtx, userId: string, evt:
 export const generateUploadUrl = mutation({
   args: {},
   handler: async (ctx) => {
-    await requireAuth(ctx);
+    const user = await requireAuth(ctx);
+    const result = await rateLimiter.limit(ctx, "documentUpload", { key: user._id });
+    if (!result.ok) {
+      throw new ConvexError({
+        kind: "RateLimited" as const,
+        name: "documentUpload",
+        retryAfter: result.retryAfter,
+      });
+    }
     return await ctx.storage.generateUploadUrl();
   },
 });

--- a/packages/backend/convex/feed/generation.ts
+++ b/packages/backend/convex/feed/generation.ts
@@ -124,16 +124,20 @@ export const generate = action({
       const user = await requireAuth(ctx);
       evt.set("userId", user._id);
 
-      const { ok, retryAfter } = await ctx.runMutation(
-        internal.lib.rateLimitChecks.checkFeedGenerationLimit,
+      const rateLimitResult = await ctx.runMutation(
+        internal.lib.rateLimitChecks.enforceFeedGenerationLimit,
         { userId: user._id },
       );
-      if (!ok) {
-        evt.set({ rateLimited: true, endpoint: "feedGeneration", retryAfterMs: retryAfter });
+      if (!rateLimitResult.ok) {
+        evt.set({
+          rateLimited: true,
+          endpoint: "feedGeneration",
+          retryAfterMs: rateLimitResult.retryAfter,
+        });
         throw new ConvexError({
           kind: "RateLimited" as const,
           name: "feedGeneration",
-          retryAfter: retryAfter!,
+          retryAfter: rateLimitResult.retryAfter,
         });
       }
 

--- a/packages/backend/convex/lib/rateLimitChecks.ts
+++ b/packages/backend/convex/lib/rateLimitChecks.ts
@@ -3,14 +3,15 @@ import { v } from "convex/values";
 import { internalMutation } from "../_generated/server";
 import { rateLimiter } from "./rateLimitConfig";
 
-export const checkFeedGenerationLimit = internalMutation({
+export const enforceFeedGenerationLimit = internalMutation({
   args: { userId: v.string() },
-  returns: v.object({
-    ok: v.boolean(),
-    retryAfter: v.optional(v.number()),
-  }),
+  returns: v.union(
+    v.object({ ok: v.literal(true), retryAfter: v.optional(v.number()) }),
+    v.object({ ok: v.literal(false), retryAfter: v.number() }),
+  ),
   handler: async (ctx, { userId }) => {
     const { ok, retryAfter } = await rateLimiter.limit(ctx, "feedGeneration", { key: userId });
-    return { ok, retryAfter };
+    if (ok) return { ok, retryAfter };
+    return { ok, retryAfter: retryAfter! };
   },
 });


### PR DESCRIPTION
## Summary

Follow-up to #101 - fixes all Important findings from code review.

- Rate-limit `generateUploadUrl` to prevent storage exhaustion via unlimited pre-signed URL generation
- Rename `checkFeedGenerationLimit` to `enforceFeedGenerationLimit` to signal token consumption
- Use discriminated union return type so TypeScript narrows `retryAfter` without `!` assertions
- Fix `isRateLimitError` type guard to preserve `ConvexError` methods via intersection type
- Extract `toastRateLimitOrFallback` helper to DRY catch blocks across upload tabs
- Extract shared `handleError` in `useAutoGenerate` to DRY effect and manual generate paths
- Fix `formatRetryAfter` double-rounding (compute minutes from raw ms)

## Test plan
- [ ] Verify upload and feed generation rate limits still work after refactor
- [ ] Verify `generateUploadUrl` is now rate-limited (exceeding 10/hr returns rate limit error)
- [ ] Verify rate limit toast shows correct retry-after duration (no double-rounding)