### PR TITLE
feat(#169): add section diversity and AI noise filtering to feed

### DIFF
--- a/packages/backend/convex/pipeline/cardDraftGeneration.ts
+++ b/packages/backend/convex/pipeline/cardDraftGeneration.ts
@@ -34,12 +34,20 @@ export const generateDraftsForDocument = internalAction({
         documentId,
       });
 
-      if (sections.length === 0) {
+      const contentSections = sections.filter((s) => s.isSubstantiveContent !== false);
+      const noiseSections = sections.filter((s) => s.isSubstantiveContent === false);
+      evt.set({
+        totalSections: sections.length,
+        noiseSectionsFiltered: noiseSections.length,
+        noiseTitles: noiseSections.map((s) => s.sectionTitle),
+      });
+
+      if (contentSections.length === 0) {
         await transitionToReady({ ctx, documentId, userId: doc.userId, evt });
         return;
       }
 
-      const totalBatches = sections.length;
+      const totalBatches = contentSections.length;
       const jobId = await ctx.runMutation(internal.processingJobs.create, {
         documentId,
         totalBatches,
@@ -47,7 +55,7 @@ export const generateDraftsForDocument = internalAction({
 
       evt.set({ totalBatches, jobId });
 
-      for (const section of sections) {
+      for (const section of contentSections) {
         await ctx.scheduler.runAfter(
           0,
           internal.pipeline.cardDraftGeneration.generateDraftsForSectionBatch,

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -126,6 +126,7 @@ export default defineSchema({
     documentId: v.id("documents"),
     sectionTitle: v.string(),
     summary: v.string(),
+    isSubstantiveContent: v.optional(v.boolean()),
     embeddingId: v.string(),
     chunkStartIndex: v.number(),
     chunkEndIndex: v.number(),

--- a/packages/backend/convex/sectionSummaries.ts
+++ b/packages/backend/convex/sectionSummaries.ts
@@ -10,6 +10,7 @@ export const createBatch = internalMutation({
       v.object({
         sectionTitle: v.string(),
         summary: v.string(),
+        isSubstantiveContent: v.optional(v.boolean()),
         embeddingId: v.string(),
         chunkStartIndex: v.number(),
         chunkEndIndex: v.number(),
@@ -24,6 +25,7 @@ export const createBatch = internalMutation({
         documentId: args.documentId,
         sectionTitle: s.sectionTitle,
         summary: s.summary,
+        isSubstantiveContent: s.isSubstantiveContent,
         embeddingId: s.embeddingId,
         chunkStartIndex: s.chunkStartIndex,
         chunkEndIndex: s.chunkEndIndex,

--- a/packages/backend/src/feed/logic/constants.ts
+++ b/packages/backend/src/feed/logic/constants.ts
@@ -14,6 +14,8 @@ export const REACTION_WRONG_TYPE_MULTIPLIER = 0.5;
 export const REACTION_LIKE_SECTION_MULTIPLIER = 1.3;
 export const REACTION_LIKE_CARD_TYPE_MULTIPLIER = 1.15;
 
+export const SECTION_DIVERSITY_CAP = 0.25;
+
 /** Short highlights (< 20 chars) produce too many false substring matches against chunk content */
 export const MIN_HIGHLIGHT_MATCH_LENGTH = 20;
 

--- a/packages/backend/src/feed/logic/scoring.ts
+++ b/packages/backend/src/feed/logic/scoring.ts
@@ -7,12 +7,14 @@ import {
   REACTION_LIKE_SECTION_MULTIPLIER,
   REACTION_NOT_INTERESTING_MULTIPLIER,
   REACTION_WRONG_TYPE_MULTIPLIER,
+  SECTION_DIVERSITY_CAP,
 } from "./constants";
 
 export type ScoringConfig = {
   highlightBoost: number;
   maxConsecutiveSameType: number;
   documentDiversityCap: number;
+  sectionDiversityCap: number;
   batchSize: number;
   replenishmentThreshold: number;
   reactionNotInterestingMultiplier: number;
@@ -26,6 +28,7 @@ export const DEFAULT_SCORING_CONFIG: ScoringConfig = {
   highlightBoost: HIGHLIGHT_BOOST,
   maxConsecutiveSameType: MAX_CONSECUTIVE_SAME_TYPE,
   documentDiversityCap: 0.4,
+  sectionDiversityCap: SECTION_DIVERSITY_CAP,
   batchSize: 15,
   replenishmentThreshold: 10,
   reactionNotInterestingMultiplier: REACTION_NOT_INTERESTING_MULTIPLIER,
@@ -89,8 +92,13 @@ export function scoreDrafts(opts: {
 
   scored.sort((a, b) => b.score - a.score);
 
-  const reordered = applyTypeDiversity(scored, config.maxConsecutiveSameType);
-  return applyDocumentDiversity(reordered, config);
+  // Diversity passes run sequentially: type -> section -> document.
+  // Later passes may partially reorder earlier caps (e.g., document diversity could
+  // shift section-demoted items back up). This is intentional: document diversity is
+  // the final constraint and takes precedence when caps conflict.
+  const typeReordered = applyTypeDiversity(scored, config.maxConsecutiveSameType);
+  const sectionReordered = applySectionDiversity(typeReordered, config);
+  return applyDocumentDiversity(sectionReordered, config);
 }
 
 function computeReactionMultiplier(
@@ -161,6 +169,30 @@ function countTrailingType(items: ScoredDraftWithScore[]): number {
     count++;
   }
   return count;
+}
+
+function applySectionDiversity(
+  sorted: ScoredDraftWithScore[],
+  config: ScoringConfig,
+): ScoredDraftWithScore[] {
+  const effectiveSize = Math.min(sorted.length, config.batchSize);
+  const maxPerSection = Math.max(1, Math.floor(effectiveSize * config.sectionDiversityCap));
+  const sectionCounts = new Map<string, number>();
+  const accepted: ScoredDraftWithScore[] = [];
+  const demoted: ScoredDraftWithScore[] = [];
+
+  for (const draft of sorted) {
+    const key = draft.sectionSummaryId ?? draft.documentId;
+    const count = sectionCounts.get(key) ?? 0;
+    if (count < maxPerSection) {
+      accepted.push(draft);
+      sectionCounts.set(key, count + 1);
+    } else {
+      demoted.push(draft);
+    }
+  }
+
+  return [...accepted, ...demoted];
 }
 
 function applyDocumentDiversity(

--- a/packages/backend/src/pipeline/logic/summarizeLogic.ts
+++ b/packages/backend/src/pipeline/logic/summarizeLogic.ts
@@ -35,6 +35,7 @@ export function truncateSectionText(chunks: Array<{ content: string }>, maxChars
 export type SectionResult = {
   sectionTitle: string;
   summary: string;
+  isSubstantiveContent: boolean;
   chunkStartIndex: number;
   chunkEndIndex: number;
 };
@@ -53,6 +54,7 @@ export type SummaryVectorPointOutput = SummaryVectorPoint;
 export type SectionDbRecord = {
   sectionTitle: string;
   summary: string;
+  isSubstantiveContent?: boolean;
   embeddingId: string;
   chunkStartIndex: number;
   chunkEndIndex: number;
@@ -92,6 +94,7 @@ export function buildSummaryVectorPoints(input: SummaryPointsInput): {
     sectionDbRecords.push({
       sectionTitle: section.sectionTitle,
       summary: section.summary,
+      isSubstantiveContent: section.isSubstantiveContent,
       embeddingId,
       chunkStartIndex: section.chunkStartIndex,
       chunkEndIndex: section.chunkEndIndex,

--- a/packages/backend/src/pipeline/logic/summarizing.ts
+++ b/packages/backend/src/pipeline/logic/summarizing.ts
@@ -63,7 +63,7 @@ export async function summarizeDocumentLogic({
   const sectionCandidates = await Promise.all(
     groups.map(async (group) => {
       const combinedText = truncateSectionText(group.chunks, MAX_SECTION_CHUNKS_CHARS);
-      const { summary, usage } = await services.llm.generateSectionSummary({
+      const { summary, isSubstantiveContent, usage } = await services.llm.generateSectionSummary({
         sectionTitle: group.sectionTitle,
         combinedText,
         language,
@@ -74,6 +74,7 @@ export async function summarizeDocumentLogic({
       return {
         sectionTitle: group.sectionTitle,
         summary,
+        isSubstantiveContent,
         chunkStartIndex: Math.min(...indices),
         chunkEndIndex: Math.max(...indices),
         usage,
@@ -89,9 +90,12 @@ export async function summarizeDocumentLogic({
     return null;
   }
 
+  const substantiveSections = sectionResults.filter((s) => s.isSubstantiveContent);
+  const docSummaryInput = substantiveSections.length > 0 ? substantiveSections : sectionResults;
+
   const { summary: docSummary, usage: docSummaryUsage } =
     await services.llm.generateDocumentSummary({
-      sectionSummaries: sectionResults,
+      sectionSummaries: docSummaryInput,
       documentTitle,
       language,
     });

--- a/packages/backend/src/providers/summarizingLlm.ts
+++ b/packages/backend/src/providers/summarizingLlm.ts
@@ -5,11 +5,16 @@ import type { SummarizingLlm, TokenUsage } from "./types";
 import { getAI } from "./ai";
 import { buildLanguageInstruction } from "./promptUtils";
 
-const summarySchema = z.object({ summary: z.string() });
+const sectionSummarySchema = z.object({
+  summary: z.string(),
+  isSubstantiveContent: z.boolean(),
+});
+
+const docSummarySchema = z.object({ summary: z.string() });
 
 function buildSectionSummaryPrompt(language?: string): string {
   return `You are a summarization assistant for a personal learning app.
-Given text chunks from a section of a document, produce a concise summary that captures the key ideas, concepts, and insights.
+Given text chunks from a section of a document, produce a concise summary and classify whether the section contains substantive learning content.
 
 Rules:
 - Write 2-5 sentences
@@ -17,8 +22,11 @@ Rules:
 - Be specific - include key terms, names, and numbers
 - Write in third person
 - ${buildLanguageInstruction(language)}
+- Set "isSubstantiveContent" to true for chapters and sections with concepts, arguments, narrative, or educational value
+- Set "isSubstantiveContent" to false for: table of contents, bibliography, references, copyright notices, title pages, acknowledgments, ads, sponsor pages, publisher letters, bookstore promotions, appendices listing only names/links
+- When in doubt, classify as substantive (true)
 
-Return a JSON object: { "summary": "..." }`;
+Return a JSON object: { "summary": "...", "isSubstantiveContent": true/false }`;
 }
 
 function buildDocumentSummaryPrompt(language?: string): string {
@@ -52,10 +60,10 @@ export class AiSdkSummarizingLlm implements SummarizingLlm {
     sectionTitle: string;
     combinedText: string;
     language?: string;
-  }): Promise<{ summary: string; usage: TokenUsage }> {
+  }): Promise<{ summary: string; isSubstantiveContent: boolean; usage: TokenUsage }> {
     const { output, usage } = await generateText({
       model: getAI().languageModel("generate"),
-      output: Output.object({ schema: summarySchema }),
+      output: Output.object({ schema: sectionSummarySchema }),
       system: buildSectionSummaryPrompt(opts.language),
       prompt: `Section: "${opts.sectionTitle}"\n\n${opts.combinedText}`,
       temperature: 0.3,
@@ -64,6 +72,7 @@ export class AiSdkSummarizingLlm implements SummarizingLlm {
 
     return {
       summary: output?.summary ?? "",
+      isSubstantiveContent: output?.isSubstantiveContent ?? true,
       usage: normalizeUsage(usage),
     };
   }
@@ -79,7 +88,7 @@ export class AiSdkSummarizingLlm implements SummarizingLlm {
 
     const { output, usage } = await generateText({
       model: getAI().languageModel("generate"),
-      output: Output.object({ schema: summarySchema }),
+      output: Output.object({ schema: docSummarySchema }),
       system: buildDocumentSummaryPrompt(opts.language),
       prompt: `Document: "${opts.documentTitle}"\n\n${userContent}`,
       temperature: 0.3,

--- a/packages/backend/src/providers/types.ts
+++ b/packages/backend/src/providers/types.ts
@@ -172,7 +172,7 @@ export interface SummarizingLlm {
     sectionTitle: string;
     combinedText: string;
     language?: string;
-  }): Promise<{ summary: string; usage: TokenUsage }>;
+  }): Promise<{ summary: string; isSubstantiveContent: boolean; usage: TokenUsage }>;
 
   generateDocumentSummary(opts: {
     sectionSummaries: Array<{ sectionTitle: string; summary: string }>;

--- a/packages/backend/tests/feed/logic/scoring.test.ts
+++ b/packages/backend/tests/feed/logic/scoring.test.ts
@@ -280,6 +280,155 @@ describe("scoreDrafts", () => {
     });
   });
 
+  describe("section diversity cap", () => {
+    it("caps a dominant section at 25% of batch", () => {
+      const drafts = [
+        ...Array.from({ length: 10 }, (_, i) =>
+          makeDraft({
+            id: `secA-${i}`,
+            documentId: `doc-${i}`,
+            sectionSummaryId: "section-A",
+            qualityScore: 0.9,
+          }),
+        ),
+        ...Array.from({ length: 5 }, (_, i) =>
+          makeDraft({
+            id: `other-${i}`,
+            documentId: `doc-other-${i}`,
+            sectionSummaryId: `section-other-${i}`,
+            qualityScore: 0.8,
+          }),
+        ),
+      ];
+
+      const config: ScoringConfig = { ...DEFAULT_SCORING_CONFIG, batchSize: 15 };
+      const result = scoreDrafts({ drafts, config, now: NOW });
+
+      // 25% of batchSize(15) = 3 max per section
+      // Section-A gets 3 accepted, then 5 others, then 7 section-A demoted
+      // The accepted portion (first 8) should have at most 3 from section-A
+      const maxPerSection = Math.floor(15 * 0.25); // 3
+      const demotedCount = 10 - maxPerSection; // 7 section-A demoted
+      const acceptedPortion = result.slice(0, result.length - demotedCount);
+      const sectionACounts = acceptedPortion.filter(
+        (d) => d.sectionSummaryId === "section-A",
+      ).length;
+
+      expect(sectionACounts).toBeLessThanOrEqual(maxPerSection);
+    });
+
+    it("demotes excess section cards to end of list", () => {
+      const drafts = [
+        ...Array.from({ length: 5 }, (_, i) =>
+          makeDraft({
+            id: `secA-${i}`,
+            documentId: `doc-a-${i}`,
+            sectionSummaryId: "section-A",
+            qualityScore: 0.9,
+          }),
+        ),
+        ...Array.from({ length: 2 }, (_, i) =>
+          makeDraft({
+            id: `secB-${i}`,
+            documentId: `doc-b-${i}`,
+            sectionSummaryId: "section-B",
+            qualityScore: 0.8,
+          }),
+        ),
+      ];
+
+      const config: ScoringConfig = {
+        ...DEFAULT_SCORING_CONFIG,
+        sectionDiversityCap: 0.5,
+        batchSize: 4,
+      };
+      const result = scoreDrafts({ drafts, config, now: NOW });
+
+      // 50% of batchSize(4) = 2 max per section
+      // section-A gets 2 accepted, section-B gets 2 accepted
+      const first4 = result.slice(0, 4);
+      const secBInFirst4 = first4.filter((d) => d.sectionSummaryId === "section-B").length;
+      expect(secBInFirst4).toBeGreaterThanOrEqual(1);
+    });
+
+    it("uses documentId as fallback when sectionSummaryId is missing", () => {
+      const drafts = [
+        ...Array.from({ length: 6 }, (_, i) =>
+          makeDraft({
+            id: `noSec-${i}`,
+            documentId: "doc-same",
+            qualityScore: 0.9,
+          }),
+        ),
+        makeDraft({
+          id: "other-doc",
+          documentId: "doc-different",
+          qualityScore: 0.8,
+        }),
+      ];
+
+      const config: ScoringConfig = { ...DEFAULT_SCORING_CONFIG, batchSize: 7 };
+      const result = scoreDrafts({ drafts, config, now: NOW });
+
+      // Without sectionSummaryId, key = documentId
+      // "doc-same" gets max floor(7*0.25)=1 in accepted portion
+      // "doc-different" gets its own bucket
+      const sameDocInTop2 = result.slice(0, 2).filter((d) => d.documentId === "doc-same").length;
+      expect(sameDocInTop2).toBeLessThanOrEqual(1);
+    });
+
+    it("guarantees at least 1 card per section even with small batch", () => {
+      const drafts = Array.from({ length: 3 }, (_, i) =>
+        makeDraft({
+          id: `same-${i}`,
+          documentId: `doc-${i}`,
+          sectionSummaryId: "section-only",
+          qualityScore: 0.9 - i * 0.01,
+        }),
+      );
+
+      const config: ScoringConfig = { ...DEFAULT_SCORING_CONFIG, batchSize: 2 };
+      const result = scoreDrafts({ drafts, config, now: NOW });
+
+      // max(1, floor(2*0.25)) = max(1, 0) = 1
+      // At least 1 accepted from that section
+      expect(result).toHaveLength(3);
+      expect(result[0]!.sectionSummaryId).toBe("section-only");
+    });
+
+    it("section and document diversity work together", () => {
+      const drafts = Array.from({ length: 15 }, (_, i) => {
+        const sectionIndex = i % 3;
+        return makeDraft({
+          id: `combo-${i}`,
+          documentId: "doc-single",
+          sectionSummaryId: `section-${sectionIndex}`,
+          qualityScore: 0.9 - i * 0.01,
+        });
+      });
+
+      const config: ScoringConfig = { ...DEFAULT_SCORING_CONFIG, batchSize: 15 };
+      const result = scoreDrafts({ drafts, config, now: NOW });
+
+      // Section diversity: max floor(15*0.25)=3 per section
+      // Document diversity: max floor(15*0.4)=6 per document
+      // The accepted portion should show both caps in effect
+      const topBatch = result.slice(0, 6);
+      const sectionCounts = new Map<string, number>();
+      for (const d of topBatch) {
+        const key = d.sectionSummaryId!;
+        sectionCounts.set(key, (sectionCounts.get(key) ?? 0) + 1);
+      }
+
+      for (const [, count] of sectionCounts) {
+        expect(count).toBeLessThanOrEqual(3);
+      }
+
+      const docCount = topBatch.filter((d) => d.documentId === "doc-single").length;
+      expect(docCount).toBeLessThanOrEqual(6);
+    });
+  });
+
   describe("custom config overrides", () => {
     it("uses custom highlight boost", () => {
       const config: ScoringConfig = { ...DEFAULT_SCORING_CONFIG, highlightBoost: 5.0 };

--- a/packages/backend/tests/pipeline/logic/mocks.ts
+++ b/packages/backend/tests/pipeline/logic/mocks.ts
@@ -33,6 +33,7 @@ export function createMockSummarizingLlm(overrides?: Partial<SummarizingLlm>): S
   return {
     generateSectionSummary: async ({ sectionTitle }) => ({
       summary: `Summary of ${sectionTitle}`,
+      isSubstantiveContent: true,
       usage: ZERO_USAGE,
     }),
     generateDocumentSummary: async () => ({

--- a/packages/backend/tests/pipeline/logic/summarizing.test.ts
+++ b/packages/backend/tests/pipeline/logic/summarizing.test.ts
@@ -52,6 +52,7 @@ describe("summarizeDocumentLogic", () => {
     expect(result!.docEmbeddingId).toBe(fakeIdToUuid("summary:doc:doc1"));
     expect(result!.sectionDbRecords).toHaveLength(1);
     expect(result!.sectionDbRecords[0]!.sectionTitle).toBe("Intro");
+    expect(result!.sectionDbRecords[0]!.isSubstantiveContent).toBe(true);
     expect(result!.embeddingUsage).toEqual({ tokens: 42 });
 
     expect(result!.metrics.sectionGroups).toBe(1);
@@ -70,6 +71,7 @@ describe("summarizeDocumentLogic", () => {
       llm: {
         generateSectionSummary: vi.fn().mockResolvedValue({
           summary: "",
+          isSubstantiveContent: true,
           usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
         }),
         generateDocumentSummary: docSummaryFn,
@@ -114,7 +116,9 @@ describe("summarizeDocumentLogic", () => {
     const usage = { inputTokens: 10, outputTokens: 5, totalTokens: 15 };
     const services = createMockSummarizingServices({
       llm: {
-        generateSectionSummary: vi.fn().mockResolvedValue({ summary: "section summary", usage }),
+        generateSectionSummary: vi
+          .fn()
+          .mockResolvedValue({ summary: "section summary", isSubstantiveContent: true, usage }),
         generateDocumentSummary: vi.fn().mockResolvedValue({ summary: "doc summary", usage }),
       },
       embedder: {
@@ -181,6 +185,7 @@ describe("summarizeDocumentLogic", () => {
   it("forwards language to section and document summary LLM calls", async () => {
     const sectionFn = vi.fn().mockResolvedValue({
       summary: "section summary",
+      isSubstantiveContent: true,
       usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
     });
     const docFn = vi.fn().mockResolvedValue({
@@ -213,5 +218,68 @@ describe("summarizeDocumentLogic", () => {
 
     expect(sectionFn).toHaveBeenCalledWith(expect.objectContaining({ language: "pl" }));
     expect(docFn).toHaveBeenCalledWith(expect.objectContaining({ language: "pl" }));
+  });
+
+  it("threads isSubstantiveContent from LLM through to sectionDbRecords", async () => {
+    const sectionFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        summary: "chapter content",
+        isSubstantiveContent: true,
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      })
+      .mockResolvedValueOnce({
+        summary: "bibliography listing",
+        isSubstantiveContent: false,
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      });
+
+    const docFn = vi.fn().mockResolvedValue({
+      summary: "doc summary",
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    });
+
+    const services = createMockSummarizingServices({
+      llm: {
+        generateSectionSummary: sectionFn,
+        generateDocumentSummary: docFn,
+      },
+      embedder: createMockEmbedder({
+        dimensions: 2,
+        embed: vi.fn().mockResolvedValue([
+          [0.1, 0.2],
+          [0.3, 0.4],
+          [0.5, 0.6],
+        ]),
+      }),
+    });
+
+    const result = await summarizeDocumentLogic({
+      input: {
+        documentId: "doc1",
+        userId: "user1",
+        documentTitle: "Test Doc",
+        chunks: [
+          makeChunk({ chunkIndex: 0, sectionTitle: "Chapter 1" }),
+          makeChunk({ chunkIndex: 1, sectionTitle: "Bibliography" }),
+        ],
+        staleVectorIds: [],
+        idToUuid: fakeIdToUuid,
+      },
+      services,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.sectionDbRecords).toHaveLength(2);
+
+    const chapter = result!.sectionDbRecords.find((r) => r.sectionTitle === "Chapter 1");
+    const biblio = result!.sectionDbRecords.find((r) => r.sectionTitle === "Bibliography");
+    expect(chapter!.isSubstantiveContent).toBe(true);
+    expect(biblio!.isSubstantiveContent).toBe(false);
+
+    // Noise sections are excluded from document summary input
+    const docSummaryCall = docFn.mock.calls[0]![0];
+    expect(docSummaryCall.sectionSummaries).toHaveLength(1);
+    expect(docSummaryCall.sectionSummaries[0].sectionTitle).toBe("Chapter 1");
   });
 });


### PR DESCRIPTION
## Summary

Closes #169

- **Section diversity**: caps any single section at 25% of the feed batch (max 3 of 15 cards), preventing one section from monopolizing the feed. Follows the existing `applyDocumentDiversity()` pattern
- **AI noise classification**: extends the summarization LLM output with `isSubstantiveContent: boolean` to classify sections as content vs noise (ads, bibliography, publisher letters). Near-zero marginal cost since the LLM already reads every section. Language-agnostic - no regex maintenance needed
- **Document summary quality**: excludes noise sections from document-level summary input so ads and publisher letters don't pollute the synthesis

## Root cause

Investigation of the production EPUB "Lewandowski._Prawdziwy" revealed:
- Epub parsing was **correct** (19 sections with proper chapter names)
- All 33 served posts came from "Legenda" section due to missing section diversity in scoring
- 11 of 19 sections were non-content (ads, bibliography, publisher letters) generating ~44 wasted card drafts

## Test plan

- [x] 5 new section diversity tests (caps, demotion, fallback, min guarantee, combined)
- [x] 1 new `isSubstantiveContent` threading test (verifies flow from LLM through to DB records and doc summary filtering)
- [x] All 196 backend tests pass
- [x] Lint and format pass (oxlint + oxfmt)
- [ ] Deploy to dev and verify via Convex query that reprocessed sections have `isSubstantiveContent` set
- [ ] Verify served posts span multiple section titles after reprocessing