### PR TITLE
feat(#166): require proper names and complete attribution in card generation

### DIFF
--- a/packages/backend/evals/cardDraft.eval.ts
+++ b/packages/backend/evals/cardDraft.eval.ts
@@ -8,6 +8,8 @@ import {
   languageMatch,
   contentSpecificity,
   typeSpecificQuality,
+  referenceClarity,
+  quoteContextCompleteness,
 } from "./scorers";
 
 type SectionInput = {
@@ -64,6 +66,13 @@ evalite.each([
       expectedLanguage: input.expectedLanguage,
     } satisfies CardDraftOutput;
   },
-  scorers: [structuralValidity, languageMatch, contentSpecificity, typeSpecificQuality],
+  scorers: [
+    structuralValidity,
+    languageMatch,
+    contentSpecificity,
+    typeSpecificQuality,
+    referenceClarity,
+    quoteContextCompleteness,
+  ],
   trialCount: 3,
 });

--- a/packages/backend/evals/scorers/index.ts
+++ b/packages/backend/evals/scorers/index.ts
@@ -2,4 +2,6 @@ export { structuralValidity } from "./structuralValidity";
 export { languageMatch, detectLanguage } from "./languageMatch";
 export { contentSpecificity } from "./contentSpecificity";
 export { typeSpecificQuality } from "./typeSpecificQuality";
+export { referenceClarity } from "./referenceClarity";
+export { quoteContextCompleteness } from "./quoteContextCompleteness";
 export { connectionGenuineness } from "./connectionGenuineness";

--- a/packages/backend/evals/scorers/quoteContextCompleteness.ts
+++ b/packages/backend/evals/scorers/quoteContextCompleteness.ts
@@ -1,0 +1,72 @@
+import { createScorer } from "evalite";
+import { generateText, Output } from "ai";
+import { z } from "zod";
+
+import { getAI } from "../../src/providers/ai";
+
+const ratingSchema = z.object({
+  score: z
+    .number()
+    .min(0)
+    .max(1)
+    .describe("Quote completeness score from 0 (missing attribution) to 1 (fully attributed)"),
+  rationale: z.string().describe("Brief explanation of the score"),
+});
+
+export const quoteContextCompleteness = createScorer<any, any, any>({
+  name: "Quote Context Completeness",
+  description:
+    "LLM-as-judge: checks that quote cards include speaker attribution with proper name and context about who/what the quote refers to",
+  scorer: async ({ output }) => {
+    if (output.cardType !== "quote") {
+      return {
+        score: 1,
+        metadata: { rationale: "Not a quote card, skipping" },
+      };
+    }
+
+    const attribution = output.typeData?.attribution;
+    const content = output.content;
+    const chunks = output.sourceChunks ?? [];
+
+    if (!content && !attribution) {
+      return {
+        score: 0,
+        metadata: { rationale: "Quote card has no content or attribution" },
+      };
+    }
+
+    const { output: result } = await generateText({
+      model: getAI().languageModel("evaluate"),
+      output: Output.object({ schema: ratingSchema }),
+      system: `You are a quote attribution evaluator. Check whether a quote card has complete attribution and context.
+
+A fully attributed quote card must have:
+1. WHO said it - the speaker's proper name (not "the author" or "a coach"), provided in the attribution field
+2. Context in the content field explaining ABOUT WHOM or WHAT the quote is about
+3. WHEN/WHERE context if available in the source (not required if the source doesn't provide it)
+
+Scoring:
+Score 0: No attribution or only vague attribution (e.g. "the author", "a player"). Content provides no context.
+Score 0.3: Attribution is present but uses a title/role instead of a proper name, OR content lacks context about the subject of the quote.
+Score 0.7: Proper name attribution is present and content provides some context, but missing key details available in the source.
+Score 1: Full proper name attribution, content explains who/what the quote is about, and includes when/where if the source provides it.`,
+      prompt: `Evaluate this quote card's attribution completeness:
+
+Attribution field: "${attribution ?? "(missing)"}"
+Card content: "${content}"
+Quoted text: "${output.typeData?.quotedText ?? ""}"
+
+Source material:
+${chunks.slice(0, 3).join("\n---\n")}`,
+      temperature: 0,
+    });
+
+    const rating = result ?? { score: 0, rationale: "No output from LLM" };
+
+    return {
+      score: rating.score,
+      metadata: { rationale: rating.rationale },
+    };
+  },
+});

