### PR TITLE
feat(#93): add file upload size limits with client and server validation

### DIFF
--- a/apps/web/src/components/upload/upload-file-tab.tsx
+++ b/apps/web/src/components/upload/upload-file-tab.tsx
@@ -1,4 +1,5 @@
 import { api } from "@scrollect/backend/convex/_generated/api";
+import { FILE_SIZE_LIMITS, formatFileSize } from "@scrollect/backend/convex/lib/fileSizeLimits";
 import { useMutation } from "convex/react";
 import { CloudUpload, FileUp, Loader2 } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
@@ -40,6 +41,19 @@ export function UploadFileTab() {
       if (!isUploadFileType(ext)) {
         toast.error(
           `Unsupported file type: .${ext}. Only .pdf, .epub, and .md files are accepted.`,
+        );
+        return;
+      }
+
+      if (file.size === 0) {
+        toast.error(`File "${file.name}" is empty.`);
+        return;
+      }
+
+      const sizeLimit = FILE_SIZE_LIMITS[ext];
+      if (file.size > sizeLimit) {
+        toast.error(
+          `File too large (${formatFileSize(file.size)}). Maximum for .${ext} files is ${formatFileSize(sizeLimit)}.`,
         );
         return;
       }
@@ -172,7 +186,11 @@ export function UploadFileTab() {
           <FileUp className="mr-2 h-4 w-4" />
           Choose files
         </Button>
-        <p className="text-xs text-muted-foreground">Accepts .pdf, .epub, and .md files</p>
+        <p className="text-xs text-muted-foreground">
+          Accepts .pdf (max {formatFileSize(FILE_SIZE_LIMITS.pdf)}), .epub (max{" "}
+          {formatFileSize(FILE_SIZE_LIMITS.epub)}), and .md (max{" "}
+          {formatFileSize(FILE_SIZE_LIMITS.md)})
+        </p>
         <input
           ref={fileInputRef}
           data-testid="file-input"

--- a/apps/web/src/components/upload/upload-text-tab.tsx
+++ b/apps/web/src/components/upload/upload-text-tab.tsx
@@ -1,4 +1,5 @@
 import { api } from "@scrollect/backend/convex/_generated/api";
+import { FILE_SIZE_LIMITS, formatFileSize } from "@scrollect/backend/convex/lib/fileSizeLimits";
 import { useMutation } from "convex/react";
 import { FileText, Loader2 } from "lucide-react";
 import { useCallback, useState } from "react";
@@ -33,6 +34,14 @@ export function UploadTextTab() {
       }
       if (!trimmedTitle) {
         toast.error("Please enter a title.");
+        return;
+      }
+
+      const textBytes = new Blob([trimmedText]).size;
+      if (textBytes > FILE_SIZE_LIMITS.text) {
+        toast.error(
+          `Text too large (${formatFileSize(textBytes)}). Maximum is ${formatFileSize(FILE_SIZE_LIMITS.text)}.`,
+        );
         return;
       }
 
@@ -92,7 +101,8 @@ export function UploadTextTab() {
           <div>
             <p className="text-lg font-semibold">Paste Text</p>
             <p className="mt-1 text-sm text-muted-foreground">
-              Paste any text to add it to your library.
+              Paste any text to add it to your library (max {formatFileSize(FILE_SIZE_LIMITS.text)}
+              ).
             </p>
           </div>
         </div>
@@ -131,7 +141,8 @@ export function UploadTextTab() {
           )}
           {text.trim() && (
             <p className="text-xs text-muted-foreground">
-              {text.trim().length.toLocaleString()} characters
+              {formatFileSize(new Blob([text.trim()]).size)} of{" "}
+              {formatFileSize(FILE_SIZE_LIMITS.text)}
             </p>
           )}
         </div>

--- a/packages/backend/convex/documents.ts
+++ b/packages/backend/convex/documents.ts
@@ -1,12 +1,40 @@
 import { ConvexError, v } from "convex/values";
 
 import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
 import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
+import { formatFileSize, getFileSizeLimit } from "./lib/fileSizeLimits";
 import { requireAuth, optionalAuth } from "./lib/functions";
 import { WideEvent } from "./lib/logging";
 import { rateLimiter } from "./lib/rateLimitConfig";
 import { documentStatus, failedAtStage, fileType, urlFileType } from "./lib/validators";
+
+async function enforceFileSizeLimit(
+  ctx: MutationCtx,
+  args: { storageId: Id<"_storage">; fileType: string; evt: WideEvent },
+) {
+  const limit = getFileSizeLimit(args.fileType);
+  if (!limit) {
+    throw new Error(`No file size limit configured for type: ${args.fileType}`);
+  }
+  const metadata = await ctx.db.system.get(args.storageId);
+  if (!metadata) return;
+  args.evt.set("fileSize", metadata.size);
+  if (metadata.size > limit) {
+    // Storage deletion is NOT transactional (persists even if mutation rolls back).
+    // This must be called BEFORE db.insert to avoid orphaned document rows.
+    await ctx.storage.delete(args.storageId);
+    args.evt.set({ fileTooLarge: true, maxSize: limit });
+    throw new ConvexError({
+      kind: "FileTooLarge" as const,
+      fileSize: metadata.size,
+      maxSize: limit,
+      maxSizeFormatted: formatFileSize(limit),
+      fileSizeFormatted: formatFileSize(metadata.size),
+    });
+  }
+}
 
 async function enforceDocumentUploadLimit(ctx: MutationCtx, userId: string, evt: WideEvent) {
   const { ok, retryAfter } = await rateLimiter.limit(ctx, "documentUpload", { key: userId });
@@ -41,6 +69,11 @@ export const create = mutation({
       const user = await requireAuth(ctx);
       evt.set("userId", user._id);
       await enforceDocumentUploadLimit(ctx, user._id, evt);
+      await enforceFileSizeLimit(ctx, {
+        storageId: args.storageId,
+        fileType: args.fileType,
+        evt,
+      });
       const documentId = await ctx.db.insert("documents", {
         title: args.title,
         fileType: args.fileType,
@@ -125,6 +158,11 @@ export const createFromText = mutation({
       const user = await requireAuth(ctx);
       evt.set("userId", user._id);
       await enforceDocumentUploadLimit(ctx, user._id, evt);
+      await enforceFileSizeLimit(ctx, {
+        storageId: args.storageId,
+        fileType: "text",
+        evt,
+      });
       const documentId = await ctx.db.insert("documents", {
         title: args.title,
         fileType: "text",

--- a/packages/backend/convex/lib/fileSizeLimits.ts
+++ b/packages/backend/convex/lib/fileSizeLimits.ts
@@ -1,0 +1,23 @@
+const MB = 1024 * 1024;
+
+export const FILE_SIZE_LIMITS = {
+  pdf: 50 * MB,
+  epub: 10 * MB,
+  md: 5 * MB,
+  text: 5 * MB,
+} as const;
+
+export type UploadFileType = keyof typeof FILE_SIZE_LIMITS;
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < MB) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / MB).toFixed(1)} MB`;
+}
+
+export function getFileSizeLimit(fileType: string): number | undefined {
+  if (fileType in FILE_SIZE_LIMITS) {
+    return FILE_SIZE_LIMITS[fileType as UploadFileType];
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- Enforce per-file-type upload size limits: PDF 50MB, EPUB 10MB, MD 5MB, Text 5MB
- Client-side validation rejects before upload begins (fast UX)
- Server-side validation in Convex mutations rejects and cleans up oversized storage (security boundary)
- Single source of truth: `fileSizeLimits.ts` imported by both backend and frontend

## Changes

### Backend (`packages/backend/convex/`)
- **`lib/fileSizeLimits.ts`** (new) - Centralized config with `FILE_SIZE_LIMITS`, `formatFileSize`, `getFileSizeLimit`
- **`documents.ts`** - `enforceFileSizeLimit` helper checks `ctx.db.system.get` metadata, deletes oversized files, throws `ConvexError({ kind: "FileTooLarge", fileSize, maxSize, ... })`

### Frontend (`apps/web/src/`)
- **`upload-file-tab.tsx`** - Client-side size + empty file check before upload, hint text shows per-format limits
- **`upload-text-tab.tsx`** - Client-side byte size check via `Blob`, hint text shows max, size progress indicator

Closes #93

## Test plan
- [ ] Upload a PDF > 50MB, verify client-side rejection with toast showing actual size and limit
- [ ] Upload an EPUB > 10MB, verify rejection
- [ ] Upload a .md > 5MB, verify rejection
- [ ] Paste text > 5MB in text tab, verify rejection before submission
- [ ] Upload an empty file, verify rejection with "File is empty" message
- [ ] Upload valid files within limits, verify normal flow works
- [ ] Verify hint text shows correct per-format limits
- [ ] Verify text tab shows byte usage progress
- [ ] Bypass client validation (curl), verify server-side rejection and storage cleanup