### PR TITLE
feat(#203): Early Adopter grants - perpetual Pro for pre-paywall users

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,10 @@ jobs:
         working-directory: packages/backend
         run: npx convex run migrations:runAll
 
+      - name: Backfill Early Adopter grants
+        working-directory: packages/backend
+        run: npx convex run migrateEarlyAdopters:runGrantEarlyAdopters
+
   notify-failure:
     name: CI failed - skip deploy
     runs-on: ubuntu-latest

--- a/apps/e2e/tests/billing.spec.ts
+++ b/apps/e2e/tests/billing.spec.ts
@@ -1,7 +1,13 @@
 import { test, expect } from "@playwright/test";
 import path from "node:path";
 
-import { FIXTURES_DIR, cleanupTestData, seedProSubscription, signUp } from "./helpers";
+import {
+  FIXTURES_DIR,
+  cleanupTestData,
+  seedEarlyAdopterGrant,
+  seedProSubscription,
+  signUp,
+} from "./helpers";
 
 const APP_SUCCESS_URL = /\/app\/library/;
 
@@ -127,6 +133,45 @@ test.describe("Pro-tier billing UX", () => {
     await expect(page.getByText(/pro plan/i)).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText(/manage billing/i)).toBeVisible();
     await expect(page.getByRole("button", { name: /open billing portal/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /upgrade to pro/i })).toHaveCount(0);
+  });
+});
+
+test.describe("Early Adopter grant", () => {
+  test.setTimeout(180_000);
+
+  let ephemeralEmail: string;
+
+  test.beforeEach(async ({ page }) => {
+    const { email } = await signUp(page);
+    ephemeralEmail = email;
+    await seedEarlyAdopterGrant(email);
+  });
+
+  test.afterEach(async () => {
+    await cleanupTestData(ephemeralEmail);
+  });
+
+  test("granted user can upload past the Free 3-document limit", async ({ page }) => {
+    const fixturePath = path.join(FIXTURES_DIR, "test.md");
+    for (let i = 0; i < 4; i++) {
+      await page.goto("/app/upload");
+      await page.getByTestId("file-input").setInputFiles(fixturePath);
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .getByText(/uploaded!/i)
+          .first(),
+      ).toBeVisible({ timeout: 30_000 });
+    }
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+  });
+
+  test("granted user sees Pro plan state and no upgrade CTA", async ({ page }) => {
+    await page.goto("/app/settings");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByText(/pro plan/i)).toBeVisible({ timeout: 15_000 });
     await expect(page.getByRole("button", { name: /upgrade to pro/i })).toHaveCount(0);
   });
 });

--- a/apps/e2e/tests/helpers.ts
+++ b/apps/e2e/tests/helpers.ts
@@ -66,6 +66,13 @@ export async function seedProSubscription(email: string) {
   }
 }
 
