### PR TITLE
feat(#167): clean speech artifacts from YouTube transcription quotes

### DIFF
--- a/packages/backend/convex/pipeline/cardDraftGeneration.ts
+++ b/packages/backend/convex/pipeline/cardDraftGeneration.ts
@@ -125,6 +125,7 @@ export const generateDraftsForSectionBatch = internalAction({
           userId: doc.userId,
           documentTitle: doc.title,
           language: doc.language,
+          fileType: doc.fileType,
           section: {
             sectionSummaryId: sectionSummaryId as string,
             sectionTitle: section.sectionTitle,

--- a/packages/backend/convex/pipeline/thematicDraftGeneration.ts
+++ b/packages/backend/convex/pipeline/thematicDraftGeneration.ts
@@ -75,6 +75,7 @@ export const generateThematicDraftsForDocument = internalAction({
           userId,
           documentTitle: doc.title,
           language: doc.language,
+          fileType: doc.fileType,
           themes: discoveryResult.themes,
           sectionSummaries,
           chunkContentMap,

--- a/packages/backend/evals/cardDraft.eval.ts
+++ b/packages/backend/evals/cardDraft.eval.ts
@@ -10,6 +10,7 @@ import {
   typeSpecificQuality,
   referenceClarity,
   quoteContextCompleteness,
+  transcriptionPolish,
 } from "./scorers";
 
 type SectionInput = {
@@ -18,6 +19,7 @@ type SectionInput = {
   chunks: Array<{ content: string; chunkId: string }>;
   documentTitle: string;
   expectedLanguage: "en" | "pl";
+  fileType?: string;
 };
 
 type CardDraftOutput = {
@@ -26,6 +28,7 @@ type CardDraftOutput = {
   typeData: Record<string, unknown>;
   sourceChunks: string[];
   expectedLanguage: "en" | "pl";
+  fileType?: string;
 };
 
 const llm = new AiSdkCardDraftLlm();
@@ -38,6 +41,7 @@ function buildSectionInputs(): SectionInput[] {
       chunks: section.chunks,
       documentTitle: doc.title,
       expectedLanguage: doc.language,
+      fileType: doc.fileType,
     })),
   );
 }
@@ -56,6 +60,7 @@ evalite.each([
       sectionTitle: input.sectionTitle,
       chunks: input.chunks,
       documentTitle: input.documentTitle,
+      fileType: input.fileType,
     });
 
     return {
@@ -64,6 +69,7 @@ evalite.each([
       typeData: card.typeData,
       sourceChunks: input.chunks.map((c) => c.content),
       expectedLanguage: input.expectedLanguage,
+      fileType: input.fileType,
     } satisfies CardDraftOutput;
   },
   scorers: [
@@ -73,6 +79,7 @@ evalite.each([
     typeSpecificQuality,
     referenceClarity,
     quoteContextCompleteness,
+    transcriptionPolish,
   ],
   trialCount: 3,
 });

--- a/packages/backend/evals/fixtures/types.ts
+++ b/packages/backend/evals/fixtures/types.ts
@@ -8,5 +8,6 @@ export type FixtureSection = {
 export type FixtureDocument = {
   title: string;
   language: "en" | "pl";
+  fileType?: string;
   sections: FixtureSection[];
 };

--- a/packages/backend/evals/fixtures/youtube-en-ml.ts
+++ b/packages/backend/evals/fixtures/youtube-en-ml.ts
@@ -3,6 +3,7 @@ import type { FixtureDocument } from "./types";
 export const YOUTUBE_EN_ML: FixtureDocument = {
   title: "Introduction to Machine Learning Fundamentals",
   language: "en",
+  fileType: "youtube",
   sections: [
     {
       sectionTitle: "What is Machine Learning",
@@ -11,7 +12,7 @@ export const YOUTUBE_EN_ML: FixtureDocument = {
       chunks: [
         {
           content:
-            "Machine learning is a subset of artificial intelligence where systems learn from data rather than being explicitly programmed. Instead of writing rules by hand, we provide examples and let algorithms discover patterns automatically. This paradigm shift has enabled breakthroughs in image recognition, natural language processing, and recommendation systems that would have been impossible with traditional programming.",
+            "So machine learning is is a subset of artificial intelligence where where systems learn from data rather than being um explicitly programmed. Instead of you know writing rules by hand, we we provide examples and let algorithms discover patterns automatically. This this paradigm shift has like enabled breakthroughs in image recognition, natural language processing, and um recommendation systems that would have been impossible with traditional programming.",
           chunkId: "youtube-en-ml-chunk-0",
         },
       ],
@@ -23,7 +24,7 @@ export const YOUTUBE_EN_ML: FixtureDocument = {
       chunks: [
         {
           content:
-            "There are three main categories of machine learning. Supervised learning uses labeled training data to learn a mapping from inputs to outputs. Common tasks include classification, where we predict discrete categories, and regression, where we predict continuous values. Examples include spam detection, medical diagnosis, and house price prediction.",
+            "There are um there are three main categories of machine learning. Supervised learning uses like labeled training data to to learn a mapping from inputs to outputs. Common tasks include classification, where we we predict discrete categories, and regression, where we predict uh continuous values. Examples include like spam detection, medical diagnosis, and house price prediction.",
           chunkId: "youtube-en-ml-chunk-1",
         },
       ],
@@ -35,12 +36,12 @@ export const YOUTUBE_EN_ML: FixtureDocument = {
       chunks: [
         {
           content:
-            "Unsupervised learning works with unlabeled data, discovering hidden structure and patterns. Clustering algorithms group similar data points together, while dimensionality reduction techniques compress high-dimensional data into lower-dimensional representations. These techniques are invaluable for exploratory data analysis and feature engineering.",
+            "Unsupervised learning works with um unlabeled data, discovering hidden structure and and patterns. Clustering algorithms like group similar data points together, while dimensionality reduction techniques compress high-dimensional data into into lower-dimensional representations. These techniques are are invaluable for exploratory data analysis and feature engineering.",
           chunkId: "youtube-en-ml-chunk-2",
         },
         {
           content:
-            "Reinforcement learning takes a different approach entirely. An agent interacts with an environment, taking actions and receiving rewards or penalties. Over time, the agent learns a policy that maximizes cumulative reward. This paradigm powers game-playing AIs, robotics control systems, and recommendation engines that adapt to user behavior in real time.",
+            "Reinforcement learning takes a a different approach entirely. An agent interacts with an environment, taking actions and receiving um rewards or penalties. Over time, the the agent learns a policy that maximizes cumulative reward. This paradigm you know powers game-playing AIs, robotics control systems, and recommendation engines that adapt to user behavior in real time.",
           chunkId: "youtube-en-ml-chunk-3",
         },
       ],
@@ -52,7 +53,7 @@ export const YOUTUBE_EN_ML: FixtureDocument = {
       chunks: [
         {
           content:
-            "The training process involves splitting data into training, validation, and test sets. We fit the model on training data, tune hyperparameters using validation data, and evaluate final performance on the held-out test set. Cross-validation provides more robust estimates by rotating which subset serves as the validation set. Overfitting occurs when a model memorizes training data rather than learning generalizable patterns.",
+            "The the training process involves splitting data into um training, validation, and test sets. We fit the model on training data, tune hyperparameters using like validation data, and evaluate final performance on the held-out test set. Cross-validation provides you know more robust estimates by rotating which subset serves as the validation set. Overfitting occurs when a model memorizes like memorizes training data rather than learning generalizable patterns.",
           chunkId: "youtube-en-ml-chunk-4",
         },
       ],

--- a/packages/backend/evals/scorers/index.ts
+++ b/packages/backend/evals/scorers/index.ts
@@ -5,3 +5,4 @@ export { typeSpecificQuality } from "./typeSpecificQuality";
 export { referenceClarity } from "./referenceClarity";
 export { quoteContextCompleteness } from "./quoteContextCompleteness";
 export { connectionGenuineness } from "./connectionGenuineness";
+export { transcriptionPolish } from "./transcriptionPolish";

--- a/packages/backend/evals/scorers/transcriptionPolish.ts
+++ b/packages/backend/evals/scorers/transcriptionPolish.ts
@@ -1,0 +1,60 @@
+import { createScorer } from "evalite";
+
+import { isSpeechSource } from "../../src/providers/contentTypes";
+
+const SPEECH_FILLER_PATTERN = /\b(um|uh|uh huh|uhh|umm|hmm|er|erm)\b/gi;
+
+const STUTTER_PATTERN = /\b(\w+)\s+\1\b/gi;
+
+function countSpeechArtifacts(text: string): number {
+  const fillers = text.match(SPEECH_FILLER_PATTERN) ?? [];
+  const stutters = text.match(STUTTER_PATTERN) ?? [];
+  return fillers.length + stutters.length;
+}
+
+export const transcriptionPolish = createScorer<any, any, any>({
+  name: "Transcription Polish",
+  description:
+    "Checks that YouTube/speech-source quote cards have speech artifacts removed while non-speech sources are unaffected",
+  scorer: async ({ output }) => {
+    if (output.cardType !== "quote") {
+      return { score: 1, metadata: { rationale: "Not a quote card, skipping" } };
+    }
+
+    if (!isSpeechSource(output.fileType)) {
+      return { score: 1, metadata: { rationale: "Not a speech source, skipping" } };
+    }
+
+    const quotedText: string = output.typeData?.quotedText ?? "";
+    if (!quotedText) {
+      return { score: 0, metadata: { rationale: "No quoted text found" } };
+    }
+
+    const artifactCount = countSpeechArtifacts(quotedText);
+
+    if (artifactCount === 0) {
+      return { score: 1, metadata: { rationale: "No speech artifacts detected in quoted text" } };
+    }
+
+    const words = quotedText.split(/\s+/).length;
+    const artifactDensity = artifactCount / words;
+
+    if (artifactDensity > 0.1) {
+      return {
+        score: 0,
+        metadata: {
+          rationale: `High speech artifact density: ${artifactCount} artifacts in ${words} words (${(artifactDensity * 100).toFixed(1)}%)`,
+          artifactCount,
+        },
+      };
+    }
+
+    return {
+      score: 0.5,
+      metadata: {
+        rationale: `Some speech artifacts remain: ${artifactCount} in ${words} words`,
+        artifactCount,
+      },
+    };
+  },
+});

--- a/packages/backend/src/pipeline/logic/cardDraftGeneration.ts
+++ b/packages/backend/src/pipeline/logic/cardDraftGeneration.ts
@@ -27,6 +27,7 @@ export type GenerateDraftsInput = {
   userId: string;
   documentTitle: string;
   language?: string;
+  fileType?: string;
   section: SectionInput;
   allChunks: ChunkData[];
   existingHashes: ReadonlySet<string>;
@@ -248,6 +249,7 @@ export async function generateDraftsForSection(opts: {
           chunks: chunksForLlm,
           documentTitle,
           language: input.language,
+          fileType: input.fileType,
         })
         .then((result) => ({ cardType, ...result })),
     ),

--- a/packages/backend/src/pipeline/logic/thematicDraftGeneration.ts
+++ b/packages/backend/src/pipeline/logic/thematicDraftGeneration.ts
@@ -32,6 +32,7 @@ export type ThematicDraftInput = {
   userId: string;
   documentTitle: string;
   language?: string;
+  fileType?: string;
   themes: Theme[];
   sectionSummaries: Array<{ sectionTitle: string; summary: string }>;
   chunkContentMap: ReadonlyMap<string, string>;
@@ -182,6 +183,7 @@ async function generateDraftsForTheme(opts: {
           chunks,
           documentTitle: input.documentTitle,
           language: input.language,
+          fileType: input.fileType,
         })
         .then((result) => ({ cardType, ...result })),
     ),

--- a/packages/backend/src/providers/cardDraftLlm.ts
+++ b/packages/backend/src/providers/cardDraftLlm.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import type { CardDraftLlm, DraftCardType, TokenUsage } from "./types";
 import { getAI } from "./ai";
+import { isSpeechSource } from "./contentTypes";
 import { buildLanguageInstruction } from "./promptUtils";
 
 const insightSchema = z.object({
@@ -63,8 +64,12 @@ const SCHEMAS: Record<DraftCardType, z.ZodSchema> = {
   summary: summarySchema,
 };
 
-function buildSystemPrompt(opts: { cardType: DraftCardType; language?: string }): string {
-  const { cardType, language } = opts;
+function buildSystemPrompt(opts: {
+  cardType: DraftCardType;
+  language?: string;
+  fileType?: string;
+}): string {
+  const { cardType, language, fileType } = opts;
   const base = `You are an AI learning assistant for Scrollect, a personal learning feed app.
 Your job is to create a single focused learning card from a section of a document.
 
@@ -121,14 +126,26 @@ Your job is to create a single focused learning card from a section of a documen
 
 <task>Create a QUOTE card featuring a notable passage from the source.</task>
 
-<format>
+${
+  isSpeechSource(fileType)
+    ? `<format>
+- Search the source chunks for the most impactful, memorable, or thought-provoking passage
+- The source is a speech transcription that may contain fillers (e.g. "um", "uh", "like", "you know"), stutters, false starts, and word repetitions
+- Lightly clean the passage: remove fillers, stutters, false starts, and word repetitions while preserving the speaker's original meaning, voice, and phrasing
+- Do NOT paraphrase or rewrite - only remove speech artifacts. The cleaned quote should read as if the speaker had spoken fluently
+- The attribution field is REQUIRED: always include the speaker's full proper name (e.g. "Ada Lovelace", not "a mathematician" or "the speaker")
+- In the content field, provide 1-2 sentences of context that include: WHO said it (proper name), ABOUT WHOM or WHAT it was said, and WHEN/WHERE if available in the source
+- The content must make the quote fully understandable without needing to read the original source
+</format>`
+    : `<format>
 - Search the source chunks for the most impactful, memorable, or thought-provoking passage
 - Copy the passage exactly as it appears in the source, character by character - do not paraphrase, rephrase, or clean up the text
 - The quotedText must be a verbatim substring of one of the source chunks
 - The attribution field is REQUIRED: always include the speaker's or writer's full proper name (e.g. "Ada Lovelace", not "a mathematician" or "the author")
 - In the content field, provide 1-2 sentences of context that include: WHO said it (proper name), ABOUT WHOM or WHAT it was said, and WHEN/WHERE if available in the source
 - The content must make the quote fully understandable without needing to read the original source
-</format>`;
+</format>`
+}`;
 
     case "summary":
       return `${base}
@@ -163,6 +180,7 @@ export class AiSdkCardDraftLlm implements CardDraftLlm {
     chunks: Array<{ content: string; chunkId: string }>;
     documentTitle: string;
     language?: string;
+    fileType?: string;
   }): Promise<{
     card: { content: string; typeData: Record<string, unknown> };
     usage: TokenUsage;
@@ -181,7 +199,11 @@ ${chunkText}`;
     const { output, usage } = await generateText({
       model: getAI().languageModel("generate"),
       output: Output.object({ schema }),
-      system: buildSystemPrompt({ cardType: opts.cardType, language: opts.language }),
+      system: buildSystemPrompt({
+        cardType: opts.cardType,
+        language: opts.language,
+        fileType: opts.fileType,
+      }),
       prompt,
       temperature: 0.4,
       maxRetries: 2,

--- a/packages/backend/src/providers/contentTypes.ts
+++ b/packages/backend/src/providers/contentTypes.ts
@@ -1,0 +1,5 @@
+const SPEECH_SOURCE_FILE_TYPES = new Set(["youtube"]);
+
+export function isSpeechSource(fileType?: string): boolean {
+  return fileType != null && SPEECH_SOURCE_FILE_TYPES.has(fileType);
+}

--- a/packages/backend/src/providers/stubs.ts
+++ b/packages/backend/src/providers/stubs.ts
@@ -239,6 +239,7 @@ export class StubCardDraftLlm implements CardDraftLlm {
     chunks: Array<{ content: string; chunkId: string }>;
     documentTitle: string;
     language?: string;
+    fileType?: string;
   }): Promise<{
     card: { content: string; typeData: Record<string, unknown> };
     usage: TokenUsage;

--- a/packages/backend/src/providers/types.ts
+++ b/packages/backend/src/providers/types.ts
@@ -219,6 +219,7 @@ export interface CardDraftLlm {
     chunks: Array<{ content: string; chunkId: string }>;
     documentTitle: string;
     language?: string;
+    fileType?: string;
   }): Promise<{
     card: { content: string; typeData: Record<string, unknown> };
     usage: TokenUsage;

--- a/packages/backend/tests/pipeline/logic/cardDraftGeneration.test.ts
+++ b/packages/backend/tests/pipeline/logic/cardDraftGeneration.test.ts
@@ -305,6 +305,25 @@ describe("generateDraftsForSection", () => {
     expect(result.metrics.draftsFailedLlm).toBe(1);
   });
 
+  it("passes fileType through to the LLM", async () => {
+    const generateDraft = vi.fn().mockResolvedValue({
+      card: {
+        content: "Draft insight for testing: a useful learning card.",
+        typeData: { type: "insight" },
+      },
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    });
+    const llm = createMockCardDraftLlm({ generateDraft });
+    const services = createMockDraftGenerationServices({ llm });
+
+    await generateDraftsForSection({
+      input: makeInput({ fileType: "youtube" }),
+      services,
+    });
+
+    expect(generateDraft).toHaveBeenCalledWith(expect.objectContaining({ fileType: "youtube" }));
+  });
+
   it("sets correct metadata on generated drafts", async () => {
     const services = createMockDraftGenerationServices();
     const result = await generateDraftsForSection({


### PR DESCRIPTION
## Summary

- Thread `fileType` through the card generation pipeline (`types.ts` -> `cardDraftLlm.ts` -> `cardDraftGeneration.ts` logic -> Convex action) so the LLM prompt branches for speech vs written sources
- YouTube/audio quote cards get light cleaning (fillers, stutters, false starts removed) while written sources (books, articles, PDFs) keep verbatim copying
- Extract shared `isSpeechSource()` into `src/providers/contentTypes.ts` for single source of truth
- Add `transcriptionPolish` eval scorer that detects speech artifacts in YouTube quote output
- Update YouTube fixture with realistic speech artifacts for eval testing

## Test plan

- [x] Unit tests pass (17/17 including new `fileType` threading test)
- [x] `bun run check` passes (lint + format)
- [x] `bun turbo run build` passes
- [x] Card draft eval passes at 91% (threshold: 80%) with Transcription Polish scorer active
- [ ] CI passes (lint, build, E2E)

Closes #167