### PR TITLE
feat: track RunPod GPU cost per parsing job

### DIFF
--- a/packages/backend/convex/pipeline/markerWebhookProcessor.ts
+++ b/packages/backend/convex/pipeline/markerWebhookProcessor.ts
@@ -8,7 +8,7 @@ import type { ActionCtx } from "../_generated/server";
 import { internalAction } from "../_generated/server";
 import { WideEvent } from "../lib/logging";
 import { captureEvent } from "../../src/providers/analytics";
-import { storeMarkdownBlob } from "./helpers";
+import { storeMarkdownBlob, createMarkerClient } from "./helpers";
 
 interface RunPodWebhookPayload {
   id: string;
@@ -114,7 +114,44 @@ async function handleCompleted(ctx: ActionCtx, body: RunPodWebhookPayload, evt: 
     evt.set("analyticsError", true);
   }
 
+  await captureRunPodCost({ jobId: body.id, documentId, userId: doc.userId, evt });
+
   evt.set("result", "complete");
+}
+
+const RUNPOD_COST_PER_SEC = 0.00016; // RTX A4500
+
+async function captureRunPodCost(opts: {
+  jobId: string;
+  documentId: string;
+  userId: string;
+  evt: WideEvent;
+}) {
+  const { jobId, documentId, userId, evt } = opts;
+  try {
+    const client = createMarkerClient();
+    const status = await client.getJobStatus?.(jobId);
+    if (!status) return;
+
+    const executionTimeSec = status.executionTimeMs / 1000;
+    const costUsd = Math.round(executionTimeSec * RUNPOD_COST_PER_SEC * 1_000_000) / 1_000_000;
+    evt.set({ runpodExecutionTimeMs: status.executionTimeMs, runpodCostUsd: costUsd });
+
+    await captureEvent({
+      distinctId: userId,
+      event: "runpod.gpu_usage",
+      properties: {
+        document_id: documentId,
+        runpod_job_id: jobId,
+        execution_time_ms: status.executionTimeMs,
+        delay_time_ms: status.delayTimeMs,
+        estimated_cost_usd: costUsd,
+        gpu_type: "RTX A4500",
+      },
+    });
+  } catch {
+    evt.set("runpodCostTrackingError", true);
+  }
 }
 
 async function handleFailed(ctx: ActionCtx, body: RunPodWebhookPayload, evt: WideEvent) {

--- a/packages/backend/src/providers/marker.ts
+++ b/packages/backend/src/providers/marker.ts
@@ -2,6 +2,11 @@ export type MarkerJobResult =
   | { kind: "submitted"; jobId: string }
   | { kind: "immediate"; markdown: string };
 
+export interface RunPodJobStatus {
+  executionTimeMs: number;
+  delayTimeMs: number;
+}
+
 export interface MarkerClient {
   submitJob(opts: {
     fileUrl: string;
@@ -9,6 +14,8 @@ export interface MarkerClient {
     fileType: string;
     webhookUrl: string;
   }): Promise<MarkerJobResult>;
+
+  getJobStatus?(jobId: string): Promise<RunPodJobStatus | null>;
 }
 
 export class RunPodMarkerClient implements MarkerClient {
@@ -53,6 +60,24 @@ export class RunPodMarkerClient implements MarkerClient {
     }
 
     return { kind: "submitted", jobId: data.id };
+  }
+
+  async getJobStatus(jobId: string): Promise<RunPodJobStatus | null> {
+    const response = await fetch(`https://api.runpod.ai/v2/${this.endpointId}/status/${jobId}`, {
+      headers: { Authorization: `Bearer ${this.apiKey}` },
+    });
+
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as {
+      executionTime?: number;
+      delayTime?: number;
+    };
+
+    return {
+      executionTimeMs: data.executionTime ?? 0,
+      delayTimeMs: data.delayTime ?? 0,
+    };
   }
 }
 

--- a/packages/backend/tests/providers/marker.test.ts
+++ b/packages/backend/tests/providers/marker.test.ts
@@ -95,4 +95,63 @@ describe("RunPodMarkerClient", () => {
       }),
     ).rejects.toThrow("RunPod submit failed: no job ID in response");
   });
+
+  describe("getJobStatus", () => {
+    it("returns execution and delay times from status API", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          id: "job-abc123",
+          status: "COMPLETED",
+          executionTime: 491,
+          delayTime: 1104,
+        }),
+      } as Response);
+
+      const client = new RunPodMarkerClient({
+        endpointId: MOCK_ENDPOINT_ID,
+        apiKey: MOCK_API_KEY,
+      });
+
+      const status = await client.getJobStatus("job-abc123");
+
+      expect(status).toEqual({
+        executionTimeMs: 491,
+        delayTimeMs: 1104,
+      });
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0];
+      expect(fetchCall[0]).toBe(`https://api.runpod.ai/v2/${MOCK_ENDPOINT_ID}/status/job-abc123`);
+    });
+
+    it("returns null on non-OK response", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 404,
+      } as Response);
+
+      const client = new RunPodMarkerClient({
+        endpointId: MOCK_ENDPOINT_ID,
+        apiKey: MOCK_API_KEY,
+      });
+
+      const status = await client.getJobStatus("job-missing");
+      expect(status).toBeNull();
+    });
+
+    it("defaults missing times to 0", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: "job-abc123", status: "COMPLETED" }),
+      } as Response);
+
+      const client = new RunPodMarkerClient({
+        endpointId: MOCK_ENDPOINT_ID,
+        apiKey: MOCK_API_KEY,
+      });
+
+      const status = await client.getJobStatus("job-abc123");
+      expect(status).toEqual({ executionTimeMs: 0, delayTimeMs: 0 });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `getJobStatus()` to `RunPodMarkerClient` that calls RunPod's status API to retrieve `executionTime` and `delayTime` after job completion
- After Marker webhook completes, fetches actual GPU execution time and emits a `runpod.gpu_usage` PostHog event with estimated cost (RTX A4500 at $0.00016/sec)
- Added "RunPod GPU Cost per User" insight to the AI Usage PostHog dashboard

## Test plan
- [x] Unit tests for `getJobStatus` (3 new tests, all passing)
- [x] Live-tested against RunPod API - confirmed correct response parsing and cost calculation
- [x] Convex functions deployed successfully
- [x] PostHog insight added to dashboard