+export async function seedEarlyAdopterGrant(email: string) {
+  const { ok, status, body } = await convexE2ERequest("/api/e2e-seed-grant", email);
+  if (!ok) {
+    throw new Error(`E2E seed grant failed: ${status} ${body}`);
+  }
+}
+
 export async function cleanupTestData(email: string) {
   try {
     const { ok, status, body } = await convexE2ERequest("/api/e2e-cleanup", email);

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as account from "../account.js";
 import type * as accountActions from "../accountActions.js";
+import type * as admin from "../admin.js";
 import type * as auth from "../auth.js";
 import type * as bookmarks from "../bookmarks.js";
 import type * as cardDrafts from "../cardDrafts.js";
@@ -17,6 +18,7 @@ import type * as chunks from "../chunks.js";
 import type * as connectionPairs from "../connectionPairs.js";
 import type * as documentActions from "../documentActions.js";
 import type * as documents from "../documents.js";
+import type * as entitlementGrants from "../entitlementGrants.js";
 import type * as entitlements from "../entitlements.js";
 import type * as feed_queries from "../feed/queries.js";
 import type * as feed_serving from "../feed/serving.js";
@@ -31,6 +33,7 @@ import type * as lib_logging from "../lib/logging.js";
 import type * as lib_rateLimitChecks from "../lib/rateLimitChecks.js";
 import type * as lib_rateLimitConfig from "../lib/rateLimitConfig.js";
 import type * as lib_validators from "../lib/validators.js";
+import type * as migrateEarlyAdopters from "../migrateEarlyAdopters.js";
 import type * as migrations from "../migrations.js";
 import type * as pipeline_cardDraftGeneration from "../pipeline/cardDraftGeneration.js";
 import type * as pipeline_chunking from "../pipeline/chunking.js";
@@ -67,6 +70,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   account: typeof account;
   accountActions: typeof accountActions;
+  admin: typeof admin;
   auth: typeof auth;
   bookmarks: typeof bookmarks;
   cardDrafts: typeof cardDrafts;
@@ -74,6 +78,7 @@ declare const fullApi: ApiFromModules<{
   connectionPairs: typeof connectionPairs;
   documentActions: typeof documentActions;
   documents: typeof documents;
+  entitlementGrants: typeof entitlementGrants;
   entitlements: typeof entitlements;
   "feed/queries": typeof feed_queries;
   "feed/serving": typeof feed_serving;
@@ -88,6 +93,7 @@ declare const fullApi: ApiFromModules<{
   "lib/rateLimitChecks": typeof lib_rateLimitChecks;
   "lib/rateLimitConfig": typeof lib_rateLimitConfig;
   "lib/validators": typeof lib_validators;
+  migrateEarlyAdopters: typeof migrateEarlyAdopters;
   migrations: typeof migrations;
   "pipeline/cardDraftGeneration": typeof pipeline_cardDraftGeneration;
   "pipeline/chunking": typeof pipeline_chunking;

--- a/packages/backend/convex/account.ts
+++ b/packages/backend/convex/account.ts
@@ -21,6 +21,7 @@ export const deleteRemainingUserData = internalMutation({
     deletedBookmarkLists: v.number(),
     deletedTags: v.number(),
     deletedReactionFeedback: v.number(),
+    deletedEntitlementGrants: v.number(),
   }),
   handler: async (ctx, args) => {
     const bookmarks = await ctx.db
@@ -55,11 +56,20 @@ export const deleteRemainingUserData = internalMutation({
       await ctx.db.delete(fb._id);
     }
 
+    const grants = await ctx.db
+      .query("entitlementGrants")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .collect();
+    for (const grant of grants) {
+      await ctx.db.delete(grant._id);
+    }
+
     return {
       deletedBookmarks: bookmarks.length,
       deletedBookmarkLists: bookmarkLists.length,
       deletedTags: tags.length,
       deletedReactionFeedback: reactionFeedback.length,
+      deletedEntitlementGrants: grants.length,
     };
   },
 });

--- a/packages/backend/convex/admin.ts
+++ b/packages/backend/convex/admin.ts
@@ -1,0 +1,43 @@
+import { v } from "convex/values";
+
+import { internalMutation } from "./_generated/server";
+import { insertEarlyAdopterGrantIfMissing } from "./entitlementGrants";
+import { WideEvent } from "./lib/logging";
+
+/**
+ * Admin-only internal mutations. These are `internalMutation`s, so the only
+ * invocation surface is the Convex dashboard — access to the dashboard is the
+ * effective admin boundary. Every invocation emits a wide event so the audit
+ * trail lives in the logs rather than relying on session-bound identity.
+ *
+ * Volume is expected to be a handful of grants per cycle, so no dedicated
+ * admin UI is justified.
+ */
+export const grantEarlyAdopter = internalMutation({
+  args: {
+    userId: v.string(),
+    note: v.optional(v.string()),
+  },
+  returns: v.object({
+    inserted: v.boolean(),
+    grantId: v.id("entitlementGrants"),
+  }),
+  handler: async (ctx, args) => {
+    const evt = new WideEvent("admin.grantEarlyAdopter");
+    evt.set({ targetUserId: args.userId });
+    try {
+      const result = await insertEarlyAdopterGrantIfMissing(ctx, {
+        userId: args.userId,
+        source: "admin",
+        note: args.note,
+      });
+      evt.set({ inserted: result.inserted, grantId: result.grantId });
+      return result;
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
+    }
+  },
+});

--- a/packages/backend/convex/documents.ts
+++ b/packages/backend/convex/documents.ts
@@ -42,17 +42,19 @@ async function enforceFileSizeLimit(
 
 async function enforceDocumentUploadLimit(
   ctx: MutationCtx,
-  userId: string,
-  evt: WideEvent,
+  args: { userId: string; userCreatedAt: number; evt: WideEvent },
 ): Promise<Tier> {
   // `enforceDocumentLimit` already reads the Polar subscription to compute the tier;
   // reuse its result so we don't fetch it twice per upload.
-  const tier: Tier = await enforceDocumentLimit(ctx, userId);
-  evt.set("tier", tier);
+  const tier: Tier = await enforceDocumentLimit(ctx, {
+    userId: args.userId,
+    userCreatedAt: args.userCreatedAt,
+  });
+  args.evt.set("tier", tier);
   const name = tieredLimiterName("documentUpload", tier);
-  const result = await rateLimiter.limit(ctx, name, { key: userId });
+  const result = await rateLimiter.limit(ctx, name, { key: args.userId });
   if (!result.ok) {
-    evt.set({ rateLimited: true, endpoint: name, retryAfterMs: result.retryAfter });
+    args.evt.set({ rateLimited: true, endpoint: name, retryAfterMs: result.retryAfter });
     throw new ConvexError({
       kind: "RateLimited" as const,
       name: "documentUpload",
@@ -66,7 +68,7 @@ export const generateUploadUrl = mutation({
   args: {},
   handler: async (ctx) => {
     const user = await requireAuth(ctx);
-    const tier = await resolveTier(ctx, user._id);
+    const tier = await resolveTier(ctx, { userId: user._id, userCreatedAt: user.createdAt });
     const name = tieredLimiterName("uploadUrlGeneration", tier);
     const result = await rateLimiter.limit(ctx, name, { key: user._id });
     if (!result.ok) {
@@ -92,7 +94,11 @@ export const create = mutation({
     try {
       const user = await requireAuth(ctx);
       evt.set("userId", user._id);
-      const tier = await enforceDocumentUploadLimit(ctx, user._id, evt);
+      const tier = await enforceDocumentUploadLimit(ctx, {
+        userId: user._id,
+        userCreatedAt: user.createdAt,
+        evt,
+      });
       await enforceFileSizeLimit(ctx, {
         storageId: args.storageId,
         fileType: args.fileType,
@@ -134,7 +140,11 @@ export const createFromUrl = mutation({
     try {
       const user = await requireAuth(ctx);
       evt.set("userId", user._id);
-      await enforceDocumentUploadLimit(ctx, user._id, evt);
+      await enforceDocumentUploadLimit(ctx, {
+        userId: user._id,
+        userCreatedAt: user.createdAt,
+        evt,
+      });
 
       const parsed = new URL(args.url);
       if (!["http:", "https:"].includes(parsed.protocol)) {
@@ -182,7 +192,11 @@ export const createFromText = mutation({
     try {
       const user = await requireAuth(ctx);
       evt.set("userId", user._id);
-      const tier = await enforceDocumentUploadLimit(ctx, user._id, evt);
+      const tier = await enforceDocumentUploadLimit(ctx, {
+        userId: user._id,
+        userCreatedAt: user.createdAt,
+        evt,
+      });
       await enforceFileSizeLimit(ctx, {
         storageId: args.storageId,
         fileType: "text",

--- a/packages/backend/convex/entitlementGrants.ts
+++ b/packages/backend/convex/entitlementGrants.ts
@@ -1,0 +1,67 @@
+import type { Doc } from "./_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+
+import { WideEvent } from "./lib/logging";
+
+/**
+ * Frozen cutoff: users whose auth `createdAt` is earlier than this timestamp
+ * are eligible for an Early Adopter grant. Set to just before the feature
+ * merged; moving this value would retroactively grant or ungrant users, so it
+ * must remain stable.
+ *
+ * 2026-04-18T00:00:00Z
+ */
+export const EARLY_ADOPTER_CUTOFF = 1776211200000;
+
+/**
+ * Per-period document quota window for grant-eligible users. The grant itself
+ * is perpetual — only the usage counter rolls (rolling `now - 30d`).
+ */
+export const GRANT_ROLLING_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type GrantSource = "migration" | "admin";
+
+export async function findGrantByUserId(
+  ctx: QueryCtx,
+  userId: string,
+): Promise<Doc<"entitlementGrants"> | null> {
+  return await ctx.db
+    .query("entitlementGrants")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .first();
+}
+
+export async function hasEarlyAdopterEntitlement(
+  ctx: QueryCtx,
+  args: { userId: string; userCreatedAt: number },
+): Promise<boolean> {
+  const grant = await findGrantByUserId(ctx, args.userId);
+  if (grant) return true;
+  return args.userCreatedAt < EARLY_ADOPTER_CUTOFF;
+}
+
+export async function insertEarlyAdopterGrantIfMissing(
+  ctx: MutationCtx,
+  args: { userId: string; source: GrantSource; note?: string },
+): Promise<{ inserted: boolean; grantId: Doc<"entitlementGrants">["_id"] }> {
+  const existing = await findGrantByUserId(ctx, args.userId);
+  if (existing) {
+    return { inserted: false, grantId: existing._id };
+  }
+  const grantId = await ctx.db.insert("entitlementGrants", {
+    userId: args.userId,
+    grantType: "early_adopter",
+    tier: "pro",
+    grantedAt: Date.now(),
+    note: args.note,
+  });
+  new WideEvent("entitlementGrant.created")
+    .set({
+      userId: args.userId,
+      grantType: "early_adopter",
+      tier: "pro",
+      source: args.source,
+    })
+    .emit();
+  return { inserted: true, grantId };
+}

--- a/packages/backend/convex/entitlements.ts
+++ b/packages/backend/convex/entitlements.ts
@@ -2,6 +2,7 @@ import { ConvexError, v } from "convex/values";
 
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 
+import { GRANT_ROLLING_WINDOW_MS, hasEarlyAdopterEntitlement } from "./entitlementGrants";
 import { mutation, query } from "./_generated/server";
 import { requireAuth, optionalAuth } from "./lib/functions";
 import { polar } from "./polar";
@@ -21,8 +22,12 @@ const usageValidator = v.object({
   periodEnd: v.union(v.number(), v.null()),
 });
 
-export async function resolveTier(ctx: QueryCtx, userId: string): Promise<Tier> {
-  const subscription = await polar.getCurrentSubscription(ctx, { userId });
+export async function resolveTier(
+  ctx: QueryCtx,
+  args: { userId: string; userCreatedAt: number },
+): Promise<Tier> {
+  if (await hasEarlyAdopterEntitlement(ctx, args)) return "pro";
+  const subscription = await polar.getCurrentSubscription(ctx, { userId: args.userId });
   if (!subscription) return "free";
   if (subscription.productKey !== "pro") return "free";
   if (subscription.status !== "active" && subscription.status !== "trialing") return "free";
@@ -31,7 +36,7 @@ export async function resolveTier(ctx: QueryCtx, userId: string): Promise<Tier> 
 
 export async function computeDocumentUsage(
   ctx: QueryCtx,
-  userId: string,
+  args: { userId: string; userCreatedAt: number },
 ): Promise<{
   tier: Tier;
   used: number;
@@ -39,22 +44,24 @@ export async function computeDocumentUsage(
   periodStart: number | null;
   periodEnd: number | null;
 }> {
-  const subscription = await polar.getCurrentSubscription(ctx, { userId });
-  const tier: Tier =
+  const { userId } = args;
+  const entitled = await hasEarlyAdopterEntitlement(ctx, args);
+  const subscription = entitled ? null : await polar.getCurrentSubscription(ctx, { userId });
+
+  const polarPro =
+    !entitled &&
     subscription &&
     subscription.productKey === "pro" &&
-    (subscription.status === "active" || subscription.status === "trialing")
-      ? "pro"
-      : "free";
+    (subscription.status === "active" || subscription.status === "trialing");
 
-  if (tier === "free") {
+  if (!entitled && !polarPro) {
     // Bound the read by limit + 1: we only need to know if usage has reached/exceeded limit.
     const docs = await ctx.db
       .query("documents")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .take(FREE_DOCUMENT_LIMIT + 1);
     return {
-      tier,
+      tier: "free",
       used: docs.length,
       limit: FREE_DOCUMENT_LIMIT,
       periodStart: null,
@@ -62,30 +69,37 @@ export async function computeDocumentUsage(
     };
   }
 
-  const periodStart = new Date(subscription!.currentPeriodStart).getTime();
-  const periodEnd = subscription!.currentPeriodEnd
-    ? new Date(subscription!.currentPeriodEnd).getTime()
-    : null;
+  const window = entitled
+    ? { start: Date.now() - GRANT_ROLLING_WINDOW_MS, end: null }
+    : {
+        start: new Date(subscription!.currentPeriodStart).getTime(),
+        end: subscription!.currentPeriodEnd
+          ? new Date(subscription!.currentPeriodEnd).getTime()
+          : null,
+      };
 
   const docs = await ctx.db
     .query("documents")
-    .withIndex("by_userId_createdAt", (q) => q.eq("userId", userId).gte("createdAt", periodStart))
+    .withIndex("by_userId_createdAt", (q) => q.eq("userId", userId).gte("createdAt", window.start))
     .take(PRO_DOCUMENT_LIMIT + 1);
 
   return {
-    tier,
+    tier: "pro",
     used: docs.length,
     limit: PRO_DOCUMENT_LIMIT,
-    periodStart,
-    periodEnd,
+    periodStart: window.start,
+    periodEnd: window.end,
   };
 }
 
 // Best-effort check: two concurrent uploads at used = limit - 1 can both pass.
 // The rate limiter backstops bursts and the absolute cost of one extra document
 // is small, so we accept the race here rather than serialize per-user uploads.
-export async function enforceDocumentLimit(ctx: MutationCtx, userId: string) {
-  const usage = await computeDocumentUsage(ctx, userId);
+export async function enforceDocumentLimit(
+  ctx: MutationCtx,
+  args: { userId: string; userCreatedAt: number },
+) {
+  const usage = await computeDocumentUsage(ctx, args);
   if (usage.used >= usage.limit) {
     throw new ConvexError({
       kind: "DocumentLimitReached" as const,
@@ -104,7 +118,7 @@ export const getUserTier = query({
   handler: async (ctx) => {
     const user = await optionalAuth(ctx);
     if (!user) return "free";
-    return await resolveTier(ctx, user._id);
+    return await resolveTier(ctx, { userId: user._id, userCreatedAt: user.createdAt });
   },
 });
 
@@ -114,7 +128,7 @@ export const getDocumentUsage = query({
   handler: async (ctx) => {
     const user = await optionalAuth(ctx);
     if (!user) return null;
-    return await computeDocumentUsage(ctx, user._id);
+    return await computeDocumentUsage(ctx, { userId: user._id, userCreatedAt: user.createdAt });
   },
 });
 

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -110,6 +110,22 @@ http.route({
 });
 
 http.route({
+  path: "/api/e2e-seed-grant",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    if (!isE2EEnabled()) return e2eNotFound();
+    try {
+      const email = await parseEmail(request);
+      await ctx.runMutation(internal.testing.seedEarlyAdopterGrantByEmail, { email });
+      return Response.json({ ok: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Seed grant failed";
+      return Response.json({ error: message }, { status: 500 });
+    }
+  }),
+});
+
+http.route({
   path: "/api/e2e-connection-drafts",
   method: "POST",
   handler: httpAction(async (ctx, request) => {

--- a/packages/backend/convex/lib/rateLimitChecks.ts
+++ b/packages/backend/convex/lib/rateLimitChecks.ts
@@ -5,13 +5,13 @@ import { resolveTier } from "../entitlements";
 import { rateLimiter, tieredLimiterName } from "./rateLimitConfig";
 
 export const enforceFeedGenerationLimit = internalMutation({
-  args: { userId: v.string() },
+  args: { userId: v.string(), userCreatedAt: v.number() },
   returns: v.union(
     v.object({ ok: v.literal(true), retryAfter: v.optional(v.number()) }),
     v.object({ ok: v.literal(false), retryAfter: v.number() }),
   ),
-  handler: async (ctx, { userId }) => {
-    const tier = await resolveTier(ctx, userId);
+  handler: async (ctx, { userId, userCreatedAt }) => {
+    const tier = await resolveTier(ctx, { userId, userCreatedAt });
     const name = tieredLimiterName("feedGeneration", tier);
     const { ok, retryAfter } = await rateLimiter.limit(ctx, name, { key: userId });
     if (ok) return { ok, retryAfter };

--- a/packages/backend/convex/lib/validators.ts
+++ b/packages/backend/convex/lib/validators.ts
@@ -64,6 +64,12 @@ export const tagSource = v.union(v.literal("ai"), v.literal("manual"));
 
 export type TagSource = Infer<typeof tagSource>;
 
+export const entitlementGrantType = v.union(v.literal("early_adopter"));
+export type EntitlementGrantType = Infer<typeof entitlementGrantType>;
+
+export const entitlementTier = v.union(v.literal("pro"));
+export type EntitlementTier = Infer<typeof entitlementTier>;
+
 export const dislikeReason = v.union(
   v.literal("not_interesting"),
   v.literal("already_know"),

--- a/packages/backend/convex/migrateEarlyAdopters.ts
+++ b/packages/backend/convex/migrateEarlyAdopters.ts
@@ -1,0 +1,114 @@
+import { v } from "convex/values";
+
+import { components, internal } from "./_generated/api";
+import { internalAction, internalMutation } from "./_generated/server";
+import { EARLY_ADOPTER_CUTOFF, insertEarlyAdopterGrantIfMissing } from "./entitlementGrants";
+import { WideEvent } from "./lib/logging";
+
+/**
+ * One-shot migration: grants Early Adopter status to every user whose
+ * better-auth `createdAt` predates `EARLY_ADOPTER_CUTOFF`. Runs as an action
+ * that paginates the better-auth component's `user` table and dispatches
+ * per-batch mutations. Idempotent — re-running skips users whose grant row
+ * already exists.
+ *
+ * Invoke from the Convex dashboard:
+ *   ctx.runAction(internal.migrateEarlyAdopters.runGrantEarlyAdopters, {})
+ */
+
+// One grant batch does up to BATCH_SIZE read+insert pairs. Convex caps each
+// transaction at 4096 reads/writes, so 100 leaves ample headroom and keeps
+// per-batch latency small.
+const BATCH_SIZE = 100;
+
+export const grantEarlyAdoptersBatch = internalMutation({
+  args: {
+    userIds: v.array(v.string()),
+  },
+  returns: v.object({
+    attempted: v.number(),
+    inserted: v.number(),
+    skipped: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    let inserted = 0;
+    let skipped = 0;
+    for (const userId of args.userIds) {
+      const result = await insertEarlyAdopterGrantIfMissing(ctx, {
+        userId,
+        source: "migration",
+        note: "Early Adopter migration (pre-paywall user)",
+      });
+      if (result.inserted) inserted++;
+      else skipped++;
+    }
+    return { attempted: args.userIds.length, inserted, skipped };
+  },
+});
+
+export const runGrantEarlyAdopters = internalAction({
+  args: {},
+  returns: v.object({
+    totalUsers: v.number(),
+    eligible: v.number(),
+    inserted: v.number(),
+    skipped: v.number(),
+    batches: v.number(),
+  }),
+  handler: async (ctx) => {
+    const evt = new WideEvent("migration.grantEarlyAdopters");
+
+    let cursor: string | null = null;
+    let totalUsers = 0;
+    let eligible = 0;
+    let inserted = 0;
+    let skipped = 0;
+    let batches = 0;
+
+    try {
+      while (true) {
+        const page: {
+          page: Array<{ _id: string; createdAt: number }>;
+          isDone: boolean;
+          continueCursor: string;
+        } = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+          model: "user",
+          paginationOpts: { cursor, numItems: BATCH_SIZE },
+        });
+
+        totalUsers += page.page.length;
+        // Defensive guard: the better-auth schema types `createdAt` as a number,
+        // but the adapter's response is typed as `GenericDocument`. Skip any
+        // row whose shape has drifted rather than comparing garbage.
+        const eligibleIds = page.page
+          .filter(
+            (user) => typeof user.createdAt === "number" && user.createdAt < EARLY_ADOPTER_CUTOFF,
+          )
+          .map((user) => user._id);
+        eligible += eligibleIds.length;
+
+        if (eligibleIds.length > 0) {
+          const result = await ctx.runMutation(
+            internal.migrateEarlyAdopters.grantEarlyAdoptersBatch,
+            { userIds: eligibleIds },
+          );
+          inserted += result.inserted;
+          skipped += result.skipped;
+        }
+
+        batches++;
+        if (page.isDone) break;
+        cursor = page.continueCursor;
+      }
+
+      evt.set({ totalUsers, eligible, inserted, skipped, batches });
+      return { totalUsers, eligible, inserted, skipped, batches };
+    } catch (error) {
+      evt.set({ totalUsers, eligible, inserted, skipped, batches });
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
+    }
+  },
+});

--- a/packages/backend/convex/polar.ts
+++ b/packages/backend/convex/polar.ts
@@ -69,6 +69,15 @@ export const startProCheckout = action({
     if (!user.email) {
       throw new Error("Pro checkout requires a verified email on the account.");
     }
+    // Run the grant check in a query context — `hasEarlyAdopterEntitlement`
+    // reads ctx.db, which actions can't do directly.
+    const entitled = await ctx.runQuery(
+      api.polarAuth.hasAuthenticatedUserEarlyAdopterEntitlement,
+      {},
+    );
+    if (entitled) {
+      throw new ConvexError({ kind: "AlreadySubscribed" as const, tier: "pro" });
+    }
     const existing = await polar.getCurrentSubscription(ctx, { userId: user._id });
     if (
       existing &&

--- a/packages/backend/convex/polarAuth.ts
+++ b/packages/backend/convex/polarAuth.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 
 import { query } from "./_generated/server";
+import { hasEarlyAdopterEntitlement } from "./entitlementGrants";
 import { optionalAuth } from "./lib/functions";
 
 export const getAuthenticatedUserInfo = query({
@@ -13,5 +14,18 @@ export const getAuthenticatedUserInfo = query({
       throw new Error("Polar: auth user has no email");
     }
     return { userId: user._id, email: user.email };
+  },
+});
+
+export const hasAuthenticatedUserEarlyAdopterEntitlement = query({
+  args: {},
+  returns: v.boolean(),
+  handler: async (ctx) => {
+    const user = await optionalAuth(ctx);
+    if (!user) return false;
+    return await hasEarlyAdopterEntitlement(ctx, {
+      userId: user._id,
+      userCreatedAt: user.createdAt,
+    });
   },
 });

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -8,6 +8,8 @@ import {
   connectionType,
   dislikeReason,
   documentStatus,
+  entitlementGrantType,
+  entitlementTier,
   failedAtStage,
   fileType,
   highlightSource,
@@ -190,6 +192,14 @@ export default defineSchema({
     .index("by_documentId_status", ["documentId", "status"])
     .index("by_userId_contentHash", ["userId", "contentHash"])
     .index("by_userId_status_cardType", ["userId", "status", "cardType"]),
+
+  entitlementGrants: defineTable({
+    userId: v.string(),
+    grantType: entitlementGrantType,
+    tier: entitlementTier,
+    grantedAt: v.number(),
+    note: v.optional(v.string()),
+  }).index("by_userId", ["userId"]),
 
   connectionPairs: defineTable({
     userId: v.string(),

--- a/packages/backend/convex/testing.ts
+++ b/packages/backend/convex/testing.ts
@@ -5,6 +5,7 @@ import { maxBy } from "es-toolkit";
 import { components } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
 import { internalMutation, internalQuery, mutation } from "./_generated/server";
+import { insertEarlyAdopterGrantIfMissing } from "./entitlementGrants";
 import { E2E_EMAIL_PATTERN } from "./lib/e2e";
 import { requireAuth } from "./lib/functions";
 import type { PostType, TypeData } from "./lib/validators";
@@ -103,6 +104,14 @@ async function cleanupUserData(ctx: MutationCtx, userId: string) {
     await ctx.db.delete(post._id);
   }
 
+  const grants = await ctx.db
+    .query("entitlementGrants")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .collect();
+  for (const grant of grants) {
+    await ctx.db.delete(grant._id);
+  }
+
   return {
     deleted: {
       bookmarks: bookmarks.length,
@@ -111,6 +120,7 @@ async function cleanupUserData(ctx: MutationCtx, userId: string) {
       tags: tags.length,
       documents: documents.length,
       posts: posts.length,
+      entitlementGrants: grants.length,
     },
   };
 }
@@ -240,6 +250,29 @@ export const seedProSubscriptionByEmail = internalMutation({
         checkoutId: null,
         metadata: {},
       },
+    });
+    return null;
+  },
+});
+
+export const seedEarlyAdopterGrantByEmail = internalMutation({
+  args: { email: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    if (!E2E_EMAIL_PATTERN.test(args.email)) {
+      throw new Error(`Seed refused: email "${args.email}" does not match E2E test pattern`);
+    }
+    const user = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
+      model: "user",
+      where: [{ field: "email", value: args.email }],
+    })) as { _id: string } | null;
+    if (!user) {
+      throw new Error(`User not found for email: ${args.email}`);
+    }
+    await insertEarlyAdopterGrantIfMissing(ctx, {
+      userId: user._id,
+      source: "admin",
+      note: "E2E seed",
     });
     return null;
   },


### PR DESCRIPTION
## Summary

Grants existing users perpetual Pro-level entitlements as a one-time goodwill gesture, durable and decoupled from Polar's subscription lifecycle. The grant itself never expires; only the Pro document-quota counter rolls on a 30-day window for granted users.

Closes #203

## What changed

**New Convex surface:**
- `entitlementGrants` table (schema) + `EARLY_ADOPTER_CUTOFF` constant (2026-04-18T00:00:00Z) + `GRANT_ROLLING_WINDOW_MS` = 30d
- `entitlementGrants.ts` - `findGrantByUserId`, `hasEarlyAdopterEntitlement` (grant row OR `createdAt < CUTOFF`), idempotent `insertEarlyAdopterGrantIfMissing` with wide-event emission
- `admin.grantEarlyAdopter` internal mutation (dashboard-only, per-invocation wide event audit)
- `migrateEarlyAdopters.runGrantEarlyAdopters` - one-shot action paginating better-auth users (via `components.betterAuth.adapter.findMany`) and batching grant inserts; idempotent, resumable via cursor, single wide event via try/finally
- `polarAuth.hasAuthenticatedUserEarlyAdopterEntitlement` query consumed by `startProCheckout`

**Behavior changes:**
- `resolveTier`, `computeDocumentUsage`, `enforceDocumentLimit` now require `userCreatedAt` so the cutoff fallback is consistent across every read path (including `lib/rateLimitChecks.ts`)
- `startProCheckout` throws `AlreadySubscribed` for granted users, not just Polar subscribers
- Granted users get a rolling `now - 30d` Pro quota window (30 docs) instead of a Polar period window
- `cleanupUserData` (E2E) + `deleteRemainingUserData` (account deletion) now also delete `entitlementGrants` rows

**Running the backfill after merge:**
```
npx convex run migrateEarlyAdopters:runGrantEarlyAdopters
```
Idempotent - safe to re-run. Returns `{ totalUsers, eligible, inserted, skipped, batches }`.

## Test plan

- [x] `bun run check` (oxlint + oxfmt) passes clean (pre-existing warnings in `cardDraftGeneration.test.ts` unrelated)
- [x] `bun turbo run build` passes
- [x] `npx convex dev --once` deploys, schema diff limited to new `entitlementGrants` table + index
- [x] Full ephemeral E2E suite passes (40 tests)
- [x] New billing tests pass:
  - Granted user uploads 4+ docs without hitting free-tier limit dialog
  - Granted user sees "Pro plan" on `/app/settings` with no "Upgrade to Pro" button
- [x] Existing billing tests (landing pricing, free-tier usage meter, free-tier limit dialog, Pro-tier settings, Polar-seeded subscription) still pass
- [x] Backend code review pass: all 12 findings (4 critical / 4 medium / 4 low) addressed and re-verified

## Out of scope

- No frontend "Early Adopter" badge or upgrade-page copy change (pure backend entitlement)
- No revocation UI - delete the grant row from the dashboard
- No additional `grantType`s or `tier`s - unions stay single-value until a second grant type exists (referral, student, etc. are separate issues)