### PR TITLE
feat(#142): prompt eval framework with quality scoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,36 @@ jobs:
       - name: Run tests
         run: bun turbo run test
 
+  eval:
+    name: Prompt Evals
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'eval')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run prompt evals
+        working-directory: packages/backend
+        run: bunx evalite
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Upload eval results
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: evalite-results
+          path: packages/backend/.evalite/
+          retention-days: 30
+
   deploy-preview:
     name: Deploy Convex Preview
     runs-on: ubuntu-latest

--- a/bun.lock
+++ b/bun.lock
@@ -126,6 +126,7 @@
       "devDependencies": {
         "@scrollect/config": "workspace:*",
         "@types/node": "^24.3.0",
+        "evalite": "^1.0.0-beta.16",
         "typescript": "catalog:",
         "vitest": "^4.1.0",
       },
@@ -269,6 +270,8 @@
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
@@ -383,6 +386,26 @@
 
     "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.41.7", "", { "dependencies": { "@expressive-code/core": "^0.41.7" } }, "sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw=="],
 
+    "@fastify/accept-negotiator": ["@fastify/accept-negotiator@2.0.1", "", {}, "sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ=="],
+
+    "@fastify/ajv-compiler": ["@fastify/ajv-compiler@4.0.5", "", { "dependencies": { "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0" } }, "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A=="],
+
+    "@fastify/error": ["@fastify/error@4.2.0", "", {}, "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ=="],
+
+    "@fastify/fast-json-stringify-compiler": ["@fastify/fast-json-stringify-compiler@5.0.3", "", { "dependencies": { "fast-json-stringify": "^6.0.0" } }, "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ=="],
+
+    "@fastify/forwarded": ["@fastify/forwarded@3.0.1", "", {}, "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw=="],
+
+    "@fastify/merge-json-schemas": ["@fastify/merge-json-schemas@0.2.1", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A=="],
+
+    "@fastify/proxy-addr": ["@fastify/proxy-addr@5.1.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw=="],
+
+    "@fastify/send": ["@fastify/send@4.1.0", "", { "dependencies": { "@lukeed/ms": "^2.0.2", "escape-html": "~1.0.3", "fast-decode-uri-component": "^1.0.1", "http-errors": "^2.0.0", "mime": "^3" } }, "sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw=="],
+
+    "@fastify/static": ["@fastify/static@8.3.0", "", { "dependencies": { "@fastify/accept-negotiator": "^2.0.0", "@fastify/send": "^4.0.0", "content-disposition": "^0.5.4", "fastify-plugin": "^5.0.0", "fastq": "^1.17.1", "glob": "^11.0.0" } }, "sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA=="],
+
+    "@fastify/websocket": ["@fastify/websocket@11.2.0", "", { "dependencies": { "duplexify": "^4.1.3", "fastify-plugin": "^5.0.0", "ws": "^8.16.0" } }, "sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w=="],
+
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
     "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
@@ -471,6 +494,8 @@
 
     "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
 
+    "@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -488,6 +513,8 @@
     "@lillallol/outline-pdf": ["@lillallol/outline-pdf@4.0.0", "", { "dependencies": { "@lillallol/outline-pdf-data-structure": "^1.0.3", "pdf-lib": "^1.16.0" } }, "sha512-tILGNyOdI3ukZfU19TNTDVoS0W1nSPlMxCKAm9FPV4OPL786Ur7e1CRLQZWKJP6uaMQsUqSDBCTzISs6lXWdAQ=="],
 
     "@lillallol/outline-pdf-data-structure": ["@lillallol/outline-pdf-data-structure@1.0.3", "", {}, "sha512-XlK9dERP2n9afkJ23JyJzpmesLgiOHmhqKuGgeytnT+IVGFdAsYl1wLr2o+byXNAN5fveNbc7CCI6RfBsd5FCw=="],
+
+    "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
 
     "@mdit-vue/plugin-component": ["@mdit-vue/plugin-component@3.0.2", "", { "dependencies": { "@types/markdown-it": "^14.1.2", "markdown-it": "^14.1.0" } }, "sha512-Fu53MajrZMOAjOIPGMTdTXgHLgGU9KwTqKtYc6WNYtFZNKw04euSfJ/zFg8eBY/2MlciVngkF7Gyc2IL7e8Bsw=="],
 
@@ -775,6 +802,8 @@
 
     "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
 
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
     "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
@@ -955,6 +984,10 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@stricli/auto-complete": ["@stricli/auto-complete@1.2.6", "", { "dependencies": { "@stricli/core": "^1.2.6" }, "bin": { "auto-complete": "dist/bin/cli.js" } }, "sha512-H7dectwnLBoyDrp4Vek1gTNdUWzqkEDt5X6oFoOPxPVbca5FA9ttBZ/OlfNvt14aeiZUsg1rC7GEHjIh3tjn2A=="],
+
+    "@stricli/core": ["@stricli/core@1.2.6", "", {}, "sha512-j5fa1wyOLrP9WJqqLFEJeQviqb3cK46K+FXTuISEkG/H5C820YfKDoVQ3CDVdM5WLhEx1ARdpiW6+hU4tYHjCQ=="],
+
     "@supadata/js": ["@supadata/js@1.4.0", "", { "dependencies": { "cross-fetch": "^4.0.0" } }, "sha512-DzKwwXApb58bAMv6PzW+kbRGMOffNfxBlN4B7eLJ/boFhylmlj6zI9fXlMKFIPt+vnPpJXGCk7OaguaosTYdYA=="],
 
     "@svgr/babel-plugin-add-jsx-attribute": ["@svgr/babel-plugin-add-jsx-attribute@8.0.0", "", { "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g=="],
@@ -1066,6 +1099,8 @@
     "@tanstack/store": ["@tanstack/store@0.9.2", "", {}, "sha512-K013lUJEFJK2ofFQ/hZKJUmCnpcV00ebLyOyFOWQvyQHUOZp/iYO84BM6aOGiV81JzwbX0APTVmW8YI7yiG5oA=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
@@ -1327,6 +1362,8 @@
 
     "@vueuse/shared": ["@vueuse/shared@14.2.1", "", { "peerDependencies": { "vue": "^3.5.0" } }, "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw=="],
 
+    "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -1345,9 +1382,9 @@
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
 
@@ -1373,6 +1410,8 @@
 
     "ast-walker-scope": ["ast-walker-scope@0.8.3", "", { "dependencies": { "@babel/parser": "^7.28.4", "ast-kit": "^2.1.3" } }, "sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg=="],
 
+    "astral-regex": ["astral-regex@2.0.0", "", {}, "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="],
+
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
     "astro": ["astro@5.18.1", "", { "dependencies": { "@astrojs/compiler": "^2.13.0", "@astrojs/internal-helpers": "0.7.6", "@astrojs/markdown-remark": "6.3.11", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^4.0.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "acorn": "^8.15.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.3.1", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^1.1.1", "cssesc": "^3.0.0", "debug": "^4.4.3", "deterministic-object-hash": "^2.0.2", "devalue": "^5.6.2", "diff": "^8.0.3", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.27.3", "estree-walker": "^3.0.3", "flattie": "^1.1.1", "fontace": "~0.4.0", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.1", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "p-limit": "^6.2.0", "p-queue": "^8.1.1", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.7.3", "shiki": "^3.21.0", "smol-toml": "^1.6.0", "svgo": "^4.0.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.3", "unist-util-visit": "^5.0.0", "unstorage": "^1.17.4", "vfile": "^6.0.3", "vite": "^6.4.1", "vitefu": "^1.1.1", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "yocto-spinner": "^0.2.3", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "astro.js" } }, "sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g=="],
@@ -1380,6 +1419,10 @@
     "astro-expressive-code": ["astro-expressive-code@0.41.7", "", { "dependencies": { "rehype-expressive-code": "^0.41.7" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta" } }, "sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "avvio": ["avvio@9.2.0", "", { "dependencies": { "@fastify/error": "^4.0.0", "fastq": "^1.17.1" } }, "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ=="],
 
     "axios": ["axios@1.13.6", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ=="],
 
@@ -1517,7 +1560,7 @@
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
-    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+    "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
@@ -1719,17 +1762,21 @@
 
     "duplexer": ["duplexer@0.1.2", "", {}, "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="],
 
+    "duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
+
     "eciesjs": ["eciesjs@0.4.18", "", { "dependencies": { "@ecies/ciphers": "^0.2.5", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.8.0" } }, "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.321", "", {}, "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
 
     "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
@@ -1785,6 +1832,8 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
+    "evalite": ["evalite@1.0.0-beta.16", "", { "dependencies": { "@fastify/static": "^8.2.0", "@fastify/websocket": "11.2.0", "@stricli/auto-complete": "^1.2.0", "@stricli/core": "^1.2.0", "@vitest/runner": "^4.0.0", "@vitest/utils": "^4.0.1", "dotenv": "^16.4.7", "fastify": "^5.6.1", "file-type": "^19.6.0", "get-port": "^7.1.0", "jiti": "^2.6.1", "js-levenshtein": "^1.1.6", "table": "^6.9.0", "tinyrainbow": "^3.0.3" }, "peerDependencies": { "ai": "^6", "better-sqlite3": "^11.6.0" }, "optionalPeers": ["ai", "better-sqlite3"], "bin": { "evalite": "dist/bin.js" } }, "sha512-14G+Y1Rqi9xOJck1vykPwaRSPSPpSvaklMS9WjJA04KWIOUwrT3jHUyA/6GkMC0twi1vdkssGS5FstNtVqVCWQ=="],
+
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
@@ -1807,11 +1856,21 @@
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
+    "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
+    "fast-json-stringify": ["fast-json-stringify@6.3.0", "", { "dependencies": { "@fastify/merge-json-schemas": "^0.2.0", "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0", "json-schema-ref-resolver": "^3.0.0", "rfdc": "^1.2.0" } }, "sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA=="],
+
+    "fast-querystring": ["fast-querystring@1.1.2", "", { "dependencies": { "fast-decode-uri-component": "^1.0.1" } }, "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fastify": ["fastify@5.8.4", "", { "dependencies": { "@fastify/ajv-compiler": "^4.0.5", "@fastify/error": "^4.0.0", "@fastify/fast-json-stringify-compiler": "^5.0.0", "@fastify/proxy-addr": "^5.0.0", "abstract-logging": "^2.0.1", "avvio": "^9.0.0", "fast-json-stringify": "^6.0.0", "find-my-way": "^9.0.0", "light-my-request": "^6.0.0", "pino": "^9.14.0 || ^10.1.0", "process-warning": "^5.0.0", "rfdc": "^1.3.1", "secure-json-parse": "^4.0.0", "semver": "^7.6.0", "toad-cache": "^3.7.0" } }, "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ=="],
+
+    "fastify-plugin": ["fastify-plugin@5.1.0", "", {}, "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -1825,9 +1884,13 @@
 
     "file-saver": ["file-saver@2.0.5", "", {}, "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="],
 
+    "file-type": ["file-type@19.6.0", "", { "dependencies": { "get-stream": "^9.0.1", "strtok3": "^9.0.1", "token-types": "^6.0.0", "uint8array-extras": "^1.3.0" } }, "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
+
+    "find-my-way": ["find-my-way@9.5.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-querystring": "^1.0.0", "safe-regex2": "^5.0.0" } }, "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ=="],
 
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
 
@@ -1838,6 +1901,8 @@
     "fontace": ["fontace@0.4.1", "", { "dependencies": { "fontkitten": "^1.0.2" } }, "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw=="],
 
     "fontkitten": ["fontkitten@1.0.3", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
@@ -1875,6 +1940,8 @@
 
     "get-own-enumerable-keys": ["get-own-enumerable-keys@1.0.0", "", {}, "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA=="],
 
+    "get-port": ["get-port@7.2.0", "", {}, "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg=="],
+
     "get-port-please": ["get-port-please@3.2.0", "", {}, "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
@@ -1886,6 +1953,8 @@
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
+
+    "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -1989,6 +2058,8 @@
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": { "image-size": "bin/image-size.js" } }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
@@ -2011,7 +2082,7 @@
 
     "ip-regex": ["ip-regex@5.0.0", "", {}, "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="],
 
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+    "ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
 
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
 
@@ -2075,9 +2146,13 @@
 
     "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
+    "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -2090,6 +2165,8 @@
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
+
+    "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -2143,6 +2220,8 @@
 
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
+    "light-my-request": ["light-my-request@6.6.0", "", { "dependencies": { "cookie": "^1.0.1", "process-warning": "^4.0.0", "set-cookie-parser": "^2.6.0" } }, "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A=="],
+
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
@@ -2174,6 +2253,8 @@
     "local-pkg": ["local-pkg@1.1.2", "", { "dependencies": { "mlly": "^1.7.4", "pkg-types": "^2.3.0", "quansync": "^0.2.11" } }, "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A=="],
 
     "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
+
+    "lodash.truncate": ["lodash.truncate@4.4.2", "", {}, "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="],
 
     "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
 
@@ -2337,6 +2418,8 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -2348,6 +2431,8 @@
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
@@ -2413,6 +2498,8 @@
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
     "on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -2449,6 +2536,8 @@
 
     "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
     "pagefind": ["pagefind@1.4.0", "", { "optionalDependencies": { "@pagefind/darwin-arm64": "1.4.0", "@pagefind/darwin-x64": "1.4.0", "@pagefind/freebsd-x64": "1.4.0", "@pagefind/linux-arm64": "1.4.0", "@pagefind/linux-x64": "1.4.0", "@pagefind/windows-x64": "1.4.0" }, "bin": { "pagefind": "lib/runner/bin.cjs" } }, "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g=="],
@@ -2479,6 +2568,8 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
@@ -2487,6 +2578,8 @@
 
     "pdf-lib": ["pdf-lib@1.17.1", "", { "dependencies": { "@pdf-lib/standard-fonts": "^1.0.0", "@pdf-lib/upng": "^1.0.1", "pako": "^1.0.11", "tslib": "^1.11.1" } }, "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw=="],
 
+    "peek-readable": ["peek-readable@5.4.2", "", {}, "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg=="],
+
     "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
 
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
@@ -2494,6 +2587,12 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
@@ -2537,6 +2636,8 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
@@ -2567,6 +2668,8 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
     "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
@@ -2589,9 +2692,11 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
-    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
@@ -2659,6 +2764,8 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
+    "ret": ["ret@0.5.0", "", {}, "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw=="],
+
     "retext": ["retext@9.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "retext-latin": "^4.0.0", "retext-stringify": "^4.0.0", "unified": "^11.0.0" } }, "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA=="],
 
     "retext-latin": ["retext-latin@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "parse-latin": "^7.0.0", "unified": "^11.0.0" } }, "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA=="],
@@ -2670,6 +2777,8 @@
     "rettime": ["rettime@0.10.1", "", {}, "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
 
@@ -2687,7 +2796,11 @@
 
     "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
-    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-regex2": ["safe-regex2@5.1.0", "", { "dependencies": { "ret": "~0.5.0" }, "bin": { "safe-regex2": "bin/safe-regex2.js" } }, "sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -2700,6 +2813,8 @@
     "scule": ["scule@1.3.0", "", {}, "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -2747,9 +2862,13 @@
 
     "sitemap": ["sitemap@9.0.1", "", { "dependencies": { "@types/node": "^24.9.2", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/esm/cli.js" } }, "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ=="],
 
+    "slice-ansi": ["slice-ansi@4.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ=="],
+
     "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
 
     "snake-case": ["snake-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg=="],
+
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
 
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
@@ -2758,6 +2877,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
@@ -2773,9 +2894,11 @@
 
     "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
+    "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
+
     "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
@@ -2783,13 +2906,15 @@
 
     "stringify-object": ["stringify-object@5.0.0", "", { "dependencies": { "get-own-enumerable-keys": "^1.0.0", "is-obj": "^3.0.0", "is-regexp": "^3.1.0" } }, "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg=="],
 
-    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
+
+    "strtok3": ["strtok3@9.1.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^5.3.1" } }, "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw=="],
 
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
@@ -2809,6 +2934,8 @@
 
     "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
+    "table": ["table@6.9.0", "", { "dependencies": { "ajv": "^8.0.1", "lodash.truncate": "^4.4.2", "slice-ansi": "^4.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1" } }, "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A=="],
+
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
@@ -2816,6 +2943,8 @@
     "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+
+    "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 
     "time-span": ["time-span@5.1.0", "", { "dependencies": { "convert-hrtime": "^5.0.0" } }, "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA=="],
 
@@ -2839,7 +2968,11 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
+
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
@@ -2886,6 +3019,8 @@
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
 
@@ -3255,8 +3390,6 @@
 
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "aria-hidden/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -3275,13 +3408,17 @@
 
     "body-parser/on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
+    "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
     "c12/rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
 
     "cheerio/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "cheerio/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
-    "cli-progress/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -3310,6 +3447,10 @@
     "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "evalite/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
+    "express/content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -3347,7 +3488,11 @@
 
     "is-installed-globally/global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
+    "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
@@ -3375,6 +3520,10 @@
 
     "nypm/citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
 
+    "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "ora/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
@@ -3392,6 +3541,8 @@
     "pptxgenjs/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "pvtsutils/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -3424,6 +3575,8 @@
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "snake-case/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "style-value-types/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
 
@@ -3459,6 +3612,16 @@
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
     "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
@@ -3474,12 +3637,6 @@
     "@dotenvx/dotenvx/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
     "@expressive-code/core/postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
-
-    "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@scrollect/web/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -3549,10 +3706,6 @@
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "astro/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
 
     "astro/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
@@ -3607,11 +3760,15 @@
 
     "astro/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
+    "boxen/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "boxen/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
     "cheerio/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "cli-progress/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "cliui/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
-    "cli-progress/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -3639,11 +3796,15 @@
 
     "is-installed-globally/global-directory/ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
 
+    "jszip/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "msw/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
-    "msw/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "ora/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "parse5-htmlparser2-tree-adapter/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -3769,13 +3930,19 @@
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
 
-    "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "widest-line/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
-    "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "widest-line/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "astro/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -3829,26 +3996,18 @@
 
     "astro/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
-    "cli-progress/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "boxen/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "cross-fetch/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "cross-fetch/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
-    "msw/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "msw/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "msw/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "msw/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "vite-plugin-static-copy/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "msw/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "msw/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "msw/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
   }
 }

--- a/packages/backend/convex/pipeline/evals/cardDraft.eval.ts
+++ b/packages/backend/convex/pipeline/evals/cardDraft.eval.ts
@@ -1,0 +1,73 @@
+import { evalite } from "evalite";
+
+import { AiSdkCardDraftLlm } from "../../providers/cardDraftLlm";
+import type { DraftCardType } from "../../lib/validators";
+import { ALL_FIXTURES } from "./fixtures";
+import {
+  structuralValidity,
+  languageMatch,
+  contentSpecificity,
+  typeSpecificQuality,
+} from "./scorers";
+
+type CardDraftInput = {
+  cardType: DraftCardType;
+  sectionTitle: string;
+  sectionSummary: string;
+  chunks: Array<{ content: string; chunkId: string }>;
+  documentTitle: string;
+  expectedLanguage: "en" | "pl";
+};
+
+type CardDraftOutput = {
+  cardType: DraftCardType;
+  content: string;
+  typeData: Record<string, unknown>;
+  sourceChunks: string[];
+  expectedLanguage: "en" | "pl";
+};
+
+const llm = new AiSdkCardDraftLlm();
+
+function buildSectionInputs(): Omit<CardDraftInput, "cardType">[] {
+  return ALL_FIXTURES.flatMap((doc) =>
+    doc.sections.map((section) => ({
+      sectionTitle: section.sectionTitle,
+      sectionSummary: section.sectionSummary,
+      chunks: section.chunks,
+      documentTitle: doc.title,
+      expectedLanguage: doc.language,
+    })),
+  );
+}
+
+evalite.each([
+  { name: "insight", input: "insight" as DraftCardType },
+  { name: "quiz", input: "quiz" as DraftCardType },
+  { name: "quote", input: "quote" as DraftCardType },
+  { name: "summary", input: "summary" as DraftCardType },
+])("Section Draft: $name", {
+  data: () =>
+    buildSectionInputs().map((s) => ({
+      input: { ...s, cardType: "insight" as DraftCardType },
+    })),
+  task: async (input, cardType) => {
+    const { card } = await llm.generateDraft({
+      cardType,
+      sectionSummary: input.sectionSummary,
+      sectionTitle: input.sectionTitle,
+      chunks: input.chunks,
+      documentTitle: input.documentTitle,
+    });
+
+    return {
+      cardType,
+      content: card.content,
+      typeData: card.typeData,
+      sourceChunks: input.chunks.map((c) => c.content),
+      expectedLanguage: input.expectedLanguage,
+    } satisfies CardDraftOutput;
+  },
+  scorers: [structuralValidity, languageMatch, contentSpecificity, typeSpecificQuality],
+  trialCount: 3,
+});

--- a/packages/backend/convex/pipeline/evals/connectionDiscovery.eval.ts
+++ b/packages/backend/convex/pipeline/evals/connectionDiscovery.eval.ts
@@ -1,0 +1,145 @@
+import { evalite } from "evalite";
+
+import { AiSdkConnectionDiscoveryLlm } from "../../providers/connectionDiscoveryLlm";
+import {
+  BOOK_EN_LEARNING,
+  ARTICLE_EN_ARCHITECTURE,
+  YOUTUBE_EN_ML,
+  BOOK_PL_LEWANDOWSKI,
+} from "./fixtures";
+import type { FixtureDocument, FixtureSection } from "./fixtures";
+import { contentSpecificity, languageMatch, connectionGenuineness } from "./scorers";
+
+type ConnectionInput = {
+  sectionATitle: string;
+  sectionASummary: string;
+  sectionAChunks: Array<{ content: string; chunkId: string }>;
+  sectionBTitle: string;
+  sectionBSummary: string;
+  sectionBChunks: Array<{ content: string; chunkId: string }>;
+  documentATitle: string;
+  documentBTitle: string;
+  expectedLanguage: "en" | "pl";
+};
+
+type ConnectionOutput = {
+  content: string;
+  typeData: Record<string, unknown>;
+  sourceChunks: string[];
+  isGenuineConnection: boolean;
+  expectedLanguage: "en" | "pl";
+  sectionATitle: string;
+  sectionASummary: string;
+  sectionBTitle: string;
+  sectionBSummary: string;
+};
+
+const llm = new AiSdkConnectionDiscoveryLlm();
+
+function makePair(opts: {
+  docA: FixtureDocument;
+  sectionA: FixtureSection;
+  docB: FixtureDocument;
+  sectionB: FixtureSection;
+}): ConnectionInput {
+  const language = opts.docA.language === opts.docB.language ? opts.docA.language : "en";
+  return {
+    sectionATitle: opts.sectionA.sectionTitle,
+    sectionASummary: opts.sectionA.sectionSummary,
+    sectionAChunks: opts.sectionA.chunks,
+    sectionBTitle: opts.sectionB.sectionTitle,
+    sectionBSummary: opts.sectionB.sectionSummary,
+    sectionBChunks: opts.sectionB.chunks,
+    documentATitle: opts.docA.title,
+    documentBTitle: opts.docB.title,
+    expectedLanguage: language,
+  };
+}
+
+function buildConnectionData(): ConnectionInput[] {
+  return [
+    makePair({
+      docA: BOOK_EN_LEARNING,
+      sectionA: BOOK_EN_LEARNING.sections[0]!,
+      docB: YOUTUBE_EN_ML,
+      sectionB: YOUTUBE_EN_ML.sections[3]!,
+    }),
+    makePair({
+      docA: BOOK_EN_LEARNING,
+      sectionA: BOOK_EN_LEARNING.sections[1]!,
+      docB: YOUTUBE_EN_ML,
+      sectionB: YOUTUBE_EN_ML.sections[1]!,
+    }),
+    makePair({
+      docA: ARTICLE_EN_ARCHITECTURE,
+      sectionA: ARTICLE_EN_ARCHITECTURE.sections[1]!,
+      docB: ARTICLE_EN_ARCHITECTURE,
+      sectionB: ARTICLE_EN_ARCHITECTURE.sections[2]!,
+    }),
+    makePair({
+      docA: BOOK_EN_LEARNING,
+      sectionA: BOOK_EN_LEARNING.sections[2]!,
+      docB: ARTICLE_EN_ARCHITECTURE,
+      sectionB: ARTICLE_EN_ARCHITECTURE.sections[0]!,
+    }),
+    makePair({
+      docA: BOOK_PL_LEWANDOWSKI,
+      sectionA: BOOK_PL_LEWANDOWSKI.sections[2]!,
+      docB: BOOK_PL_LEWANDOWSKI,
+      sectionB: BOOK_PL_LEWANDOWSKI.sections[3]!,
+    }),
+  ];
+}
+
+evalite("Connection Discovery", {
+  data: () => buildConnectionData().map((d) => ({ input: d })),
+  task: async (input) => {
+    const { card } = await llm.generateConnectionDraft({
+      sectionA: {
+        title: input.sectionATitle,
+        summary: input.sectionASummary,
+        chunks: input.sectionAChunks,
+      },
+      sectionB: {
+        title: input.sectionBTitle,
+        summary: input.sectionBSummary,
+        chunks: input.sectionBChunks,
+      },
+      documentATitle: input.documentATitle,
+      documentBTitle: input.documentBTitle,
+    });
+
+    const allChunks = [
+      ...input.sectionAChunks.map((c) => c.content),
+      ...input.sectionBChunks.map((c) => c.content),
+    ];
+
+    if (!card) {
+      return {
+        content: "",
+        typeData: {},
+        sourceChunks: allChunks,
+        isGenuineConnection: false,
+        expectedLanguage: input.expectedLanguage,
+        sectionATitle: input.sectionATitle,
+        sectionASummary: input.sectionASummary,
+        sectionBTitle: input.sectionBTitle,
+        sectionBSummary: input.sectionBSummary,
+      } satisfies ConnectionOutput;
+    }
+
+    return {
+      content: card.content,
+      typeData: card.typeData,
+      sourceChunks: allChunks,
+      isGenuineConnection: true,
+      expectedLanguage: input.expectedLanguage,
+      sectionATitle: input.sectionATitle,
+      sectionASummary: input.sectionASummary,
+      sectionBTitle: input.sectionBTitle,
+      sectionBSummary: input.sectionBSummary,
+    } satisfies ConnectionOutput;
+  },
+  scorers: [contentSpecificity, languageMatch, connectionGenuineness],
+  trialCount: 3,
+});

--- a/packages/backend/convex/pipeline/evals/fixtures/article-en-architecture.ts
+++ b/packages/backend/convex/pipeline/evals/fixtures/article-en-architecture.ts
@@ -1,0 +1,59 @@
+import type { FixtureDocument } from "./types";
+
+export const ARTICLE_EN_ARCHITECTURE: FixtureDocument = {
+  title: "Understanding Software Architecture Patterns",
+  language: "en",
+  sections: [
+    {
+      sectionTitle: "Layered Architecture",
+      sectionSummary:
+        "The layered architecture organizes code into horizontal layers (presentation, business logic, data access). Each layer only communicates with the layer below, enforcing separation of concerns. Works well for enterprise apps but can lead to the sinkhole anti-pattern.",
+      chunks: [
+        {
+          content:
+            "The layered architecture pattern organizes code into horizontal layers, each with a specific responsibility. The most common layers are presentation, business logic, and data access. Each layer only communicates with the layer directly below it, which enforces separation of concerns and makes the system easier to test and maintain.",
+          chunkId: "article-en-arch-chunk-0",
+        },
+        {
+          content:
+            'This pattern works well for traditional enterprise applications where the domain is well-understood and the team structure maps cleanly to the layers. However, it can lead to the "sinkhole anti-pattern" where requests pass through multiple layers without any meaningful transformation.',
+          chunkId: "article-en-arch-chunk-1",
+        },
+      ],
+    },
+    {
+      sectionTitle: "Event-Driven Architecture",
+      sectionSummary:
+        "Event-driven architecture uses events for communication between decoupled services. Message brokers like Kafka or RabbitMQ provide durability, ordering, and backpressure. Event sourcing stores every state change as an immutable event.",
+      chunks: [
+        {
+          content:
+            "Event-driven architecture uses events to trigger and communicate between decoupled services. Producers emit events without knowing who will consume them, and consumers react to events without knowing who produced them. This loose coupling makes it easier to add new features without modifying existing code.",
+          chunkId: "article-en-arch-chunk-2",
+        },
+        {
+          content:
+            "Message brokers like Kafka or RabbitMQ sit between producers and consumers, providing durability, ordering guarantees, and backpressure handling. Event sourcing takes this further by storing every state change as an immutable event, enabling full audit trails and temporal queries.",
+          chunkId: "article-en-arch-chunk-3",
+        },
+      ],
+    },
+    {
+      sectionTitle: "Microservices",
+      sectionSummary:
+        "Microservices decompose systems into independently deployable services with their own data stores. Conway's Law means microservices work best when team boundaries align with service boundaries. Requires distributed tracing, service discovery, and circuit breakers.",
+      chunks: [
+        {
+          content:
+            "Microservices decompose a system into small, independently deployable services, each owning its own data store. Teams can choose different technologies for different services and deploy them on independent schedules. This autonomy comes at the cost of operational complexity: distributed tracing, service discovery, and circuit breakers become essential infrastructure.",
+          chunkId: "article-en-arch-chunk-4",
+        },
+        {
+          content:
+            "The key insight is that microservices are an organizational pattern, not just a technical one. Conway's Law tells us that system architecture mirrors communication structures, so microservices work best when team boundaries align with service boundaries.",
+          chunkId: "article-en-arch-chunk-5",
+        },
+      ],
+    },
+  ],
+};

--- a/packages/backend/convex/pipeline/evals/fixtures/book-en-learning.ts
+++ b/packages/backend/convex/pipeline/evals/fixtures/book-en-learning.ts
@@ -1,0 +1,73 @@
+import type { FixtureDocument } from "./types";
+
+export const BOOK_EN_LEARNING: FixtureDocument = {
+  title: "The Art of Effective Learning",
+  language: "en",
+  sections: [
+    {
+      sectionTitle: "Spaced Repetition",
+      sectionSummary:
+        "Spaced repetition exploits the spacing effect by reviewing information at gradually increasing intervals (1, 3, 7, 21 days). This technique forms stronger memories than cramming by spreading exposure over time.",
+      chunks: [
+        {
+          content:
+            "Spaced repetition is a learning technique that involves reviewing information at gradually increasing intervals. Instead of cramming all at once, you space out your practice sessions over days, weeks, and months. This approach exploits the spacing effect, a phenomenon where our brains form stronger memories when exposure to information is spread out over time rather than concentrated in a single session.",
+          chunkId: "book-en-learning-chunk-0",
+        },
+        {
+          content:
+            "The optimal spacing schedule depends on the complexity of the material and the desired retention period. For simple facts, a schedule of 1 day, 3 days, 7 days, and 21 days works well. For complex concepts, shorter intervals with more repetitions may be needed.",
+          chunkId: "book-en-learning-chunk-1",
+        },
+      ],
+      highlights: [
+        {
+          highlightId: "book-en-learning-highlight-0",
+          highlightText:
+            "our brains form stronger memories when exposure to information is spread out over time rather than concentrated in a single session",
+        },
+        {
+          highlightId: "book-en-learning-highlight-1",
+          highlightText:
+            "For simple facts, a schedule of 1 day, 3 days, 7 days, and 21 days works well",
+        },
+      ],
+    },
+    {
+      sectionTitle: "Active Recall",
+      sectionSummary:
+        "Active recall strengthens memory by forcing retrieval during learning. Research by Karpicke and Roediger showed 80% better retention vs re-reading. Known as the testing effect, it is one of the most robust findings in cognitive psychology.",
+      chunks: [
+        {
+          content:
+            "Active recall is the practice of actively stimulating memory during the learning process. Rather than passively reviewing notes, you close the book and try to recall the key points from memory. This forces your brain to strengthen the neural pathways associated with the information, making it easier to retrieve later.",
+          chunkId: "book-en-learning-chunk-2",
+        },
+        {
+          content:
+            "Research by Karpicke and Roediger demonstrated that students who practiced active recall retained 80% more information than those who simply re-read the material. The testing effect, as it is known, is one of the most robust findings in cognitive psychology.",
+          chunkId: "book-en-learning-chunk-3",
+        },
+      ],
+      highlights: [
+        {
+          highlightId: "book-en-learning-highlight-2",
+          highlightText:
+            "students who practiced active recall retained 80% more information than those who simply re-read the material",
+        },
+      ],
+    },
+    {
+      sectionTitle: "Interleaving",
+      sectionSummary:
+        "Interleaving mixes different topics during study sessions. While blocked practice feels easier, interleaving leads to better long-term retention by forcing continuous strategy retrieval and comparison.",
+      chunks: [
+        {
+          content:
+            "Interleaving involves mixing different topics or types of problems during a single study session. While blocked practice, focusing on one topic at a time, feels easier, interleaving leads to better long-term retention and the ability to discriminate between different concepts. This is because interleaving forces the brain to continuously retrieve different strategies and compare them.",
+          chunkId: "book-en-learning-chunk-4",
+        },
+      ],
+    },
+  ],
+};

--- a/packages/backend/convex/pipeline/evals/fixtures/book-pl-lewandowski.ts
+++ b/packages/backend/convex/pipeline/evals/fixtures/book-pl-lewandowski.ts
@@ -1,0 +1,124 @@
+import type { FixtureDocument } from "./types";
+
+export const BOOK_PL_LEWANDOWSKI: FixtureDocument = {
+  title: "Lewandowski. Prawdziwy",
+  language: "pl",
+  sections: [
+    {
+      sectionTitle: "Wstep",
+      sectionSummary:
+        "The introduction describes the author's encounter with Robert Lewandowski on September 11, coinciding with La Diada, a Catalonia celebration. The author aims to create an unauthorized biography that reveals the true Lewandowski, addressing difficult topics such as family issues, conflicts, and controversies. Despite initial tension during their meeting, Lewandowski opened up over three sessions, allowing the author to capture a more authentic portrait of the football star. The author conducted extensive interviews with over 250 individuals to uncover Lewandowski's true character.",
+      chunks: [
+        {
+          content: `Tego dnia znalezienie wolnego stolika graniczyło z cudem. Wszystko przez La Diadę, obchodzone 11 września Święto Katalonii, które mieszkańcy tej miłącej wolność i futbol krainy celebrowali winem pitym z dzbanka zwanego porró. Nie inaczej było w położonej na przedmieściach Barcelony Gavie. A właśnie tam czekało mnie spotkanie z Robertem Lewandowskim.
+
+Obsesją jednego z najlepszych piłkarzy świata jest nie tylko strzelanie goli i zdrowy styl życia, ale także kontrola. Wraz ze swoim otoczeniem od dawna robi wiele, aby zbudowany z kolejnych pucharów i statuetek złoty cielec nie miał choćby rysy. Dlatego też pobłogosławione przez niego projekty – jak autoryzowana biografia czy film dokumentalny – były słodkie niczym wanilia. „Mój największy zarzut pod adresem Roberta jest taki, że nie poruszył w nich trudnych tematów" – powiedział mi kiedyś Wojciech Szczęsny, jeden z najbliższych kolegów gwiazdora Barcelony.`,
+          chunkId: "book-pl-lewa-chunk-1",
+        },
+        {
+          content: `Cztery godziny później rozstaliśmy się z poczuciem ulgi. Przynajmniej ja. To nie była łatwa rozmowa, w jej trakcie śmiech Roberta zastępowała irytacja, a rozbawienie – złość i rozczarowanie. W pewnym momencie, lecz może to tylko moje wrażenie, w jego oczach pojawiły się nawet łzy. Chociaż poznałem go na długo przed tym, jak stał się tym Lewandowskim, i przeprowadziłem z nim wiele wywiadów, nigdy wcześniej nie słyszałem go tak szczerze. Tym razem nie chował się za okrągłymi zdaniami, odpierał trudne zarzuty, ale i sam je formułował, mówił o konkretnych ludziach oraz momentach, zdobył się również na samokrytykę.`,
+          chunkId: "book-pl-lewa-chunk-2",
+        },
+        {
+          content: `Od początku pracy nad tą biografią moim drogowskazem był jej tytuł – Prawdziwy. Bo prawdziwy miał być portret człowieka, którego niemożliwy do zrozumienia dla zwykłych śmiertelników perfekcjonizm przysporzył mu krytyków, a nawet wrogów, a jednocześnie pozwolił wejść na piłkarski olimp, gdzie czekali Leo Messi z Cristiano Ronaldo. Tworząc ten portret, odbyłem pięćdziesiąt podróży po trzech krajach i przeprowadziłem wywiady z ponad dwustu pięćdziesięcioma osobami.`,
+          chunkId: "book-pl-lewa-chunk-3",
+        },
+      ],
+    },
+    {
+      sectionTitle: "Prolog",
+      sectionSummary:
+        "The prologue describes a profound moment of loss experienced by a young boy when he learns that his father has died. The narrative captures the emotional turmoil and trauma that follows the revelation. The father had struggled with health issues, including a serious illness and alcohol use. The boy reflects on his father's influence and vows to honor him through future achievements in football.",
+      chunks: [
+        {
+          content: `Świat, który znał, rozpadł się na tysiące kawałków po trzech słowach. Z prędkością światła przeszły jego dziecięcą duszę, wypełniły każdą komórkę wątłego jeszcze ciała, jednocześnie zmroziły i rozpalily serce, umysł przygniotły myślami ciężkimi jak głaz. Takie słowa potrafią skruszyć nawet prawdziwych twardieli. Mówią wszystko, chociaż zawierają tylko krótką informację.
+
+– Tata nie żyje.
+
+Najpierw pomyślał, że chodzi o dziadka. Ale po chwili wszystko zrozumiał. Gdy dotarło do niego, że najbliższa mu osoba odeszła drogą wszystkich ludzi, zapadła w nim ciemność.`,
+          chunkId: "book-pl-lewa-chunk-4",
+        },
+        {
+          content: `Wiedział o złym stanie ojca, który zmagał się z chorobą wieńcową i nadciśnieniem. Do tego przytył, zdarzało mu się też nadużywać alkoholu. Jakby tego było mało, wyrósł mu guz – jak podejrzewano – nowotworowy. A to zwaliło go z nóg. On – dusza towarzystwa, wodzirej, judoka, trener – stracił chęć do walki. Poddał się, opuścił gardę – a choroba tylko na to czekała. Po latach jego żona przyzna, że prawdopodobnie cierpiał na depresję.
+
+Wszystkie najważniejsze bramki zadedykuję ojcu. To dla niego zdemoluje Real Madryt, ośmieszę Wolfsburg i wygram Ligę Mistrzów.`,
+          chunkId: "book-pl-lewa-chunk-5",
+        },
+      ],
+    },
+    {
+      sectionTitle: "Polowanie",
+      sectionSummary:
+        "Borussia Dortmund faced financial difficulties and was cautious with spending. Michael Zorc, the sports director, sought to acquire Robert Lewandowski from Lech Poznań. Despite initial offers of 2 million euros being rejected, Zorc's determination grew with each of Lewandowski's impressive performances. Lewandowski expressed his desire to join Borussia, but Lech remained resistant to selling.",
+      chunks: [
+        {
+          content: `Borussia znalazła się w ślepym zaułku. W ostatnich latach kłopotów miała zresztą co niemiara, w 2005 roku niewiele zabrakło, aby dortmundczycy splajtowali. Sytuację z trudem udało się ustabilizować, a zaglądające w oczy bankructwo stało się złym wspomnieniem, ale słynny klub wciąż nie mógł szastać pieniędzmi.
+
+Michael Zorc podrapał się po głowie, zerknął w oprawiony skórą zeszyt i po raz kolejny postanowił wybrać się do Polski. W Poznaniu szybko go dostrzeżono. Był wysoki, nosił świetnie skrojone grafitowe marynarki i choć skończył czterdziestkę, mógł pochwalić się sportową sylwetką.`,
+          chunkId: "book-pl-lewa-chunk-110",
+        },
+        {
+          content: `– Szczerze? Mecze Ekstraklasy były straszne: zimno, murawa wyglądała, jakby przebiegło po niej stado koni, a słabi obrońcy myśleli tylko o tym, jak zniszczyć młodego napastnika – wspomina Zorc. – Odwiedziłem Polskę wielokrotnie. I któregoś dnia poczułem, że to ten moment. Rano przyszedłem do biura, siedział tam już Aki Watzke. Powiedziałem mu: „No dobra, chcę go mieć".
+
+I podobnie jak koledzy po fachu, poprosił poznaniaków o rozmowę. A ci się zgodzili. Niemiec nie przybył jednak podziwiać architektury. Od razu przeszedł więc do rzeczy i zza kłębów papierosowego dymu wypalił: „Borussia chce Lewandowskiego".`,
+          chunkId: "book-pl-lewa-chunk-111",
+        },
+        {
+          content: `Uczestnicy rozmowy przyznają, że kwota wywołała pewne poruszenie, wszakże była to dziesięciokrotność sumy, którą Lech rok wcześniej zapłacił Zniczowi. Ale Jacek Rutkowski widział to inaczej. – Nie chciałem, żeby Robert poszedł drogą Radosława Matusiaka, który po jednej dobrej rundzie wyjechał do Włoch i przepadł – twierdzi były właściciel klubu z Poznania.
+
+Zorc nie miał zamiaru się poddawać, a jego determinacja rosła proporcjonalnie do kolejnych dobrych występów Roberta.`,
+          chunkId: "book-pl-lewa-chunk-112",
+        },
+      ],
+    },
+    {
+      sectionTitle: "FC Hollywood",
+      sectionSummary:
+        "The section discusses the dynamics between Robert Lewandowski and coach Josep Guardiola at Bayern Munich. Zbigniew Boniek warned Lewandowski about Guardiola's aversion to traditional strikers. Despite initial skepticism, Bayern's management believed Lewandowski's talent would win Guardiola over. The narrative highlights Lewandowski's adaptation to Guardiola's demanding tactical system.",
+      chunks: [
+        {
+          content: `Po wygranym aż 7:1 wyjazdowym meczu Bayernu z AS Romą w Lidze Mistrzów z Lewandowskim spotkał się Zbigniew Boniek. Prezes PZPN skorzystał z okazji, aby zamienić kilka słów z nowym piłkarzem mistrzów Niemiec. „Wiesz, co myślę? Że nie będziesz miał u niego życia – powiedział. – Przecież on nie znosi klasycznych napastników".
+
+Lista trenerskich osiągnięć Guardioli rzucała na kolana: trzy mistrzostwa Hiszpanii, dwie wygrane edycje Ligi Mistrzów, do tego kilka innych pucharów. W sumie czternaście trofeów zdobytych z Barcą w cztery lata. Ale wśród jego skalpów znajdowali się też snajperzy. Najbardziej znany jest konflikt Katalończyka ze Zlatanem Ibrahimoviciem.`,
+          chunkId: "book-pl-lewa-chunk-242",
+        },
+        {
+          content: `Chociaż Pep traktował Lewandowskiego jak istotny element swojej układanki, to Bońka nie zawiódł piłkarski nos. Pierwszy sezon Polaka nie obfitował w zachwyty – drużyna uczyła się jego stylu, a on uczył się stylu drużyny. Guardiola oczekiwał na przykład, aby jego podwładni byli wszechstronni. Również Lewy musiał zrozumieć, że w Bayernie będzie pracował na dwa etaty. A przecież nie znosił, gdy Klopp ustawiał go na skrzydle czy za plecami napastnika. Robert miał duszę klasycznej dziewiątki – i numer 9 na plecach – więc pola karnego potrzebował jak ryba wody.`,
+          chunkId: "book-pl-lewa-chunk-244",
+        },
+        {
+          content: `Zarówno Pep, jak i Robert rozumieli, że droga do perfekcji wiedzie przez detale. Guardiola od pierwszego dnia wymagał, aby rondo stało się rywalizacją na śmierć i życie. Miało to pomóc piłkarzom doskonalić grę obiema nogami, refleks, kreatywność, zdolność skanowania przestrzeni.
+
+Już na pierwszych zajęciach Guardiola tłumaczył Robertowi: „Jesteś nowoczesnym snajperem, nie możesz tylko stać i czekać na piłkę". A on słuchał, bo z takim założeniem przyjechał do Bawarii. Szybko zrozumiał, że możliwość współpracy z Pepem to okazja, by wejść na wyższy poziom.`,
+          chunkId: "book-pl-lewa-chunk-247",
+        },
+      ],
+      highlights: [
+        {
+          highlightId: "book-pl-lewa-highlight-1",
+          highlightText:
+            "W reprezentacji gram siedemnaście lat, opuściłem może drugie zgrupowanie. Zadam więc pytanie: kto z was może wiedzieć, co ja czuję albo co będzie dla mnie najlepsze? Znam swój organizm, wiem, co mi podpowiada",
+        },
+        {
+          highlightId: "book-pl-lewa-highlight-2",
+          highlightText:
+            'Młodzież wyśmiewała też kolejne stylizacje Lewandowskiego, podśmiewała się, że siwe włosy przykrywa czarnym sprayem, a nieudane zagrania puentowała docinkami w stylu: „Co za drewniak". Zaczęła też nazywać go „Dziadkiem" lub „Starym".',
+        },
+        {
+          highlightId: "book-pl-lewa-highlight-3",
+          highlightText:
+            "Czułem, że zespół potrzebował kapitana będącego także kumplem, a nie tylko wielkim piłkarzem",
+        },
+        {
+          highlightId: "book-pl-lewa-highlight-4",
+          highlightText:
+            "Swojego pierwszego mundialowego gola zdobył w wieku trzydziestu czterech lat, trzech miesięcy i pięciu dni. Dosłownie w ostatniej chwili.",
+        },
+        {
+          highlightId: "book-pl-lewa-highlight-5",
+          highlightText: "Byliśmy rozczarowani jego decyzją, bo drużyna go potrzebowała.",
+        },
+      ],
+    },
+  ],
+};

--- a/packages/backend/convex/pipeline/evals/fixtures/index.ts
+++ b/packages/backend/convex/pipeline/evals/fixtures/index.ts
@@ -1,0 +1,26 @@
+export type { FixtureDocument, FixtureSection } from "./types";
+export { BOOK_EN_LEARNING } from "./book-en-learning";
+export { ARTICLE_EN_ARCHITECTURE } from "./article-en-architecture";
+export { YOUTUBE_EN_ML } from "./youtube-en-ml";
+export { BOOK_PL_LEWANDOWSKI } from "./book-pl-lewandowski";
+
+import { BOOK_EN_LEARNING } from "./book-en-learning";
+import { ARTICLE_EN_ARCHITECTURE } from "./article-en-architecture";
+import { YOUTUBE_EN_ML } from "./youtube-en-ml";
+import { BOOK_PL_LEWANDOWSKI } from "./book-pl-lewandowski";
+import type { FixtureDocument } from "./types";
+
+export const ALL_FIXTURES: FixtureDocument[] = [
+  BOOK_EN_LEARNING,
+  ARTICLE_EN_ARCHITECTURE,
+  YOUTUBE_EN_ML,
+  BOOK_PL_LEWANDOWSKI,
+];
+
+export const EN_FIXTURES: FixtureDocument[] = [
+  BOOK_EN_LEARNING,
+  ARTICLE_EN_ARCHITECTURE,
+  YOUTUBE_EN_ML,
+];
+
+export const PL_FIXTURES: FixtureDocument[] = [BOOK_PL_LEWANDOWSKI];

--- a/packages/backend/convex/pipeline/evals/fixtures/types.ts
+++ b/packages/backend/convex/pipeline/evals/fixtures/types.ts
@@ -1,0 +1,12 @@
+export type FixtureSection = {
+  sectionTitle: string;
+  sectionSummary: string;
+  chunks: Array<{ content: string; chunkId: string }>;
+  highlights?: Array<{ highlightId: string; highlightText: string }>;
+};
+
+export type FixtureDocument = {
+  title: string;
+  language: "en" | "pl";
+  sections: FixtureSection[];
+};

--- a/packages/backend/convex/pipeline/evals/fixtures/youtube-en-ml.ts
+++ b/packages/backend/convex/pipeline/evals/fixtures/youtube-en-ml.ts
@@ -1,0 +1,61 @@
+import type { FixtureDocument } from "./types";
+
+export const YOUTUBE_EN_ML: FixtureDocument = {
+  title: "Introduction to Machine Learning Fundamentals",
+  language: "en",
+  sections: [
+    {
+      sectionTitle: "What is Machine Learning",
+      sectionSummary:
+        "Machine learning is a subset of AI where systems learn from data rather than being explicitly programmed. This paradigm shift has enabled breakthroughs in image recognition, NLP, and recommendation systems.",
+      chunks: [
+        {
+          content:
+            "Machine learning is a subset of artificial intelligence where systems learn from data rather than being explicitly programmed. Instead of writing rules by hand, we provide examples and let algorithms discover patterns automatically. This paradigm shift has enabled breakthroughs in image recognition, natural language processing, and recommendation systems that would have been impossible with traditional programming.",
+          chunkId: "youtube-en-ml-chunk-0",
+        },
+      ],
+    },
+    {
+      sectionTitle: "Supervised Learning",
+      sectionSummary:
+        "Supervised learning uses labeled training data to learn input-to-output mappings. Common tasks include classification (discrete categories) and regression (continuous values). Examples: spam detection, medical diagnosis, house price prediction.",
+      chunks: [
+        {
+          content:
+            "There are three main categories of machine learning. Supervised learning uses labeled training data to learn a mapping from inputs to outputs. Common tasks include classification, where we predict discrete categories, and regression, where we predict continuous values. Examples include spam detection, medical diagnosis, and house price prediction.",
+          chunkId: "youtube-en-ml-chunk-1",
+        },
+      ],
+    },
+    {
+      sectionTitle: "Unsupervised and Reinforcement Learning",
+      sectionSummary:
+        "Unsupervised learning discovers hidden structure in unlabeled data via clustering and dimensionality reduction. Reinforcement learning trains agents to maximize cumulative reward through environment interaction, powering game-playing AIs and robotics.",
+      chunks: [
+        {
+          content:
+            "Unsupervised learning works with unlabeled data, discovering hidden structure and patterns. Clustering algorithms group similar data points together, while dimensionality reduction techniques compress high-dimensional data into lower-dimensional representations. These techniques are invaluable for exploratory data analysis and feature engineering.",
+          chunkId: "youtube-en-ml-chunk-2",
+        },
+        {
+          content:
+            "Reinforcement learning takes a different approach entirely. An agent interacts with an environment, taking actions and receiving rewards or penalties. Over time, the agent learns a policy that maximizes cumulative reward. This paradigm powers game-playing AIs, robotics control systems, and recommendation engines that adapt to user behavior in real time.",
+          chunkId: "youtube-en-ml-chunk-3",
+        },
+      ],
+    },
+    {
+      sectionTitle: "Training Process",
+      sectionSummary:
+        "Training involves splitting data into training, validation, and test sets. Cross-validation provides robust estimates. Overfitting occurs when a model memorizes training data instead of learning generalizable patterns.",
+      chunks: [
+        {
+          content:
+            "The training process involves splitting data into training, validation, and test sets. We fit the model on training data, tune hyperparameters using validation data, and evaluate final performance on the held-out test set. Cross-validation provides more robust estimates by rotating which subset serves as the validation set. Overfitting occurs when a model memorizes training data rather than learning generalizable patterns.",
+          chunkId: "youtube-en-ml-chunk-4",
+        },
+      ],
+    },
+  ],
+};

--- a/packages/backend/convex/pipeline/evals/highlightDraft.eval.ts
+++ b/packages/backend/convex/pipeline/evals/highlightDraft.eval.ts
@@ -1,0 +1,88 @@
+import { evalite } from "evalite";
+
+import { AiSdkHighlightDraftLlm } from "../../providers/highlightDraftLlm";
+import { ALL_FIXTURES } from "./fixtures";
+import {
+  structuralValidity,
+  languageMatch,
+  contentSpecificity,
+  typeSpecificQuality,
+} from "./scorers";
+import type { DraftCardType } from "../../lib/validators";
+
+type HighlightDraftInput = {
+  highlightId: string;
+  highlightText: string;
+  sectionTitle: string;
+  sectionSummary: string;
+  chunks: Array<{ content: string; chunkId: string }>;
+  documentTitle: string;
+  expectedLanguage: "en" | "pl";
+};
+
+type HighlightDraftOutput = {
+  cardType: DraftCardType;
+  content: string;
+  typeData: Record<string, unknown>;
+  sourceChunks: string[];
+  expectedLanguage: "en" | "pl";
+};
+
+const llm = new AiSdkHighlightDraftLlm();
+
+function collectHighlightInputs(): HighlightDraftInput[] {
+  const inputs: HighlightDraftInput[] = [];
+
+  for (const doc of ALL_FIXTURES) {
+    for (const section of doc.sections) {
+      if (!section.highlights?.length) continue;
+      for (const highlight of section.highlights) {
+        inputs.push({
+          highlightId: highlight.highlightId,
+          highlightText: highlight.highlightText,
+          sectionTitle: section.sectionTitle,
+          sectionSummary: section.sectionSummary,
+          chunks: section.chunks,
+          documentTitle: doc.title,
+          expectedLanguage: doc.language,
+        });
+      }
+    }
+  }
+
+  return inputs;
+}
+
+evalite("Highlight Draft", {
+  data: () => collectHighlightInputs().map((d) => ({ input: d })),
+  task: async (input) => {
+    const { cards } = await llm.generateDraftsFromHighlights({
+      highlights: [{ highlightId: input.highlightId, highlightText: input.highlightText }],
+      sectionSummary: input.sectionSummary,
+      sectionTitle: input.sectionTitle,
+      chunks: input.chunks,
+      documentTitle: input.documentTitle,
+    });
+
+    const card = cards[0];
+    if (!card) {
+      return {
+        cardType: "insight" as DraftCardType,
+        content: "",
+        typeData: { type: "insight" },
+        sourceChunks: input.chunks.map((c) => c.content),
+        expectedLanguage: input.expectedLanguage,
+      };
+    }
+
+    return {
+      cardType: card.cardType,
+      content: card.content,
+      typeData: card.typeData,
+      sourceChunks: input.chunks.map((c) => c.content),
+      expectedLanguage: input.expectedLanguage,
+    } satisfies HighlightDraftOutput;
+  },
+  scorers: [structuralValidity, languageMatch, contentSpecificity, typeSpecificQuality],
+  trialCount: 3,
+});

--- a/packages/backend/convex/pipeline/evals/scorers/connectionGenuineness.ts
+++ b/packages/backend/convex/pipeline/evals/scorers/connectionGenuineness.ts
@@ -1,0 +1,54 @@
+import { createScorer } from "evalite";
+import { generateText, Output } from "ai";
+import { z } from "zod";
+
+import { getAI } from "../../../providers/ai";
+
+const ratingSchema = z.object({
+  score: z
+    .number()
+    .min(0)
+    .max(1)
+    .describe("Connection genuineness score from 0 (superficial) to 1 (meaningful)"),
+  rationale: z.string().describe("Brief explanation"),
+});
+
+export const connectionGenuineness = createScorer<any, any, any>({
+  name: "Connection Genuineness",
+  description: "LLM-as-judge: evaluates whether the connection between two sections is meaningful",
+  scorer: async ({ input, output }) => {
+    if (!output.isGenuineConnection) {
+      return {
+        score: 0.5,
+        metadata: { rationale: "Connection rejected by LLM (isGenuineConnection=false)" },
+      };
+    }
+
+    const { output: result } = await generateText({
+      model: getAI().languageModel("fast"),
+      output: Output.object({ schema: ratingSchema }),
+      system: `You are a connection quality evaluator for a learning app. Rate how meaningful and genuine the discovered connection between two document sections is.
+
+Score 0: Superficial or forced connection. The sections merely share a common word or broad topic without real conceptual overlap.
+Score 0.5: Moderate connection. There is some thematic overlap but the explanation is vague or doesn't reference specific evidence from both sources.
+Score 1: Genuine, insightful connection. The card explains a specific conceptual link with evidence from both sections - shared patterns, complementary perspectives, or cause-and-effect relationships.`,
+      prompt: `Section A: "${input.sectionATitle}"
+Summary A: ${input.sectionASummary}
+
+Section B: "${input.sectionBTitle}"
+Summary B: ${input.sectionBSummary}
+
+Connection card content: "${output.content}"
+Source A hint: ${output.typeData.sourceATitleHint}
+Source B hint: ${output.typeData.sourceBTitleHint}`,
+      temperature: 0,
+    });
+
+    const rating = result ?? { score: 0, rationale: "No output from LLM" };
+
+    return {
+      score: rating.score,
+      metadata: { rationale: rating.rationale },
+    };
+  },
+});

--- a/packages/backend/convex/pipeline/evals/scorers/contentSpecificity.ts
+++ b/packages/backend/convex/pipeline/evals/scorers/contentSpecificity.ts
@@ -1,0 +1,46 @@
+import { createScorer } from "evalite";
+import { generateText, Output } from "ai";
+import { z } from "zod";
+
+import { getAI } from "../../../providers/ai";
+
+const ratingSchema = z.object({
+  score: z
+    .number()
+    .min(0)
+    .max(1)
+    .describe("Specificity score from 0 (generic) to 1 (highly specific)"),
+  rationale: z.string().describe("Brief explanation of the score"),
+});
+
+export const contentSpecificity = createScorer<any, any, any>({
+  name: "Content Specificity",
+  description: "LLM-as-judge: penalizes generic filler, rewards specific names, numbers, quotes",
+  scorer: async ({ output }) => {
+    const { output: result } = await generateText({
+      model: getAI().languageModel("fast"),
+      output: Output.object({ schema: ratingSchema }),
+      system: `You are a content quality evaluator. Rate how specific and concrete the given learning card content is on a 0-1 scale.
+
+Score 0: Generic content that could apply to any topic. Uses vague phrases like "this chapter discusses important concepts", "there are many factors", "the author explains key ideas".
+Score 0.5: Some specific details but padded with generic filler.
+Score 1: Highly specific content with concrete facts, exact names, numbers, dates, verbatim quotes, or precise examples from the source.
+
+Be strict. Most AI-generated content scores 0.3-0.6 due to vague hedging.`,
+      prompt: `Rate the specificity of this learning card content:
+
+Card content: "${output.content}"
+
+Source material (for context):
+${output.sourceChunks.slice(0, 2).join("\n---\n")}`,
+      temperature: 0,
+    });
+
+    const rating = result ?? { score: 0, rationale: "No output from LLM" };
+
+    return {
+      score: rating.score,
+      metadata: { rationale: rating.rationale },
+    };
+  },
+});

--- a/packages/backend/convex/pipeline/evals/scorers/index.ts
+++ b/packages/backend/convex/pipeline/evals/scorers/index.ts
@@ -1,0 +1,5 @@
+export { structuralValidity } from "./structuralValidity";
+export { languageMatch, detectLanguage } from "./languageMatch";
+export { contentSpecificity } from "./contentSpecificity";
+export { typeSpecificQuality } from "./typeSpecificQuality";
+export { connectionGenuineness } from "./connectionGenuineness";

--- a/packages/backend/convex/pipeline/evals/scorers/languageMatch.ts
+++ b/packages/backend/convex/pipeline/evals/scorers/languageMatch.ts
@@ -1,0 +1,20 @@
+import { createScorer } from "evalite";
+
+function detectLanguage(text: string): "pl" | "en" {
+  const polishChars = /[ąćęłńóśźżĄĆĘŁŃÓŚŹŻ]/g;
+  const matches = text.match(polishChars);
+  if (!matches) return "en";
+  const ratio = matches.length / text.length;
+  return ratio > 0.005 ? "pl" : "en";
+}
+
+export const languageMatch = createScorer<any, any, any>({
+  name: "Language Match",
+  description: "Checks if card output language matches the expected source language",
+  scorer: ({ input, output }) => {
+    const detected = detectLanguage(output.content);
+    return detected === input.expectedLanguage ? 1 : 0;
+  },
+});
+
+export { detectLanguage };

--- a/packages/backend/convex/pipeline/evals/scorers/structuralValidity.ts
+++ b/packages/backend/convex/pipeline/evals/scorers/structuralValidity.ts
@@ -1,0 +1,18 @@
+import { createScorer } from "evalite";
+
+import { castTypeData, computeStructuralScore } from "../../logic/cardDraftGeneration";
+export const structuralValidity = createScorer<any, any, any>({
+  name: "Structural Validity",
+  description: "Validates card structure using castTypeData and computeStructuralScore",
+  scorer: ({ output }) => {
+    try {
+      castTypeData(output.cardType, output.typeData);
+      return computeStructuralScore({
+        cardType: output.cardType,
+        typeData: output.typeData,
+      });
+    } catch {
+      return 0;
+    }
+  },
+});

--- a/packages/backend/convex/pipeline/evals/scorers/typeSpecificQuality.ts
+++ b/packages/backend/convex/pipeline/evals/scorers/typeSpecificQuality.ts
@@ -1,0 +1,74 @@
+import { createScorer } from "evalite";
+import { generateText, Output } from "ai";
+import { z } from "zod";
+
+import { getAI } from "../../../providers/ai";
+import type { DraftCardType } from "../../../lib/validators";
+
+const ratingSchema = z.object({
+  score: z.number().min(0).max(1).describe("Quality score from 0 (poor) to 1 (excellent)"),
+  rationale: z.string().describe("Brief explanation"),
+});
+
+function buildTypePrompt(cardType: DraftCardType): string {
+  switch (cardType) {
+    case "insight":
+      return `Evaluate this INSIGHT card:
+- Does it contain a specific fact or surprising detail (not a vague summary)?
+- Is the insight grounded in the source material?
+- Does it use bold formatting for key terms?
+Score 0 for generic "this section discusses..." content. Score 1 for a concrete, memorable fact.`;
+
+    case "quiz":
+      return `Evaluate this QUIZ card:
+- Is the question about a concrete, verifiable fact from the source?
+- Are all options plausible and distinct (not obviously wrong)?
+- Is the correct answer unambiguous?
+- Does the explanation reference the source?
+Score 0 if the question is vague or options are trivially distinguishable. Score 1 for a well-crafted quiz.`;
+
+    case "quote":
+      return `Evaluate this QUOTE card:
+- Is the quotedText a verbatim passage from the source chunks? Check for exact substring match.
+- Is the context (content field) helpful and concise?
+- Is the quote notable, memorable, or thought-provoking?
+Score 0 if the quote is fabricated or paraphrased. Score 1 for an exact, impactful quote.`;
+
+    case "summary":
+      return `Evaluate this SUMMARY card:
+- Are the bullet points concrete and specific (names, numbers, concepts)?
+- Does each bullet reference a distinct takeaway?
+- Is the overview concise and informative?
+Score 0 for abstract bullet points like "the author discusses key concepts". Score 1 for specific, useful takeaways.`;
+  }
+}
+
+export const typeSpecificQuality = createScorer<any, any, any>({
+  name: "Type-Specific Quality",
+  description: "LLM-as-judge: evaluates card quality based on its specific type requirements",
+  scorer: async ({ output }) => {
+    const sourceContext = output.sourceChunks.slice(0, 2).join("\n---\n");
+    const typeDataStr = JSON.stringify(output.typeData, null, 2);
+
+    const { output: result } = await generateText({
+      model: getAI().languageModel("fast"),
+      output: Output.object({ schema: ratingSchema }),
+      system: `You are a learning card quality evaluator. Be strict and specific in your assessment.`,
+      prompt: `${buildTypePrompt(output.cardType)}
+
+Card content: "${output.content}"
+Type data: ${typeDataStr}
+
+Source chunks:
+${sourceContext}`,
+      temperature: 0,
+    });
+
+    const rating = result ?? { score: 0, rationale: "No output from LLM" };
+
+    return {
+      score: rating.score,
+      metadata: { rationale: rating.rationale, cardType: output.cardType },
+    };
+  },
+});

--- a/packages/backend/convex/pipeline/evals/thematic.eval.ts
+++ b/packages/backend/convex/pipeline/evals/thematic.eval.ts
@@ -1,0 +1,114 @@
+import { evalite, createScorer } from "evalite";
+
+import { AiSdkThematicLlm } from "../../providers/thematicLlm";
+import { ALL_FIXTURES } from "./fixtures";
+import { contentSpecificity } from "./scorers";
+import { detectLanguage } from "./scorers/languageMatch";
+
+type ThematicInput = {
+  sectionSummaries: Array<{ sectionTitle: string; summary: string }>;
+  documentTitle: string;
+  sectionTitles: string[];
+};
+
+type ThematicOutput = {
+  themes: Array<{
+    title: string;
+    description: string;
+    relevantSections: string[];
+  }>;
+  content: string;
+  sourceChunks: string[];
+};
+
+const llm = new AiSdkThematicLlm();
+
+const thematicLanguageMatch = createScorer<unknown, ThematicOutput, unknown>({
+  name: "Language Match (English)",
+  description: "Thematic themes must always be in English regardless of source language",
+  scorer: ({ output }) => {
+    const allText = output.themes.map((t) => `${t.title} ${t.description}`).join(" ");
+    if (allText.length < 10) return 0;
+    const detected = detectLanguage(allText);
+    return detected === "en" ? 1 : 0;
+  },
+});
+
+const sectionCoverage = createScorer<ThematicInput, ThematicOutput, unknown>({
+  name: "Section Coverage",
+  description: "Checks that relevantSections reference actual section titles from the input",
+  scorer: ({ input, output }) => {
+    const validTitles = new Set(input.sectionTitles);
+    let total = 0;
+    let valid = 0;
+
+    for (const theme of output.themes) {
+      for (const section of theme.relevantSections) {
+        total++;
+        if (validTitles.has(section)) valid++;
+      }
+    }
+
+    return total === 0 ? 0 : valid / total;
+  },
+});
+
+const themeCount = createScorer<unknown, ThematicOutput, unknown>({
+  name: "Theme Count",
+  description: "Checks that the number of discovered themes is reasonable (2-10)",
+  scorer: ({ output }) => {
+    const count = output.themes.length;
+    if (count < 2) return 0;
+    if (count > 10) return 0.5;
+    return 1;
+  },
+});
+
+const thematicSpecificity = createScorer<any, ThematicOutput, any>({
+  name: "Theme Specificity",
+  description: "Adapts contentSpecificity to work with thematic output format",
+  scorer: async ({ output }) => {
+    const result = await contentSpecificity({
+      input: undefined,
+      output: {
+        content: output.themes.map((t) => `${t.title}: ${t.description}`).join("\n\n"),
+        sourceChunks: output.sourceChunks,
+      },
+      expected: undefined,
+    });
+    return result.score ?? 0;
+  },
+});
+
+function buildThematicData(): ThematicInput[] {
+  return ALL_FIXTURES.map((doc) => ({
+    sectionSummaries: doc.sections.map((s) => ({
+      sectionTitle: s.sectionTitle,
+      summary: s.sectionSummary,
+    })),
+    documentTitle: doc.title,
+    sectionTitles: doc.sections.map((s) => s.sectionTitle),
+  }));
+}
+
+evalite("Thematic Discovery", {
+  data: () => buildThematicData().map((d) => ({ input: d })),
+  task: async (input) => {
+    const { themes } = await llm.discoverThemes({
+      sectionSummaries: input.sectionSummaries,
+      documentTitle: input.documentTitle,
+    });
+
+    const allSummaryText = input.sectionSummaries
+      .map((s) => `${s.sectionTitle}: ${s.summary}`)
+      .join("\n");
+
+    return {
+      themes,
+      content: themes.map((t) => `${t.title}: ${t.description}`).join("\n\n"),
+      sourceChunks: [allSummaryText],
+    } satisfies ThematicOutput;
+  },
+  scorers: [thematicLanguageMatch, sectionCoverage, themeCount, thematicSpecificity],
+  trialCount: 3,
+});

--- a/packages/backend/convex/pipeline/logic/cardDraftGeneration.ts
+++ b/packages/backend/convex/pipeline/logic/cardDraftGeneration.ts
@@ -96,7 +96,7 @@ export function computeQualityScore(opts: {
   return structuralScore * 0.4 + lengthScore * 0.3 + coverageScore * 0.3;
 }
 
-function computeStructuralScore(opts: {
+export function computeStructuralScore(opts: {
   cardType: DraftCardType;
   typeData: Record<string, unknown>;
 }): number {

--- a/packages/backend/convex/providers/cardDraftLlm.ts
+++ b/packages/backend/convex/providers/cardDraftLlm.ts
@@ -59,46 +59,112 @@ const SCHEMAS: Record<DraftCardType, z.ZodSchema> = {
   summary: summarySchema,
 };
 
+// --- Prompt improvement notes ---
+// Each change is annotated with which eval scorer it targets:
+//   [CS] = Content Specificity scorer
+//   [TSQ] = Type-Specific Quality scorer
+//   [LM] = Language Match scorer
+//   [SV] = Structural Validity scorer
+//
+// Change 1 (base): Added grounding step "First, identify 2-3 specific details"
+//   [CS] Forces the model to extract concrete facts before writing, reducing generic filler.
+//   The Content Specificity scorer penalizes vague phrases - grounding upfront steers
+//   the model toward names, numbers, and quotes that score high.
+//
+// Change 2 (base): Added explicit negative examples of bad content
+//   [CS] The scorer's LLM judge penalizes exactly these patterns ("this chapter discusses
+//   important concepts"). Showing the model what NOT to write directly targets low scores.
+//
+// Change 3 (base): Strengthened language rule with "detect language from chunks first"
+//   [LM] The Language Match scorer checks Polish diacritics ratio. Telling the model to
+//   explicitly detect the language first reduces mismatches, especially for mixed-script input.
+//
+// Change 4 (quiz): Added "all wrong options must be plausible" + "explanation must quote source"
+//   [TSQ] The quiz quality scorer checks: "Are all options plausible and distinct?" and
+//   "Does the explanation reference the source?" These instructions directly address those criteria.
+//
+// Change 5 (quote): Added "search chunks for the exact passage, then copy character-by-character"
+//   [TSQ] The quote quality scorer checks for exact substring match against source chunks.
+//   Telling the model to find-then-copy reduces paraphrasing that scores 0.
+//
+// Change 6 (summary): Added "each bullet must contain at least one proper noun, number, or technical term"
+//   [CS][TSQ] Both scorers reward concrete details. This constraint makes abstract bullets
+//   impossible, directly lifting scores on both dimensions.
+//
+// Change 7 (insight): Added "include at least one direct phrase from the source text"
+//   [CS] The scorer rewards "verbatim quotes or precise examples from the source".
+//   This constraint ensures the content references the actual text, not a paraphrase.
+
 function buildSystemPrompt(cardType: DraftCardType): string {
   const base = `You are an AI learning assistant for Scrollect, a personal learning feed app.
 Your job is to create a single focused learning card from a section of a document.
 
-CONTENT PHILOSOPHY: Stay close to the source. Prefer exact wordings, specific facts, surprising details, and concrete examples over generic summaries or interpretations. The user wants to re-encounter the actual content they saved - not a paraphrased version.
+<instructions>
+1. First, detect the language of the source chunks. Write your entire response in that same language. If chunks are in Polish, write in Polish. If in English, write in English. Never translate or mix languages.
+2. Before writing, identify 2-3 specific details from the source: exact names, numbers, dates, or notable phrases you will reference in the card.
+3. Create the card using those specific details. Stay close to the source text.
+</instructions>
 
-LANGUAGE RULE: Write in the same language as the source chunks. If the chunks are in Polish, write in Polish. If in English, write in English. Never translate.`;
+<quality_rules>
+- Prefer exact wordings, specific facts, and concrete examples over generic summaries
+- The user wants to re-encounter the actual content they saved, not a paraphrased version
+- Every sentence must reference something specific from the source chunks
+</quality_rules>
+
+<avoid>
+- "This section discusses important concepts about..."
+- "The author explores various aspects of..."
+- "There are several key factors that..."
+- Any sentence that could apply to a different document without changes
+</avoid>`;
 
   switch (cardType) {
     case "insight":
       return `${base}
 
-Create an INSIGHT card - a specific fact, surprising detail, or concrete example from the source.
+<task>Create an INSIGHT card - a specific fact, surprising detail, or concrete example from the source.</task>
+
+<format>
 - 2-4 sentences
-- Use **bold** for key terms
-- Prefer verbatim phrases and exact numbers/names from the text`;
+- Use **bold** for key terms (names, technical terms, numbers)
+- Include at least one direct phrase from the source text
+- The first sentence must contain a specific fact, not a general introduction
+</format>`;
 
     case "quiz":
       return `${base}
 
-Create a QUIZ card testing recall of specific details from the source.
-- Ask about concrete facts, names, numbers - not vague concepts
-- Provide 4 options for multiple_choice or ["True", "False"] for true_false
-- Include a brief explanation referencing the exact source detail`;
+<task>Create a QUIZ card testing recall of a specific detail from the source.</task>
+
+<format>
+- The question must target a concrete, verifiable fact (a name, number, date, or specific claim)
+- For multiple_choice: provide exactly 4 options where all wrong options are plausible but clearly incorrect based on the source
+- For true_false: the statement must be specific enough that the answer is unambiguous
+- The explanation must quote or closely reference the exact source passage that contains the answer
+</format>`;
 
     case "quote":
       return `${base}
 
-Create a QUOTE card - a notable, memorable, or thought-provoking passage from the source.
-- Copy the quote VERBATIM from the source chunks - do not paraphrase
-- Pick the most impactful or insightful passage
-- Provide brief context (1-2 sentences) in the content field`;
+<task>Create a QUOTE card featuring a notable passage from the source.</task>
+
+<format>
+- Search the source chunks for the most impactful, memorable, or thought-provoking passage
+- Copy the passage exactly as it appears in the source, character by character - do not paraphrase, rephrase, or clean up the text
+- The quotedText must be a verbatim substring of one of the source chunks
+- In the content field, provide 1-2 sentences of context explaining why this quote matters
+</format>`;
 
     case "summary":
       return `${base}
 
-Create a SUMMARY card with bullet points listing specific takeaways from the section.
-- 2-5 bullet points, each referencing a concrete detail
-- No abstract generalizations - include names, numbers, specific concepts
-- Provide a brief overview (1-2 sentences) in the content field`;
+<task>Create a SUMMARY card with bullet points listing specific takeaways from the section.</task>
+
+<format>
+- 2-5 bullet points, each containing at least one proper noun, number, or technical term from the source
+- Each bullet must reference a distinct, concrete detail - not a rewording of another bullet
+- In the content field, provide a 1-2 sentence overview that names the specific topic (not "this section covers key ideas")
+</format>`;
   }
 }
 

--- a/packages/backend/convex/providers/connectionDiscoveryLlm.ts
+++ b/packages/backend/convex/providers/connectionDiscoveryLlm.ts
@@ -31,19 +31,51 @@ const connectionDraftSchema = z.object({
     ),
 });
 
+// --- Prompt improvement notes (scorer impact) ---
+// [CG] Added structured evaluation steps: "identify the specific concept in A, then in B, then explain the link"
+//   Connection Genuineness scorer checks for "specific conceptual link with evidence from both sections".
+//   Step-by-step reasoning forces the model to ground the connection in concrete evidence from both sides.
+// [CS] Added "reference at least one specific fact from each section"
+//   Content Specificity scorer penalizes vague connections. This constraint ensures each connection
+//   card contains concrete details from both sources.
+// [LM] Strengthened language detection instruction
+//   Same pattern as other providers - explicit language detection step.
+// [CG] Added explicit superficial connection examples to reject
+//   The Connection Genuineness scorer gives 0 for superficial connections. Showing examples of
+//   what "superficial" means helps the model set isGenuineConnection=false correctly.
+
 function buildSystemPrompt(): string {
   return `You are a connection discovery assistant for Scrollect, a personal learning feed app.
 Given two sections from the user's library (possibly from different documents), determine if they share a meaningful conceptual connection and generate a connection card.
 
-RULES:
-- Set isGenuineConnection to false if the sections are only superficially related (e.g. both mention "software" but discuss unrelated topics)
-- Set isGenuineConnection to true only for meaningful connections: shared concepts, complementary perspectives, cause-and-effect relationships, or pattern parallels
-- sourceATitleHint and sourceBTitleHint should be concise labels (document title or section title, whichever is more specific)
-- Content should explain the CONNECTION between the two ideas, not just summarize each one
-- Stay close to the source material - reference specific facts, concepts, or examples
-- Write in the same language as the source chunks. If chunks are in Polish, write in Polish. If in English, write in English. Never translate.
+<instructions>
+1. Detect the language of the source chunks. Write in that language.
+2. Identify the key specific concept or fact in Section A.
+3. Identify the key specific concept or fact in Section B.
+4. Determine if there is a genuine conceptual link between them.
+5. If yes, explain the connection referencing at least one specific detail from each section.
+</instructions>
 
-Return a JSON object matching the schema.`;
+<genuine_connection_criteria>
+Set isGenuineConnection to true ONLY for:
+- Shared concepts discussed from different angles (e.g., both sections discuss the spacing effect but in different contexts)
+- Complementary perspectives on the same phenomenon (e.g., one section describes the problem, the other the solution)
+- Cause-and-effect relationships across sections
+- Specific pattern parallels (e.g., both describe a "10x improvement" or a similar structural pattern)
+</genuine_connection_criteria>
+
+<reject_as_superficial>
+Set isGenuineConnection to false if:
+- Both sections merely mention the same broad topic (e.g., both mention "software" or "learning")
+- The connection requires stretching or over-interpreting the text
+- You cannot cite a specific fact from each section that supports the connection
+</reject_as_superficial>
+
+<format>
+- Content must explain the CONNECTION between the two ideas, not summarize each one separately
+- sourceATitleHint and sourceBTitleHint should be concise labels (use section title if more specific than document title)
+- Reference specific facts, names, numbers, or quotes from both sources
+</format>`;
 }
 
 function normalizeUsage(usage: {

--- a/packages/backend/convex/providers/highlightDraftLlm.ts
+++ b/packages/backend/convex/providers/highlightDraftLlm.ts
@@ -39,26 +39,51 @@ const responseSchema = z.object({
   cards: z.array(highlightCardSchema),
 });
 
+// --- Prompt improvement notes (scorer impact) ---
+// [CS] Added grounding: "the card content must directly reference the highlighted text"
+//   Prevents generic summaries that ignore the actual highlight. Content Specificity scorer
+//   penalizes content that could apply to any document.
+// [TSQ] Added "prefer quote type when highlight is < 200 chars"
+//   Short highlights are best as verbatim quotes. The quote quality scorer checks for exact
+//   substring match - choosing quote type for short text raises this score.
+// [LM] Added explicit "detect language from the source chunks first" step
+//   Language Match scorer uses diacritics detection. Explicit language detection step
+//   reduces mismatches on multilingual content.
+// [SV] Added "you MUST include all required fields for the chosen type"
+//   Structural Validity scorer calls castTypeData which throws on missing fields.
+//   Emphasizing required fields reduces structural failures.
+
 const SYSTEM_PROMPT = `You are an AI learning assistant for Scrollect, a personal learning feed app.
 Your job is to create focused learning cards from highlighted passages in a document.
 
-CONTENT PHILOSOPHY: Stay close to the source. The user highlighted these passages because they matter. Your cards must directly reference and build upon the highlighted text - not generic section summaries.
+<instructions>
+1. Detect the language of the source chunks. Write your entire response in that same language.
+2. For each highlight, read it carefully and choose the best-fit card type.
+3. The card content must directly reference the highlighted text - not generic section summaries.
+</instructions>
 
-LANGUAGE RULE: Write in the same language as the source content. If the chunks are in Polish, write in Polish. If in English, write in English. Never translate.
-
-CARD TYPE SELECTION: For each highlight, choose the single best-fit card type:
-- "quote" - for short, memorable, or thought-provoking passages. Copy the highlight text verbatim as quotedText.
+<card_type_selection>
+- "quote" - for short passages (under ~200 characters), memorable, or thought-provoking text. Copy the highlight text verbatim as quotedText, character by character.
 - "insight" - for conceptual passages, surprising details, or concrete examples. Write 2-4 sentences grounding the insight in the highlighted text. Use **bold** for key terms.
-- "quiz" - for factual claims, specific numbers, or testable knowledge. Create a question about the highlighted fact.
-- "summary" - for dense passages with multiple takeaways. Extract 2-5 bullet points from the highlight.
+- "quiz" - for factual claims, specific numbers, or testable knowledge. Create a question about a concrete fact from the highlighted text. All wrong options must be plausible.
+- "summary" - for dense passages with multiple distinct takeaways. Extract 2-5 bullet points, each containing at least one specific name, number, or term from the highlight.
+</card_type_selection>
 
-TYPE DATA REQUIREMENTS:
+<type_data_requirements>
+You MUST include all required fields for the chosen card type:
 - insight: no extra fields needed
-- quiz: variant ("multiple_choice" or "true_false"), question, options (4 for MC, ["True","False"] for TF), correctIndex (0-based), explanation
-- quote: quotedText (verbatim from source), attribution (optional)
-- summary: bulletPoints (2-5 specific takeaways)
+- quiz: variant ("multiple_choice" or "true_false"), question, options (4 for MC, ["True","False"] for TF), correctIndex (0-based), explanation (must reference the source)
+- quote: quotedText (exact verbatim text from source - not paraphrased), attribution (optional)
+- summary: bulletPoints (2-5 specific takeaways with concrete details)
+</type_data_requirements>
 
-IMPORTANT: Return exactly one card per highlight. Use the same highlightId from the input.`;
+<avoid>
+- Generic content like "this passage highlights an important aspect of..."
+- Paraphrasing the highlight instead of using its actual words
+- Quiz questions that are vague or have obviously wrong options
+</avoid>
+
+Return exactly one card per highlight. Use the same highlightId from the input.`;
 
 function buildUserPrompt(opts: {
   highlights: Array<{ highlightId: string; highlightText: string }>;

--- a/packages/backend/convex/providers/thematicLlm.ts
+++ b/packages/backend/convex/providers/thematicLlm.ts
@@ -19,19 +19,38 @@ const themeSchema = z.object({
   ),
 });
 
+// --- Prompt improvement notes (scorer impact) ---
+// [LM] Moved "Write in English" to a prominent position + added emphasis
+//   Language Match scorer for thematic expects English output regardless of source.
+//   The old prompt buried this rule in a list. Elevating it reduces mismatches on Polish input.
+// [CS] Added "Theme titles must name a specific concept, not a category"
+//   Content Specificity scorer penalizes generic titles like "Key Concepts" or "Main Ideas".
+//   Explicit instruction with negative examples steers toward concrete theme names.
+// [CS] Added "description must reference specific details from the sections"
+//   Forces descriptions to cite concrete evidence rather than abstract summaries.
+// [TSQ-thematic] Added "relevantSections must be EXACT section titles - copy them verbatim"
+//   The sectionCoverage scorer checks exact string match. Emphasizing verbatim copying
+//   prevents the model from slightly rewording section titles (which scores 0).
+
 function buildSystemPrompt(): string {
   return `You are a theme discovery assistant for Scrollect, a personal learning feed app.
 Given section summaries from a document, identify cross-cutting themes that span multiple sections.
 
-RULES:
-- Each theme MUST involve at least 2 sections
-- Discover 5-10 themes (fewer for shorter documents, more for longer ones)
-- Themes should represent ideas, patterns, or concepts that connect different parts of the document
-- Theme titles should be specific and descriptive, not generic
-- relevantSections must contain exact section titles from the input
-- Write in English regardless of source language
+IMPORTANT: Always write in English, regardless of the source language. Even if the section summaries are in Polish or another language, your theme titles and descriptions must be in English.
 
-Return a JSON object: { "themes": [{ "title": "...", "description": "...", "relevantSections": ["..."] }] }`;
+<rules>
+- Each theme MUST involve at least 2 sections
+- Discover 3-10 themes (fewer for shorter documents, more for longer ones)
+- Theme titles must name a specific concept, pattern, or idea - not a generic category
+- Descriptions must reference specific details from the relevant sections (names, facts, examples)
+- relevantSections must contain EXACT section titles copied verbatim from the input - do not rephrase them
+</rules>
+
+<avoid>
+- Generic theme titles: "Key Concepts", "Main Ideas", "Important Topics", "Core Themes"
+- Vague descriptions: "This theme explores various aspects of the topic"
+- Rewording section titles in relevantSections (must be exact matches)
+</avoid>`;
 }
 
 function normalizeUsage(usage: {

--- a/packages/backend/evalite.config.ts
+++ b/packages/backend/evalite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "evalite/config";
+
+export default defineConfig({
+  testTimeout: 120_000,
+  maxConcurrency: 5,
+  trialCount: 1,
+  cache: true,
+  scoreThreshold: 80,
+  forceRerunTriggers: [
+    "convex/providers/cardDraftLlm.ts",
+    "convex/providers/highlightDraftLlm.ts",
+    "convex/providers/thematicLlm.ts",
+    "convex/providers/connectionDiscoveryLlm.ts",
+  ],
+  server: { port: 3006 },
+});

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "dev": "convex dev",
     "dev:setup": "convex dev --configure --until-success",
-    "test": "vitest run"
+    "test": "vitest run",
+    "eval:dev": "evalite watch",
+    "eval:run": "evalite"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.48",
@@ -27,6 +29,7 @@
   "devDependencies": {
     "@scrollect/config": "workspace:*",
     "@types/node": "^24.3.0",
+    "evalite": "^1.0.0-beta.16",
     "typescript": "catalog:",
     "vitest": "^4.1.0"
   }


### PR DESCRIPTION
## Summary

- Add Evalite-based prompt eval framework for all 4 LLM generation pipelines (section drafts, highlight drafts, thematic discovery, connection discovery)
- Create 5 custom scorers: structural validity, language match, content specificity (LLM-as-judge), type-specific quality (LLM-as-judge), connection genuineness (LLM-as-judge)
- Build eval fixtures from real production data (Polish Lewandowski biography) and English stub documents (book, article, YouTube transcript)
- Improve all 4 LLM provider prompts with structured XML tags, grounding instructions, negative examples, and explicit quality constraints - each change annotated with which eval scorer it targets
- Add opt-in CI eval job triggered by `eval` label on PRs

## Prompt improvements (scorer impact mapping)

| Change | Scorers affected | Mechanism |
|---|---|---|
| Grounding step: "identify 2-3 specific details first" | Content Specificity | Forces extraction of concrete facts before writing, reducing generic filler |
| Negative examples: "avoid 'this chapter discusses...'" | Content Specificity | Scorer penalizes exactly these patterns - showing the model what NOT to write |
| Explicit language detection step | Language Match | Reduces mismatches on multilingual input, especially Polish |
| XML structure (`<instructions>`, `<avoid>`, `<format>`) | All scorers | Clear separation of concerns improves instruction following across all dimensions |
| Quote: "copy character by character" | Type-Specific Quality | Quote scorer checks exact substring match - explicit copy instruction reduces paraphrasing |
| Quiz: "all wrong options must be plausible" | Type-Specific Quality | Quiz scorer checks option plausibility and distinctness |
| Summary: "each bullet must contain a proper noun/number/term" | Content Specificity, Type-Specific Quality | Makes abstract bullets impossible, lifts both scores |
| Thematic: "titles must name a specific concept, not a category" | Content Specificity | Prevents generic titles like "Key Concepts" that score 0 |
| Thematic: "copy section titles verbatim" | Section Coverage | Custom scorer checks exact string match against input titles |
| Connection: step-by-step evaluation (identify A, identify B, explain link) | Connection Genuineness | Forces grounding in concrete evidence from both sections |

## New files

```
packages/backend/
  evalite.config.ts
  convex/pipeline/evals/
    fixtures/ (types, 3 EN docs, 1 PL doc with real prod highlights)
    scorers/ (5 scorers + index)
    cardDraft.eval.ts
    highlightDraft.eval.ts
    thematic.eval.ts
    connectionDiscovery.eval.ts
```

## Modified files

- `packages/backend/package.json` - evalite devDep + eval scripts
- `packages/backend/convex/pipeline/logic/cardDraftGeneration.ts` - export `computeStructuralScore`
- `packages/backend/convex/providers/cardDraftLlm.ts` - improved prompts
- `packages/backend/convex/providers/highlightDraftLlm.ts` - improved prompts
- `packages/backend/convex/providers/thematicLlm.ts` - improved prompts
- `packages/backend/convex/providers/connectionDiscoveryLlm.ts` - improved prompts
- `.github/workflows/ci.yml` - eval CI job

## Test plan

- [x] All 240 existing unit tests pass
- [x] Lint passes (0 errors)
- [x] Format passes
- [x] Pre-commit hooks pass
- [ ] Run `cd packages/backend && bun run eval:dev` locally with OPENAI_API_KEY to verify evals execute and Evalite UI shows results at localhost:3006
- [ ] Verify structural validity >95% across fixtures
- [ ] Verify language match: Polish cards in Polish, English in English, thematic themes in English
- [ ] Compare prompt improvements vs baseline by reverting provider changes and re-running

Closes #142