### PR TITLE
chore: nightly cleanup of Convex preview deployments

### DIFF
--- a/.github/workflows/cleanup-convex-previews.yml
+++ b/.github/workflows/cleanup-convex-previews.yml
@@ -1,0 +1,42 @@
+name: Cleanup Convex Preview Deployments
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # Daily at 2:00 AM UTC
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete all preview deployments
+        env:
+          CONVEX_ACCESS_TOKEN: ${{ secrets.CONVEX_ACCESS_TOKEN }}
+          CONVEX_PROJECT_ID: "1771561"
+        run: |
+          DEPLOYMENTS=$(curl -sf \
+            "https://api.convex.dev/v1/projects/${CONVEX_PROJECT_ID}/list_deployments?deploymentType=preview" \
+            -H "Authorization: Bearer ${CONVEX_ACCESS_TOKEN}")
+
+          COUNT=$(echo "$DEPLOYMENTS" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+          echo "Found $COUNT preview deployments"
+
+          if [ "$COUNT" = "0" ]; then
+            echo "Nothing to clean up"
+            exit 0
+          fi
+
+          echo "$DEPLOYMENTS" | python3 -c "import json,sys;[print(d['name']) for d in json.load(sys.stdin)]" | \
+            while IFS= read -r name; do
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                -X POST "https://api.convex.dev/v1/deployments/${name}/delete" \
+                -H "Authorization: Bearer ${CONVEX_ACCESS_TOKEN}" \
+                -H "Content-Type: application/json")
+              if [ "$STATUS" = "200" ]; then
+                echo "Deleted: $name"
+              else
+                echo "::warning::Failed to delete $name (HTTP $STATUS)"
+              fi
+            done
+
+          echo "Cleanup complete"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that deletes all Convex preview deployments daily at 2 AM UTC
- E2E test runs create preview deployments that pile up (31 were cleaned up manually today)
- Can also be triggered manually via workflow_dispatch

## Setup
- `CONVEX_ACCESS_TOKEN` secret has been added to the repo

## Test plan
- [x] Verified the Management API works by deleting 31 preview deployments manually
- [ ] Trigger the workflow manually from the Actions tab to confirm it runs end-to-end