### PR TITLE
fix: remove runAll runner until first migration is defined

### DIFF
--- a/docs/adr/010-deployment-pipeline.md
+++ b/docs/adr/010-deployment-pipeline.md
@@ -20,14 +20,14 @@ Today there is no production deployment workflow. The CI pipeline (`.github/work
 Use Convex's official Vercel integration. Override Vercel's build command to:
 
 ```
-npx convex deploy --cmd 'npx convex run migrations:runAll && npm run build'
+npx convex deploy --cmd 'npm run build'
 ```
 
 This command:
 
 1. Reads the `CONVEX_DEPLOY_KEY` environment variable
 2. Pushes Convex functions + schema to the target deployment
-3. Runs the provided `--cmd`: first executes pending migrations, then builds the web app
+3. Runs the provided `--cmd` to build the web app
 
 This guarantees ordering - Convex functions are live before the web app builds against them. No separate GitHub Actions deploy workflow needed.
 
@@ -57,7 +57,13 @@ When Vercel builds a production deploy (merge to `main`), it uses the production
 
 Adopt the `@convex-dev/migrations` component for automated, stateful data backfills. Register in `convex/convex.config.ts`, define all migrations in `convex/migrations.ts`.
 
-Migrations run as part of the Vercel build command (see section 1) - after `convex deploy` succeeds and before the web app builds. This ensures backfilled data is available when the new frontend goes live.
+When the first migration is defined, update the Vercel build command to run migrations between Convex deploy and the web app build:
+
+```
+npx convex deploy --cmd 'npx convex run migrations:runAll && npm run build'
+```
+
+This ensures backfilled data is available when the new frontend goes live.
 
 **Two-phase schema change pattern** (Convex's fundamental constraint):
 

--- a/packages/backend/convex/migrations.ts
+++ b/packages/backend/convex/migrations.ts
@@ -3,4 +3,8 @@ import { components } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
 
 export const migrations = new Migrations<DataModel>(components.migrations);
-export const runAll = migrations.runner();
+
+// Add migrations here as they are defined, then pass them to the runner:
+// export const runAll = migrations.runner([
+//   internal.migrations.myFirstMigration,
+// ]);


### PR DESCRIPTION
## Summary

- Comment out the `runAll` runner export in `migrations.ts` - the `@convex-dev/migrations` runner requires at least one migration function reference, and errors when called with none
- Update ADR-010 build command to `npx convex deploy --cmd 'npm run build'` (no migration step until first migration exists)
- Add note in ADR to update the build command when the first migration is defined

## Test plan

- [ ] Verify `npx convex dev --once` succeeds with the updated migrations.ts
- [ ] Verify Vercel build command `npx convex deploy --cmd 'npm run build'` works without migration step