--- a/packages/backend/evals/scorers/referenceClarity.ts
+++ b/packages/backend/evals/scorers/referenceClarity.ts
@@ -1,0 +1,59 @@
+import { createScorer } from "evalite";
+import { generateText, Output } from "ai";
+import { z } from "zod";
+
+import { getAI } from "../../src/providers/ai";
+
+const ratingSchema = z.object({
+  score: z
+    .number()
+    .min(0)
+    .max(1)
+    .describe("Reference clarity score from 0 (vague references) to 1 (all proper names used)"),
+  rationale: z.string().describe("Brief explanation of the score"),
+});
+
+export const referenceClarity = createScorer<any, any, any>({
+  name: "Reference Clarity",
+  description:
+    "LLM-as-judge: penalizes vague references like 'the player' or 'the author' when proper names are available in the source",
+  scorer: async ({ output }) => {
+    if (!output.content) {
+      return {
+        score: 1,
+        metadata: {
+          rationale: "No content to evaluate (follows suite convention for empty outputs)",
+        },
+      };
+    }
+
+    const chunks = output.sourceChunks ?? [];
+
+    const { output: result } = await generateText({
+      model: getAI().languageModel("evaluate"),
+      output: Output.object({ schema: ratingSchema }),
+      system: `You are a reference clarity evaluator. Check whether a learning card uses proper names instead of vague references.
+
+Score 0: Card uses vague references like "the player", "the coach", "the author", "the expert", "a prominent figure" when the person's actual name is clearly available in the source material.
+Score 0.5: Some proper names are used but there are still vague references where names were available.
+Score 1: All people, teams, and organizations mentioned in the card are referred to by their proper names when those names appear in the source.
+
+Important: Only penalize vague references when the proper name IS available in the source. If the source itself uses a vague reference without providing a name, the card is not expected to invent one.`,
+      prompt: `Evaluate reference clarity in this learning card:
+
+Card content: "${output.content}"
+Type data: ${JSON.stringify(output.typeData, null, 2)}
+
+Source material:
+${chunks.slice(0, 3).join("\n---\n")}`,
+      temperature: 0,
+    });
+
+    const rating = result ?? { score: 0, rationale: "No output from LLM" };
+
+    return {
+      score: rating.score,
+      metadata: { rationale: rating.rationale },
+    };
+  },
+});

--- a/packages/backend/src/providers/cardDraftLlm.ts
+++ b/packages/backend/src/providers/cardDraftLlm.ts
@@ -37,7 +37,12 @@ const quoteSchema = z.object({
     .string()
     .min(10)
     .describe("Exact verbatim quote copied from the source chunks - do not paraphrase"),
-  attribution: z.string().nullable().describe("Author or source name if available"),
+  attribution: z
+    .string()
+    .min(1)
+    .describe(
+      "Who said or wrote this quote - use their full proper name (e.g. 'Robert Lewandowski', not 'the player')",
+    ),
 });
 
 const summarySchema = z.object({
@@ -73,6 +78,8 @@ Your job is to create a single focused learning card from a section of a documen
 - Prefer exact wordings, specific facts, and concrete examples over generic summaries
 - The user wants to re-encounter the actual content they saved, not a paraphrased version
 - Every sentence must reference something specific from the source chunks
+- ALWAYS use proper names (e.g. "Marie Curie", "Google DeepMind") instead of vague references (e.g. "the scientist", "the company", "the author", "the coach"). If a person's or organization's name appears in the source, use it
+- When referring to people, places, teams, or organizations, use their specific names from the source text. Never substitute a proper name with a generic title or pronoun when the name is available
 </quality_rules>
 
 <avoid>
@@ -80,6 +87,8 @@ Your job is to create a single focused learning card from a section of a documen
 - "The author explores various aspects of..."
 - "There are several key factors that..."
 - Any sentence that could apply to a different document without changes
+- Vague references like "the player", "the coach", "the author", "the expert" when their proper name is in the source
+- "A prominent figure" or "one individual" instead of their actual name
 </avoid>`;
 
   switch (cardType) {
@@ -116,7 +125,9 @@ Your job is to create a single focused learning card from a section of a documen
 - Search the source chunks for the most impactful, memorable, or thought-provoking passage
 - Copy the passage exactly as it appears in the source, character by character - do not paraphrase, rephrase, or clean up the text
 - The quotedText must be a verbatim substring of one of the source chunks
-- In the content field, provide 1-2 sentences of context explaining why this quote matters
+- The attribution field is REQUIRED: always include the speaker's or writer's full proper name (e.g. "Ada Lovelace", not "a mathematician" or "the author")
+- In the content field, provide 1-2 sentences of context that include: WHO said it (proper name), ABOUT WHOM or WHAT it was said, and WHEN/WHERE if available in the source
+- The content must make the quote fully understandable without needing to read the original source
 </format>`;
 
     case "summary":
@@ -195,7 +206,7 @@ ${chunkText}`;
       case "quote": {
         const q = result as z.infer<typeof quoteSchema>;
         typeData.quotedText = q.quotedText;
-        if (q.attribution) typeData.attribution = q.attribution;
+        typeData.attribution = q.attribution;
         break;
       }
       case "summary": {


### PR DESCRIPTION
## Summary

- Updated `quality_rules` and `avoid` prompt sections to explicitly require proper names (e.g. "Marie Curie") over vague references (e.g. "the scientist", "the author")
- Updated quote format prompt to mandate complete attribution: WHO said it (proper name), ABOUT WHOM/WHAT, and WHEN/WHERE
- Made `attribution` required (not nullable) in the quote card Zod schema for LLM generation
- Added `referenceClarity` eval scorer - LLM-as-judge that penalizes vague references when proper names are available in source
- Added `quoteContextCompleteness` eval scorer - LLM-as-judge that checks quote cards for full speaker attribution and context

## Test plan

- [ ] Run `bun run eval` on card draft evals and verify `referenceClarity` scorer produces scores > 0.7 on fixture data
- [ ] Run `bun run eval` and verify `quoteContextCompleteness` scorer produces scores > 0.7 on quote card fixtures
- [ ] Manually verify generated cards from Lewandowski fixture use "Robert Lewandowski" instead of "the player"
- [ ] Verify quote cards from Lewandowski fixture include proper name attribution (e.g. "Wojciech Szczesny", "Zbigniew Boniek")

Closes #166