### PR TITLE
chore: better-auth upgrade and source provenance UX cleanup

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,5 @@
+[shell_environment_policy]
+inherit = "core"
+
+[shell_environment_policy.set]
+CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,6 @@ jobs:
           bunx convex env set QDRANT_URL "$QDRANT_URL" --preview-name "$PREVIEW_NAME"
           bunx convex env set QDRANT_API_KEY "$QDRANT_API_KEY" --preview-name "$PREVIEW_NAME"
           bunx convex env set BETTER_AUTH_SECRET "$BETTER_AUTH_SECRET" --preview-name "$PREVIEW_NAME"
-          bunx convex env set SITE_URL http://localhost:3000 --preview-name "$PREVIEW_NAME"
           bunx convex env set ENABLE_E2E_ROUTES true --preview-name "$PREVIEW_NAME"
           bunx convex env set POLAR_ORGANIZATION_TOKEN "$POLAR_ORGANIZATION_TOKEN" --preview-name "$PREVIEW_NAME"
           bunx convex env set POLAR_WEBHOOK_SECRET "$POLAR_WEBHOOK_SECRET" --preview-name "$PREVIEW_NAME"

--- a/apps/e2e/tests/bookmarked-cards-section.spec.ts
+++ b/apps/e2e/tests/bookmarked-cards-section.spec.ts
@@ -10,13 +10,11 @@ async function bookmarkFirstCardAndNavigateToDocument(page: Page) {
   await saveButton.click();
   await expect(saveButton).toHaveAttribute("aria-pressed", "true", { timeout: 15000 });
 
-  const sourceBadge = firstCard.locator('[data-testid="source-badge"]');
-  await expect(sourceBadge).toBeVisible();
-  await sourceBadge.click();
+  await firstCard.click();
 
-  const detailSheet = page.locator('[data-testid="source-detail-sheet"]');
-  await expect(detailSheet).toBeVisible({ timeout: 10000 });
-  await detailSheet.getByText(/view in library/i).click();
+  const libraryLink = page.getByRole("link", { name: /view in library/i });
+  await expect(libraryLink).toBeVisible({ timeout: 10000 });
+  await libraryLink.click();
 
   await expect(page).toHaveURL(/\/app\/library\/.+/, { timeout: 15000 });
   await expect(page.locator('[data-testid="status-ready"]').first()).toBeVisible({

--- a/apps/e2e/tests/bookmarked-cards-section.spec.ts
+++ b/apps/e2e/tests/bookmarked-cards-section.spec.ts
@@ -10,7 +10,10 @@ async function bookmarkFirstCardAndNavigateToDocument(page: Page) {
   await saveButton.click();
   await expect(saveButton).toHaveAttribute("aria-pressed", "true", { timeout: 15000 });
 
-  await firstCard.click();
+  // Click the source badge (not the whole card) — quiz cards have answer
+  // buttons that stopPropagation, so Playwright's center-click doesn't
+  // reliably reach the article's onClick.
+  await firstCard.locator('[data-testid="source-badge"]').click();
 
   const libraryLink = page.getByRole("link", { name: /view in library/i });
   await expect(libraryLink).toBeVisible({ timeout: 10000 });

--- a/apps/e2e/tests/helpers.ts
+++ b/apps/e2e/tests/helpers.ts
@@ -33,11 +33,11 @@ export async function ensureSeededAccount() {
     }),
   });
 
-  // 200 = created, 4xx = already exists — both are fine
-  if (!res.ok && res.status >= 500) {
-    const body = await res.text();
-    throw new Error(`Failed to ensure seeded account: ${res.status} ${body}`);
-  }
+  // 200 = created, 422 = already exists — both are fine.
+  // Anything else is a real failure we want to see.
+  if (res.ok || res.status === 422) return;
+  const body = await res.text();
+  throw new Error(`Failed to ensure seeded account: ${res.status} ${body}`);
 }
 
 export async function seedTestData(email: string) {

--- a/apps/e2e/tests/helpers.ts
+++ b/apps/e2e/tests/helpers.ts
@@ -25,7 +25,13 @@ export async function ensureSeededAccount() {
 
   const res = await fetch(`${siteUrl}/api/auth/sign-up/email`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      // Node's fetch auto-sends Sec-Fetch-* headers, which trips better-auth's
+      // CSRF check and requires an Origin. Send the Convex site as Origin —
+      // it's already trusted via allowedHosts in the auth config.
+      Origin: siteUrl,
+    },
     body: JSON.stringify({
       email: SEEDED_USER.email,
       password: SEEDED_USER.password,

--- a/apps/e2e/tests/source-provenance.spec.ts
+++ b/apps/e2e/tests/source-provenance.spec.ts
@@ -20,20 +20,14 @@ test.describe("Source provenance on feed cards", { tag: "@seeded" }, () => {
     await expect(sourceBadge).toContainText("E2E Seed Document");
   });
 
-  test("source badge opens detail sheet with attribution info", async ({ page }) => {
+  test("clicking a card opens detail panel with library link", async ({ page }) => {
     const firstCard = page.locator('[data-testid="post-card"]').first();
-    const sourceBadge = firstCard.locator('[data-testid="source-badge"]');
-    await expect(sourceBadge).toBeVisible({ timeout: 10000 });
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
 
-    await sourceBadge.click();
+    await firstCard.click();
 
-    const sheet = page.locator('[data-testid="source-detail-sheet"]');
-    await expect(sheet).toBeVisible({ timeout: 5000 });
-
-    await expect(sheet).toContainText("E2E Seed Document");
-
-    const libraryLink = sheet.getByRole("link", { name: /view in library/i });
-    await expect(libraryLink).toBeVisible();
+    const libraryLink = page.getByRole("link", { name: /view in library/i });
+    await expect(libraryLink).toBeVisible({ timeout: 5000 });
 
     await libraryLink.click();
     await expect(page).toHaveURL(/\/app\/library\/.+/, { timeout: 15000 });

--- a/apps/e2e/tests/source-provenance.spec.ts
+++ b/apps/e2e/tests/source-provenance.spec.ts
@@ -24,7 +24,10 @@ test.describe("Source provenance on feed cards", { tag: "@seeded" }, () => {
     const firstCard = page.locator('[data-testid="post-card"]').first();
     await expect(firstCard).toBeVisible({ timeout: 10000 });
 
-    await firstCard.click();
+    // Click the source badge — a non-interactive region that reliably bubbles
+    // to the article's onClick regardless of the card type (quiz cards have
+    // answer buttons that stopPropagation on clicks in their area).
+    await firstCard.locator('[data-testid="source-badge"]').click();
 
     const libraryLink = page.getByRole("link", { name: /view in library/i });
     await expect(libraryLink).toBeVisible({ timeout: 5000 });

--- a/apps/web/src/components/cards/card-shell.tsx
+++ b/apps/web/src/components/cards/card-shell.tsx
@@ -2,7 +2,7 @@ import { api } from "@scrollect/backend/convex/_generated/api";
 import type { OptimisticLocalStore } from "convex/browser";
 import { useMutation } from "convex/react";
 import { formatDistanceToNow } from "date-fns";
-import { Bookmark, BookmarkCheck, ChevronRight, ThumbsDown, ThumbsUp } from "lucide-react";
+import { Bookmark, BookmarkCheck, ThumbsDown, ThumbsUp } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import type { ReactNode } from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
@@ -18,7 +18,6 @@ import { useDetailPanel } from "@/components/detail-panel";
 
 import { DislikeReasonSheet } from "./dislike-reason-sheet";
 import { getFileTypeConfig } from "./file-type-config";
-import { SourceDetailSheet } from "./source-detail-sheet";
 import type { DislikeReason, PostCardData, PostType } from "./types";
 
 const cardAccentColor: Record<PostType, string> = {
@@ -63,40 +62,18 @@ function removePostFromPaginatedPages(
 }
 
 export function SourceBadge({ post, className }: { post: PostCardData; className?: string }) {
-  const posthog = usePostHog();
-  const [sheetOpen, setSheetOpen] = useState(false);
-  const badgeRef = useRef<HTMLButtonElement>(null);
-
   const { Icon } = getFileTypeConfig(post.fileType);
 
   return (
-    <div className={cn("mb-3", className)}>
-      <button
-        ref={badgeRef}
-        type="button"
-        data-testid="source-badge"
-        aria-label={`Source details: ${post.primarySourceDocumentTitle ?? "Untitled"}`}
-        className="inline-flex max-w-full cursor-pointer items-center gap-1.5 rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground/80"
-        onClick={(e) => {
-          e.stopPropagation();
-          posthog.capture("source.detail_opened", {
-            card_type: post.postType,
-          });
-          setSheetOpen(true);
-        }}
-      >
-        <Icon className="size-3.5 shrink-0" />
-        <span className="truncate">{post.primarySourceDocumentTitle ?? "Untitled"}</span>
-        <ChevronRight className="size-3 shrink-0 text-muted-foreground/50" />
-      </button>
-
-      <SourceDetailSheet
-        open={sheetOpen}
-        onOpenChange={setSheetOpen}
-        postId={post._id}
-        documentId={post.primarySourceDocumentId}
-        anchorRef={badgeRef}
-      />
+    <div
+      data-testid="source-badge"
+      className={cn(
+        "mb-3 flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground",
+        className,
+      )}
+    >
+      <Icon className="size-3.5 shrink-0" />
+      <span className="truncate">{post.primarySourceDocumentTitle ?? "Untitled"}</span>
     </div>
   );
 }

--- a/apps/web/src/components/cards/source-detail-sheet.tsx
+++ b/apps/web/src/components/cards/source-detail-sheet.tsx
@@ -1,17 +1,12 @@
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 import { api } from "@scrollect/backend/convex/_generated/api";
 import type { Id } from "@scrollect/backend/convex/_generated/dataModel";
 import { BookOpen, ExternalLink, Loader2, MapPin } from "lucide-react";
-import type { RefObject } from "react";
 import { usePostHog } from "posthog-js/react";
 
 import { Badge } from "@/components/ui/badge";
-import { Popover, PopoverContent, PopoverDescription, PopoverTitle } from "@/components/ui/popover";
-import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@/components/ui/sheet";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 
 import { getFileTypeConfig } from "./file-type-config";
 
@@ -138,65 +133,5 @@ export function SourceDetailsContent({
         </Link>
       </div>
     </div>
-  );
-}
-
-interface SourceDetailSheetProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  postId: Id<"posts">;
-  documentId: Id<"documents">;
-  anchorRef: RefObject<HTMLButtonElement | null>;
-}
-
-export function SourceDetailSheet({
-  open,
-  onOpenChange,
-  postId,
-  documentId,
-  anchorRef,
-}: SourceDetailSheetProps) {
-  const isMobile = useIsMobile();
-
-  if (!isMobile) {
-    return (
-      <Popover open={open} onOpenChange={onOpenChange}>
-        <PopoverPrimitive.Backdrop className="fixed inset-0 z-40" />
-        <PopoverContent
-          anchor={anchorRef}
-          side="bottom"
-          align="start"
-          sideOffset={8}
-          data-testid="source-detail-sheet"
-          className="w-80 gap-0 p-0 py-3"
-        >
-          <PopoverTitle className="sr-only">Source details</PopoverTitle>
-          <PopoverDescription className="sr-only">
-            Details about the source of this learning card.
-          </PopoverDescription>
-          <SourceDetailsContent postId={postId} documentId={documentId} />
-        </PopoverContent>
-      </Popover>
-    );
-  }
-
-  return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        side="bottom"
-        showCloseButton={false}
-        className="max-h-[70dvh] overflow-y-auto rounded-t-2xl px-0 pb-[env(safe-area-inset-bottom)]"
-        data-testid="source-detail-sheet"
-      >
-        <div className="mx-auto mb-1 mt-0 h-1 w-10 shrink-0 rounded-full bg-muted-foreground/25" />
-
-        <SheetTitle className="sr-only">Source details</SheetTitle>
-        <SheetDescription className="sr-only">
-          Details about the source of this learning card.
-        </SheetDescription>
-
-        <SourceDetailsContent postId={postId} documentId={documentId} />
-      </SheetContent>
-    </Sheet>
   );
 }

--- a/apps/web/src/components/detail-panel.tsx
+++ b/apps/web/src/components/detail-panel.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useState } from "react";
-import { MousePointerClick, X } from "lucide-react";
+import { X } from "lucide-react";
 
 import { PostCard } from "@/components/post-card";
 import type { PostCardData } from "@/components/cards/types";
@@ -44,23 +44,7 @@ export function DetailPanel() {
   if (!ctx) return null;
   const { selectedPost, closeDetail } = ctx;
 
-  if (!selectedPost) {
-    if (isMobile) return null;
-
-    return (
-      <aside className="-ml-px hidden flex-1 border-l border-border lg:block">
-        <div className="sticky top-14 flex h-[calc(100svh-3.5rem)] flex-col items-center justify-center px-6 text-center">
-          <div className="flex size-12 items-center justify-center border border-border">
-            <MousePointerClick className="size-5 text-muted-foreground" />
-          </div>
-          <p className="mt-4 text-sm font-medium text-foreground">Select a card</p>
-          <p className="mt-1 max-w-[200px] text-xs text-muted-foreground">
-            Click any card in the feed to see its full content and source details here.
-          </p>
-        </div>
-      </aside>
-    );
-  }
+  if (!selectedPost) return null;
 
   if (isMobile) {
     return (
@@ -82,7 +66,7 @@ export function DetailPanel() {
   }
 
   return (
-    <aside className="-ml-px hidden flex-1 border-l border-border lg:block">
+    <aside className="-ml-px hidden min-w-0 flex-1 border-l border-border lg:block">
       <div className="sticky top-14 h-[calc(100svh-3.5rem)] overflow-y-auto">
         <div key={selectedPost._id} className="animate-in fade-in slide-in-from-top-2 duration-200">
           <DetailPanelContent post={selectedPost} onClose={closeDetail} />

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -1,5 +1,4 @@
 import { Link, Outlet, createFileRoute, redirect, useRouterState } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
 
 import { AppSidebar } from "@/components/app-sidebar";
 import { DetailPanel, DetailPanelProvider } from "@/components/detail-panel";
@@ -12,6 +11,7 @@ import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/s
 import { usePostHogIdentify } from "@/hooks/use-posthog-identify";
 
 export const Route = createFileRoute("/_authenticated")({
+  ssr: false,
   head: () => ({
     meta: [{ name: "robots", content: "noindex, nofollow" }],
   }),
@@ -20,12 +20,6 @@ export const Route = createFileRoute("/_authenticated")({
       throw redirect({ to: "/signin" });
     }
   },
-  pendingMs: 200,
-  pendingComponent: () => (
-    <div className="flex min-h-[50vh] items-center justify-center">
-      <Loader2 className="h-8 w-8 animate-spin text-primary" />
-    </div>
-  ),
   component: AuthenticatedLayout,
 });
 
@@ -54,7 +48,7 @@ function AuthenticatedLayout() {
           {isFeedRoute ? (
             <DetailPanelProvider>
               <div className="flex flex-1">
-                <main className="w-full max-w-2xl shrink-0 border-r border-border">
+                <main className="w-full max-w-2xl shrink-0">
                   <Outlet />
                 </main>
                 <DetailPanel />

--- a/apps/web/src/routes/_authenticated/app/library/index.tsx
+++ b/apps/web/src/routes/_authenticated/app/library/index.tsx
@@ -29,9 +29,6 @@ type LibrarySearch = {
 
 export const Route = createFileRoute("/_authenticated/app/library/")({
   ssr: false,
-  loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(convexQuery(api.tags.listUserTags, {}));
-  },
   head: () => ({
     meta: [{ title: "Library | Scrollect" }],
   }),

--- a/apps/web/src/routes/_authenticated/app/settings.tsx
+++ b/apps/web/src/routes/_authenticated/app/settings.tsx
@@ -1,17 +1,15 @@
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@scrollect/backend/convex/_generated/api";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Mail, User } from "lucide-react";
 
 import { BillingSection } from "@/components/billing/billing-section";
 import { DeleteAccountDialog } from "@/components/delete-account-dialog";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/_authenticated/app/settings")({
   ssr: false,
-  loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(convexQuery(api.auth.getCurrentUser, {}));
-  },
   head: () => ({
     meta: [{ title: "Settings | Scrollect" }],
   }),
@@ -19,7 +17,7 @@ export const Route = createFileRoute("/_authenticated/app/settings")({
 });
 
 function SettingsPage() {
-  const { data: user } = useSuspenseQuery(convexQuery(api.auth.getCurrentUser, {}));
+  const { data: user } = useQuery(convexQuery(api.auth.getCurrentUser, {}));
 
   return (
     <div className="px-4 py-6 md:px-6">
@@ -33,11 +31,19 @@ function SettingsPage() {
         <div className="border border-border border-l-[2px] border-l-primary bg-card px-6 py-5">
           <div className="flex items-center gap-3">
             <User className="size-4 text-muted-foreground" />
-            <span className="text-sm">{user?.name}</span>
+            {user ? (
+              <span className="text-sm">{user.name}</span>
+            ) : (
+              <Skeleton className="h-4 w-32" />
+            )}
           </div>
           <div className="mt-3 flex items-center gap-3">
             <Mail className="size-4 text-muted-foreground" />
-            <span className="text-sm text-muted-foreground">{user?.email}</span>
+            {user ? (
+              <span className="text-sm text-muted-foreground">{user.email}</span>
+            ) : (
+              <Skeleton className="h-4 w-48" />
+            )}
           </div>
         </div>
       </section>

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
       "dependencies": {
         "@ai-sdk/google": "^3.0.53",
         "@ai-sdk/openai": "^3.0.48",
-        "@convex-dev/better-auth": "^0.10.13",
+        "@convex-dev/better-auth": "^0.11.4",
         "@convex-dev/migrations": "^0.3.1",
         "@convex-dev/polar": "^0.9.0",
         "@convex-dev/rate-limiter": "^0.3.2",
@@ -156,8 +156,8 @@
     },
   },
   "catalog": {
-    "@convex-dev/better-auth": "^0.10.13",
-    "better-auth": "1.4.9",
+    "@convex-dev/better-auth": "^0.11.4",
+    "better-auth": "1.5.6",
     "convex": "^1.33.1",
     "dotenv": "^17.2.2",
     "typescript": "^5",
@@ -268,13 +268,21 @@
 
     "@base-ui/utils": ["@base-ui/utils@0.2.6", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw=="],
 
-    "@better-auth/core": ["@better-auth/core@1.4.9", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "zod": "^4.1.12" }, "peerDependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-call": "1.1.7", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" } }, "sha512-JT2q4NDkQzN22KclUEoZ7qU6tl9HUTfK1ctg2oWlT87SEagkwJcnrUwS9VznL+u9ziOIfY27P0f7/jSnmvLcoQ=="],
+    "@better-auth/core": ["@better-auth/core@1.5.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.3.1", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.2", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types"] }, "sha512-Ez9DZdIMFyxHremmoLz1emFPGNQomDC1jqqBPnZ6Ci+6TiGN3R9w/Y03cJn6I8r1ycKgOzeVMZtJ/erOZ27Gsw=="],
 
-    "@better-auth/passkey": ["@better-auth/passkey@1.4.9", "", { "dependencies": { "@simplewebauthn/browser": "^13.1.2", "@simplewebauthn/server": "^13.1.2", "zod": "^4.1.12" }, "peerDependencies": { "@better-auth/core": "1.4.9", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-auth": "1.4.9", "better-call": "1.1.7", "nanostores": "^1.0.1" } }, "sha512-fPsV0LYbmPytxrTaltM2RXbJnmSttX9UWr4wkZtJYgCBGeFqN8+8ZzBTZXOymWDJTVQ0kVZrD7c7/HyxXEG1zA=="],
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.5.6", "", { "peerDependencies": { "@better-auth/core": "1.5.6", "@better-auth/utils": "^0.3.0", "drizzle-orm": ">=0.41.0" }, "optionalPeers": ["drizzle-orm"] }, "sha512-VfFFmaoFw3ug12SiSuIwzrMoHyIVmkMGWm9gZ4sXdYYVX4HboCL4m3fjzOhppcmK5OGatRuU+N1UX6wxCITcXw=="],
 
-    "@better-auth/telemetry": ["@better-auth/telemetry@1.4.9", "", { "dependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21" }, "peerDependencies": { "@better-auth/core": "1.4.9" } }, "sha512-Tthy1/Gmx+pYlbvRQPBTKfVei8+pJwvH1NZp+5SbhwA6K2EXIaoonx/K6N/AXYs2aKUpyR4/gzqDesDjL7zd6A=="],
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.5.6", "", { "peerDependencies": { "@better-auth/core": "1.5.6", "@better-auth/utils": "^0.3.0", "kysely": "^0.27.0 || ^0.28.0" }, "optionalPeers": ["kysely"] }, "sha512-Fnf+h8WVKtw6lEOmVmiVVzDf3shJtM60AYf9XTnbdCeUd6MxN/KnaJZpkgtYnRs7a+nwtkVB+fg4lGETebGFXQ=="],
 
-    "@better-auth/utils": ["@better-auth/utils@0.3.0", "", {}, "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw=="],
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.5.6", "", { "peerDependencies": { "@better-auth/core": "1.5.6", "@better-auth/utils": "^0.3.0" } }, "sha512-rS7ZsrIl5uvloUgNN0u9LOZJMMXnsZXVdUZ3MrTBKWM2KpoJjzPr9yN3Szyma5+0V7SltnzSGHPkYj2bEzzmlA=="],
+
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.5.6", "", { "peerDependencies": { "@better-auth/core": "1.5.6", "@better-auth/utils": "^0.3.0", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-6+M3MS2mor8fTUV3EI1FBLP0cs6QfbN+Ovx9+XxR/GdfKIBoNFzmPEPRbdGt+ft6PvrITsUm+T70+kkHgVSP6w=="],
+
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.5.6", "", { "peerDependencies": { "@better-auth/core": "1.5.6", "@better-auth/utils": "^0.3.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-UxY9vQJs1Tt+O+T2YQnseDMlWmUSQvFZSBb5YiFRg7zcm+TEzujh4iX2/csA0YiZptLheovIuVWTP9nriewEBA=="],
+
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.5.6", "", { "dependencies": { "@better-auth/utils": "0.3.1", "@better-fetch/fetch": "1.1.21" }, "peerDependencies": { "@better-auth/core": "1.5.6" } }, "sha512-yXC7NSxnIFlxDkGdpD7KA+J9nqIQAPCJKe77GoaC5bWoe/DALo1MYorZfTgOafS7wrslNtsPT4feV/LJi1ubqQ=="],
+
+    "@better-auth/utils": ["@better-auth/utils@0.3.1", "", {}, "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg=="],
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
@@ -298,7 +306,7 @@
 
     "@comark/markdown-it": ["@comark/markdown-it@0.3.2", "", { "dependencies": { "js-yaml": "^4.1.1" }, "peerDependencies": { "@types/markdown-it": "*", "markdown-it": "^14.0.0" } }, "sha512-h+zwwsqr2zLBajKqdzLiLjhccO8+euTAKiBRLJcJvaMGma4yPCrYfWM0dgO0AFz3gK030cf5I5qBN0a3C3jzpQ=="],
 
-    "@convex-dev/better-auth": ["@convex-dev/better-auth@0.10.13", "", { "dependencies": { "@better-auth/passkey": "1.4.9", "@better-fetch/fetch": "^1.1.18", "common-tags": "^1.8.2", "convex-helpers": "^0.1.95", "jose": "^6.1.0", "remeda": "^2.32.0", "semver": "^7.7.3", "type-fest": "^4.39.1", "zod": "^4.0.0" }, "peerDependencies": { "better-auth": ">=1.4.9 <1.5.0", "convex": "^1.25.0", "react": "^18.3.1 || ^19.0.0" } }, "sha512-ll59IxdJrefJkKcH667aWt0S5Z0vPNiW2EixWlsdz0h4qdm31J8dxwxO9aDIaeqnE+m1iJ0mUwRedTgYcxQxiQ=="],
+    "@convex-dev/better-auth": ["@convex-dev/better-auth@0.11.4", "", { "dependencies": { "@better-fetch/fetch": "^1.1.18", "common-tags": "^1.8.2", "convex-helpers": "^0.1.95", "jose": "^6.1.0", "remeda": "^2.32.0", "semver": "^7.7.3", "type-fest": "^4.39.1", "zod": "^4.0.0" }, "peerDependencies": { "better-auth": ">=1.5.0 <1.6.0", "convex": "^1.25.0", "react": "^18.3.1 || ^19.0.0" } }, "sha512-CsRsM7UaQgQKH1mt4z64QOZUfrhZKNsspkpWjlhqLiIz5THfnM2vaSVMQ3GOddcUvw7AgkNCNR3u8C8HjLQEMA=="],
 
     "@convex-dev/migrations": ["@convex-dev/migrations@0.3.1", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-dGiN82vWMN415/AGMcVooDOJk8iTousZahBBs27uA03pL74Uo3ksucUW3CiCfPx75rv+x9UnenEakimQYYNIrA=="],
 
@@ -432,8 +440,6 @@
 
     "@fontsource/geist-sans": ["@fontsource/geist-sans@5.2.5", "", {}, "sha512-anllOHyJbElRs9fV15TeDRqAeb1IKm4bSknPl6ZMoyPTx1BBy7logudcUwpNjmQLkzn4Q0JGQLRCUKJYoyST6A=="],
 
-    "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
-
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
     "@iconify-json/carbon": ["@iconify-json/carbon@1.2.19", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-l89XjtEeSA5fxlxPTNSU9AA+rxaz/Dn0X/ux0/3awR+tAayY8iJqWQu3AKxhchfx3LB/fX1Nv3ZppZzrBAt7aA=="],
@@ -519,8 +525,6 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
-
-    "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
     "@lillallol/outline-pdf": ["@lillallol/outline-pdf@4.0.0", "", { "dependencies": { "@lillallol/outline-pdf-data-structure": "^1.0.3", "pdf-lib": "^1.16.0" } }, "sha512-tILGNyOdI3ukZfU19TNTDVoS0W1nSPlMxCKAm9FPV4OPL786Ur7e1CRLQZWKJP6uaMQsUqSDBCTzISs6lXWdAQ=="],
 
@@ -790,30 +794,6 @@
 
     "@pdf-lib/upng": ["@pdf-lib/upng@1.0.1", "", { "dependencies": { "pako": "^1.0.10" } }, "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ=="],
 
-    "@peculiar/asn1-android": ["@peculiar/asn1-android@2.6.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ=="],
-
-    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/asn1-x509-attr": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw=="],
-
-    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w=="],
-
-    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g=="],
-
-    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.6.1", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.1", "@peculiar/asn1-pkcs8": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw=="],
-
-    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw=="],
-
-    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.6.1", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.1", "@peculiar/asn1-pfx": "^2.6.1", "@peculiar/asn1-pkcs8": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/asn1-x509-attr": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw=="],
-
-    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA=="],
-
-    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.6.0", "", { "dependencies": { "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg=="],
-
-    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA=="],
-
-    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ=="],
-
-    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
-
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
@@ -1037,10 +1017,6 @@
     "@shikijs/vitepress-twoslash": ["@shikijs/vitepress-twoslash@4.0.2", "", { "dependencies": { "@shikijs/twoslash": "4.0.2", "floating-vue": "^5.2.2", "lz-string": "^1.5.0", "magic-string": "^0.30.21", "markdown-it": "^14.1.1", "mdast-util-from-markdown": "^2.0.3", "mdast-util-gfm": "^3.1.0", "mdast-util-to-hast": "^13.2.1", "ohash": "^2.0.11", "shiki": "4.0.2", "twoslash": "^0.3.6", "twoslash-vue": "^0.3.6", "vue": "^3.5.29" } }, "sha512-Bk01fAYDDiTffRPLHNJdNlYwzExXIVcrHUVNciD931SMlKZArvteKib6mM3mWAUhcy78RW1llT3fczjKIgQHBA=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
-
-    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
-
-    "@simplewebauthn/server": ["@simplewebauthn/server@13.3.0", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
@@ -1492,8 +1468,6 @@
 
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
 
-    "asn1js": ["asn1js@3.0.7", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.3", "tslib": "^2.8.1" } }, "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ=="],
-
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-kit": ["ast-kit@2.2.0", "", { "dependencies": { "@babel/parser": "^7.28.5", "pathe": "^2.0.3" } }, "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw=="],
@@ -1538,9 +1512,9 @@
 
     "bcp-47-match": ["bcp-47-match@2.0.3", "", {}, "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ=="],
 
-    "better-auth": ["better-auth@1.4.9", "", { "dependencies": { "@better-auth/core": "1.4.9", "@better-auth/telemetry": "1.4.9", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "better-call": "1.1.7", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.1.12" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-usSdjuyTzZwIvM8fjF8YGhPncxV3MAg3dHUO9uPUnf0yklXUSYISiH1+imk6/Z+UBqsscyyPRnbIyjyK97p7YA=="],
+    "better-auth": ["better-auth@1.5.6", "", { "dependencies": { "@better-auth/core": "1.5.6", "@better-auth/drizzle-adapter": "1.5.6", "@better-auth/kysely-adapter": "1.5.6", "@better-auth/memory-adapter": "1.5.6", "@better-auth/mongo-adapter": "1.5.6", "@better-auth/prisma-adapter": "1.5.6", "@better-auth/telemetry": "1.5.6", "@better-auth/utils": "0.3.1", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.2", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.12", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-QSpJTqaT1XVfWRQe/fm3PgeuwOIlz1nWX/Dx7nsHStJ382bLzmDbQk2u7IT0IJ6wS5SRxfqEE1Ev9TXontgyAQ=="],
 
-    "better-call": ["better-call@1.1.7", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.7.10", "set-cookie-parser": "^2.7.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-6gaJe1bBIEgVebQu/7q9saahVzvBsGaByEnE8aDVncZEDiJO7sdNB28ot9I6iXSbR25egGmmZ6aIURXyQHRraQ=="],
+    "better-call": ["better-call@1.3.2", "", { "dependencies": { "@better-auth/utils": "^0.3.1", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw=="],
 
     "better-sqlite3": ["better-sqlite3@12.8.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ=="],
 
@@ -2802,10 +2776,6 @@
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
-    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
-
-    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
-
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
@@ -2875,8 +2845,6 @@
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
     "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
-
-    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
@@ -2992,7 +2960,7 @@
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+    "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
 
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
@@ -3173,8 +3141,6 @@
     "tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
-
-    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
@@ -3450,30 +3416,6 @@
 
     "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
-    "@peculiar/asn1-android/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@peculiar/asn1-cms/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@peculiar/asn1-csr/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@peculiar/asn1-ecc/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@peculiar/asn1-pfx/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@peculiar/asn1-pkcs8/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@peculiar/asn1-pkcs9/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@peculiar/asn1-rsa/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@peculiar/asn1-schema/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@peculiar/asn1-x509/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@peculiar/asn1-x509-attr/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@peculiar/x509/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
     "@polar-sh/checkout/@polar-sh/sdk": ["@polar-sh/sdk@0.42.5", "", { "dependencies": { "standardwebhooks": "^1.0.0", "zod": "^3.25.65 || ^4.0.0" } }, "sha512-GzC3/ElCtMO55+KeXwFTANlydZzw5qI3DU/F9vAFIsUKuegSmh+Xu03KCL+ct9/imJOvLUQucYhUSsNKqo2j2Q=="],
 
     "@polar-sh/ui/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
@@ -3624,8 +3566,6 @@
 
     "aria-hidden/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "asn1js/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
     "ast-types/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "astro/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
@@ -3726,6 +3666,8 @@
 
     "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
 
+    "light-my-request/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
     "lower-case/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -3775,8 +3717,6 @@
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
-
-    "pvtsutils/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
       "zod": "^4.1.13",
       "typescript": "^5",
       "convex": "^1.33.1",
-      "better-auth": "1.4.9",
-      "@convex-dev/better-auth": "^0.10.13"
+      "better-auth": "1.5.6",
+      "@convex-dev/better-auth": "^0.11.4"
     }
   },
   "type": "module",

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -219,21 +219,6 @@ export declare const components: {
               }
             | {
                 data: {
-                  aaguid?: null | string;
-                  backedUp: boolean;
-                  counter: number;
-                  createdAt?: null | number;
-                  credentialID: string;
-                  deviceType: string;
-                  name?: null | string;
-                  publicKey: string;
-                  transports?: null | string;
-                  userId: string;
-                };
-                model: "passkey";
-              }
-            | {
-                data: {
                   clientId?: null | string;
                   clientSecret?: null | string;
                   createdAt?: null | number;
@@ -241,7 +226,7 @@ export declare const components: {
                   icon?: null | string;
                   metadata?: null | string;
                   name?: null | string;
-                  redirectURLs?: null | string;
+                  redirectUrls?: null | string;
                   type?: null | string;
                   updatedAt?: null | number;
                   userId?: null | string;
@@ -276,17 +261,14 @@ export declare const components: {
             | {
                 data: {
                   createdAt: number;
+                  expiresAt?: null | number;
                   privateKey: string;
                   publicKey: string;
                 };
                 model: "jwks";
               }
             | {
-                data: {
-                  count?: null | number;
-                  key?: null | string;
-                  lastRequest?: null | number;
-                };
+                data: { count: number; key: string; lastRequest: number };
                 model: "rateLimit";
               };
           onCreateHandle?: string;
@@ -471,43 +453,6 @@ export declare const components: {
                 }>;
               }
             | {
-                model: "passkey";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field:
-                    | "name"
-                    | "publicKey"
-                    | "userId"
-                    | "credentialID"
-                    | "counter"
-                    | "deviceType"
-                    | "backedUp"
-                    | "transports"
-                    | "createdAt"
-                    | "aaguid"
-                    | "_id";
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "not_in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
                 model: "oauthApplication";
                 where?: Array<{
                   connector?: "AND" | "OR";
@@ -517,7 +462,7 @@ export declare const components: {
                     | "metadata"
                     | "clientId"
                     | "clientSecret"
-                    | "redirectURLs"
+                    | "redirectUrls"
                     | "type"
                     | "disabled"
                     | "userId"
@@ -618,7 +563,12 @@ export declare const components: {
                 model: "jwks";
                 where?: Array<{
                   connector?: "AND" | "OR";
-                  field: "publicKey" | "privateKey" | "createdAt" | "_id";
+                  field:
+                    | "publicKey"
+                    | "privateKey"
+                    | "createdAt"
+                    | "expiresAt"
+                    | "_id";
                   operator?:
                     | "lt"
                     | "lte"
@@ -855,43 +805,6 @@ export declare const components: {
                 }>;
               }
             | {
-                model: "passkey";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field:
-                    | "name"
-                    | "publicKey"
-                    | "userId"
-                    | "credentialID"
-                    | "counter"
-                    | "deviceType"
-                    | "backedUp"
-                    | "transports"
-                    | "createdAt"
-                    | "aaguid"
-                    | "_id";
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "not_in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
                 model: "oauthApplication";
                 where?: Array<{
                   connector?: "AND" | "OR";
@@ -901,7 +814,7 @@ export declare const components: {
                     | "metadata"
                     | "clientId"
                     | "clientSecret"
-                    | "redirectURLs"
+                    | "redirectUrls"
                     | "type"
                     | "disabled"
                     | "userId"
@@ -1002,7 +915,12 @@ export declare const components: {
                 model: "jwks";
                 where?: Array<{
                   connector?: "AND" | "OR";
-                  field: "publicKey" | "privateKey" | "createdAt" | "_id";
+                  field:
+                    | "publicKey"
+                    | "privateKey"
+                    | "createdAt"
+                    | "expiresAt"
+                    | "_id";
                   operator?:
                     | "lt"
                     | "lte"
@@ -1066,7 +984,6 @@ export declare const components: {
             | "account"
             | "verification"
             | "twoFactor"
-            | "passkey"
             | "oauthApplication"
             | "oauthAccessToken"
             | "oauthConsent"
@@ -1081,6 +998,7 @@ export declare const components: {
             maximumRowsRead?: number;
             numItems: number;
           };
+          select?: Array<string>;
           sortBy?: { direction: "asc" | "desc"; field: string };
           where?: Array<{
             connector?: "AND" | "OR";
@@ -1119,7 +1037,6 @@ export declare const components: {
             | "account"
             | "verification"
             | "twoFactor"
-            | "passkey"
             | "oauthApplication"
             | "oauthAccessToken"
             | "oauthConsent"
@@ -1379,55 +1296,6 @@ export declare const components: {
                 }>;
               }
             | {
-                model: "passkey";
-                update: {
-                  aaguid?: null | string;
-                  backedUp?: boolean;
-                  counter?: number;
-                  createdAt?: null | number;
-                  credentialID?: string;
-                  deviceType?: string;
-                  name?: null | string;
-                  publicKey?: string;
-                  transports?: null | string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field:
-                    | "name"
-                    | "publicKey"
-                    | "userId"
-                    | "credentialID"
-                    | "counter"
-                    | "deviceType"
-                    | "backedUp"
-                    | "transports"
-                    | "createdAt"
-                    | "aaguid"
-                    | "_id";
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "not_in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
                 model: "oauthApplication";
                 update: {
                   clientId?: null | string;
@@ -1437,7 +1305,7 @@ export declare const components: {
                   icon?: null | string;
                   metadata?: null | string;
                   name?: null | string;
-                  redirectURLs?: null | string;
+                  redirectUrls?: null | string;
                   type?: null | string;
                   updatedAt?: null | number;
                   userId?: null | string;
@@ -1450,7 +1318,7 @@ export declare const components: {
                     | "metadata"
                     | "clientId"
                     | "clientSecret"
-                    | "redirectURLs"
+                    | "redirectUrls"
                     | "type"
                     | "disabled"
                     | "userId"
@@ -1570,12 +1438,18 @@ export declare const components: {
                 model: "jwks";
                 update: {
                   createdAt?: number;
+                  expiresAt?: null | number;
                   privateKey?: string;
                   publicKey?: string;
                 };
                 where?: Array<{
                   connector?: "AND" | "OR";
-                  field: "publicKey" | "privateKey" | "createdAt" | "_id";
+                  field:
+                    | "publicKey"
+                    | "privateKey"
+                    | "createdAt"
+                    | "expiresAt"
+                    | "_id";
                   operator?:
                     | "lt"
                     | "lte"
@@ -1599,11 +1473,7 @@ export declare const components: {
               }
             | {
                 model: "rateLimit";
-                update: {
-                  count?: null | number;
-                  key?: null | string;
-                  lastRequest?: null | number;
-                };
+                update: { count?: number; key?: string; lastRequest?: number };
                 where?: Array<{
                   connector?: "AND" | "OR";
                   field: "key" | "count" | "lastRequest" | "_id";
@@ -1867,55 +1737,6 @@ export declare const components: {
                 }>;
               }
             | {
-                model: "passkey";
-                update: {
-                  aaguid?: null | string;
-                  backedUp?: boolean;
-                  counter?: number;
-                  createdAt?: null | number;
-                  credentialID?: string;
-                  deviceType?: string;
-                  name?: null | string;
-                  publicKey?: string;
-                  transports?: null | string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field:
-                    | "name"
-                    | "publicKey"
-                    | "userId"
-                    | "credentialID"
-                    | "counter"
-                    | "deviceType"
-                    | "backedUp"
-                    | "transports"
-                    | "createdAt"
-                    | "aaguid"
-                    | "_id";
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "not_in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
                 model: "oauthApplication";
                 update: {
                   clientId?: null | string;
@@ -1925,7 +1746,7 @@ export declare const components: {
                   icon?: null | string;
                   metadata?: null | string;
                   name?: null | string;
-                  redirectURLs?: null | string;
+                  redirectUrls?: null | string;
                   type?: null | string;
                   updatedAt?: null | number;
                   userId?: null | string;
@@ -1938,7 +1759,7 @@ export declare const components: {
                     | "metadata"
                     | "clientId"
                     | "clientSecret"
-                    | "redirectURLs"
+                    | "redirectUrls"
                     | "type"
                     | "disabled"
                     | "userId"
@@ -2058,12 +1879,18 @@ export declare const components: {
                 model: "jwks";
                 update: {
                   createdAt?: number;
+                  expiresAt?: null | number;
                   privateKey?: string;
                   publicKey?: string;
                 };
                 where?: Array<{
                   connector?: "AND" | "OR";
-                  field: "publicKey" | "privateKey" | "createdAt" | "_id";
+                  field:
+                    | "publicKey"
+                    | "privateKey"
+                    | "createdAt"
+                    | "expiresAt"
+                    | "_id";
                   operator?:
                     | "lt"
                     | "lte"
@@ -2087,11 +1914,7 @@ export declare const components: {
               }
             | {
                 model: "rateLimit";
-                update: {
-                  count?: null | number;
-                  key?: null | string;
-                  lastRequest?: null | number;
-                };
+                update: { count?: number; key?: string; lastRequest?: number };
                 where?: Array<{
                   connector?: "AND" | "OR";
                   field: "key" | "count" | "lastRequest" | "_id";
@@ -2122,8 +1945,19381 @@ export declare const components: {
       >;
     };
     adapterTest: {
-      runCustomTests: FunctionReference<"action", "internal", any, any>;
       runTests: FunctionReference<"action", "internal", any, any>;
+    };
+    testProfiles: {
+      adapterAdditionalFields: {
+        create: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email: string;
+                    emailVerified: boolean;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    ipAddress?: null | string;
+                    token: string;
+                    updatedAt: number;
+                    userAgent?: null | string;
+                    userId: string;
+                  };
+                  model: "session";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId: string;
+                    createdAt: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt: number;
+                    userId: string;
+                  };
+                  model: "account";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    identifier: string;
+                    updatedAt: number;
+                    value: string;
+                  };
+                  model: "verification";
+                }
+              | {
+                  data: { backupCodes: string; secret: string; userId: string };
+                  model: "twoFactor";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthApplication";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthAccessToken";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthConsent";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt?: null | number;
+                    privateKey: string;
+                    publicKey: string;
+                  };
+                  model: "jwks";
+                }
+              | {
+                  data: { count: number; key: string; lastRequest: number };
+                  model: "rateLimit";
+                };
+            onCreateHandle?: string;
+            select?: Array<string>;
+          },
+          any
+        >;
+        deleteMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "customField"
+                      | "numericField"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        deleteOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "customField"
+                      | "numericField"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+          },
+          any
+        >;
+        findMany: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            limit?: number;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit";
+            offset?: number;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+            select?: Array<string>;
+            sortBy?: { direction: "asc" | "desc"; field: string };
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        findOne: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit";
+            select?: Array<string>;
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        updateMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: string;
+                    emailVerified?: boolean;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "customField"
+                      | "numericField"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        updateOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: string;
+                    emailVerified?: boolean;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "customField"
+                      | "numericField"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+          },
+          any
+        >;
+      };
+      adapterOrganizationJoins: {
+        create: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    ipAddress?: null | string;
+                    token: string;
+                    updatedAt: number;
+                    userAgent?: null | string;
+                    userId: string;
+                  };
+                  model: "session";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId: string;
+                    createdAt: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt: number;
+                    userId: string;
+                  };
+                  model: "account";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    identifier: string;
+                    updatedAt: number;
+                    value: string;
+                  };
+                  model: "verification";
+                }
+              | {
+                  data: { backupCodes: string; secret: string; userId: string };
+                  model: "twoFactor";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthApplication";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthAccessToken";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthConsent";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt?: null | number;
+                    privateKey: string;
+                    publicKey: string;
+                  };
+                  model: "jwks";
+                }
+              | {
+                  data: { count: number; key: string; lastRequest: number };
+                  model: "rateLimit";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user_custom";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user_table";
+                }
+              | { data: { oneToOne: string }; model: "oneToOneTable" }
+              | {
+                  data: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  model: "one_to_one_table";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  model: "testModel";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name: string;
+                    slug: string;
+                    updatedAt?: null | number;
+                  };
+                  model: "organization";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    organizationId: string;
+                    role: string;
+                    updatedAt?: null | number;
+                    userId: string;
+                  };
+                  model: "member";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    name: string;
+                    organizationId: string;
+                    updatedAt?: null | number;
+                  };
+                  model: "team";
+                }
+              | {
+                  data: {
+                    createdAt?: null | number;
+                    teamId: string;
+                    userId: string;
+                  };
+                  model: "teamMember";
+                }
+              | {
+                  data: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  model: "invitation";
+                };
+            onCreateHandle?: string;
+            select?: Array<string>;
+          },
+          any
+        >;
+        deleteMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        deleteOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+          },
+          any
+        >;
+        findMany: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            limit?: number;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit"
+              | "user_custom"
+              | "user_table"
+              | "oneToOneTable"
+              | "one_to_one_table"
+              | "testModel"
+              | "organization"
+              | "member"
+              | "team"
+              | "teamMember"
+              | "invitation";
+            offset?: number;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+            select?: Array<string>;
+            sortBy?: { direction: "asc" | "desc"; field: string };
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        findOne: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit"
+              | "user_custom"
+              | "user_table"
+              | "oneToOneTable"
+              | "one_to_one_table"
+              | "testModel"
+              | "organization"
+              | "member"
+              | "team"
+              | "teamMember"
+              | "invitation";
+            select?: Array<string>;
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        updateMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  update: { oneToOne?: string };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  update: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  update: {
+                    createdAt?: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name?: string;
+                    slug?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  update: {
+                    createdAt?: number;
+                    organizationId?: string;
+                    role?: string;
+                    updatedAt?: null | number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  update: {
+                    createdAt?: number;
+                    name?: string;
+                    organizationId?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  update: {
+                    createdAt?: null | number;
+                    teamId?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  update: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        updateOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  update: { oneToOne?: string };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  update: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  update: {
+                    createdAt?: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name?: string;
+                    slug?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  update: {
+                    createdAt?: number;
+                    organizationId?: string;
+                    role?: string;
+                    updatedAt?: null | number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  update: {
+                    createdAt?: number;
+                    name?: string;
+                    organizationId?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  update: {
+                    createdAt?: null | number;
+                    teamId?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  update: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+          },
+          any
+        >;
+      };
+      adapterPluginTable: {
+        create: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    ipAddress?: null | string;
+                    token: string;
+                    updatedAt: number;
+                    userAgent?: null | string;
+                    userId: string;
+                  };
+                  model: "session";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId: string;
+                    createdAt: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt: number;
+                    userId: string;
+                  };
+                  model: "account";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    identifier: string;
+                    updatedAt: number;
+                    value: string;
+                  };
+                  model: "verification";
+                }
+              | {
+                  data: { backupCodes: string; secret: string; userId: string };
+                  model: "twoFactor";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthApplication";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthAccessToken";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthConsent";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt?: null | number;
+                    privateKey: string;
+                    publicKey: string;
+                  };
+                  model: "jwks";
+                }
+              | {
+                  data: { count: number; key: string; lastRequest: number };
+                  model: "rateLimit";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user_custom";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user_table";
+                }
+              | { data: { oneToOne: string }; model: "oneToOneTable" }
+              | {
+                  data: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  model: "one_to_one_table";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  model: "testModel";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name: string;
+                    slug: string;
+                    updatedAt?: null | number;
+                  };
+                  model: "organization";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    organizationId: string;
+                    role: string;
+                    updatedAt?: null | number;
+                    userId: string;
+                  };
+                  model: "member";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    name: string;
+                    organizationId: string;
+                    updatedAt?: null | number;
+                  };
+                  model: "team";
+                }
+              | {
+                  data: {
+                    createdAt?: null | number;
+                    teamId: string;
+                    userId: string;
+                  };
+                  model: "teamMember";
+                }
+              | {
+                  data: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  model: "invitation";
+                };
+            onCreateHandle?: string;
+            select?: Array<string>;
+          },
+          any
+        >;
+        deleteMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        deleteOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+          },
+          any
+        >;
+        findMany: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            limit?: number;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit"
+              | "user_custom"
+              | "user_table"
+              | "oneToOneTable"
+              | "one_to_one_table"
+              | "testModel"
+              | "organization"
+              | "member"
+              | "team"
+              | "teamMember"
+              | "invitation";
+            offset?: number;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+            select?: Array<string>;
+            sortBy?: { direction: "asc" | "desc"; field: string };
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        findOne: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit"
+              | "user_custom"
+              | "user_table"
+              | "oneToOneTable"
+              | "one_to_one_table"
+              | "testModel"
+              | "organization"
+              | "member"
+              | "team"
+              | "teamMember"
+              | "invitation";
+            select?: Array<string>;
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        updateMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  update: { oneToOne?: string };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  update: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  update: {
+                    createdAt?: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name?: string;
+                    slug?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  update: {
+                    createdAt?: number;
+                    organizationId?: string;
+                    role?: string;
+                    updatedAt?: null | number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  update: {
+                    createdAt?: number;
+                    name?: string;
+                    organizationId?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  update: {
+                    createdAt?: null | number;
+                    teamId?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  update: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        updateOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  update: { oneToOne?: string };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  update: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  update: {
+                    createdAt?: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name?: string;
+                    slug?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  update: {
+                    createdAt?: number;
+                    organizationId?: string;
+                    role?: string;
+                    updatedAt?: null | number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  update: {
+                    createdAt?: number;
+                    name?: string;
+                    organizationId?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  update: {
+                    createdAt?: null | number;
+                    teamId?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  update: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+          },
+          any
+        >;
+      };
+      adapterRenameField: {
+        create: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    ipAddress?: null | string;
+                    token: string;
+                    updatedAt: number;
+                    userAgent?: null | string;
+                    userId: string;
+                  };
+                  model: "session";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId: string;
+                    createdAt: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt: number;
+                    userId: string;
+                  };
+                  model: "account";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    identifier: string;
+                    updatedAt: number;
+                    value: string;
+                  };
+                  model: "verification";
+                }
+              | {
+                  data: { backupCodes: string; secret: string; userId: string };
+                  model: "twoFactor";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthApplication";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthAccessToken";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthConsent";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt?: null | number;
+                    privateKey: string;
+                    publicKey: string;
+                  };
+                  model: "jwks";
+                }
+              | {
+                  data: { count: number; key: string; lastRequest: number };
+                  model: "rateLimit";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user_custom";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user_table";
+                }
+              | { data: { oneToOne: string }; model: "oneToOneTable" }
+              | {
+                  data: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  model: "one_to_one_table";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  model: "testModel";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name: string;
+                    slug: string;
+                    updatedAt?: null | number;
+                  };
+                  model: "organization";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    organizationId: string;
+                    role: string;
+                    updatedAt?: null | number;
+                    userId: string;
+                  };
+                  model: "member";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    name: string;
+                    organizationId: string;
+                    updatedAt?: null | number;
+                  };
+                  model: "team";
+                }
+              | {
+                  data: {
+                    createdAt?: null | number;
+                    teamId: string;
+                    userId: string;
+                  };
+                  model: "teamMember";
+                }
+              | {
+                  data: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  model: "invitation";
+                };
+            onCreateHandle?: string;
+            select?: Array<string>;
+          },
+          any
+        >;
+        deleteMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        deleteOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+          },
+          any
+        >;
+        findMany: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            limit?: number;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit"
+              | "user_custom"
+              | "user_table"
+              | "oneToOneTable"
+              | "one_to_one_table"
+              | "testModel"
+              | "organization"
+              | "member"
+              | "team"
+              | "teamMember"
+              | "invitation";
+            offset?: number;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+            select?: Array<string>;
+            sortBy?: { direction: "asc" | "desc"; field: string };
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        findOne: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit"
+              | "user_custom"
+              | "user_table"
+              | "oneToOneTable"
+              | "one_to_one_table"
+              | "testModel"
+              | "organization"
+              | "member"
+              | "team"
+              | "teamMember"
+              | "invitation";
+            select?: Array<string>;
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        updateMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  update: { oneToOne?: string };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  update: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  update: {
+                    createdAt?: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name?: string;
+                    slug?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  update: {
+                    createdAt?: number;
+                    organizationId?: string;
+                    role?: string;
+                    updatedAt?: null | number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  update: {
+                    createdAt?: number;
+                    name?: string;
+                    organizationId?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  update: {
+                    createdAt?: null | number;
+                    teamId?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  update: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        updateOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  update: { oneToOne?: string };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  update: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  update: {
+                    createdAt?: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name?: string;
+                    slug?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  update: {
+                    createdAt?: number;
+                    organizationId?: string;
+                    role?: string;
+                    updatedAt?: null | number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  update: {
+                    createdAt?: number;
+                    name?: string;
+                    organizationId?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  update: {
+                    createdAt?: null | number;
+                    teamId?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  update: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+          },
+          any
+        >;
+      };
+      adapterRenameUserCustom: {
+        create: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    ipAddress?: null | string;
+                    token: string;
+                    updatedAt: number;
+                    userAgent?: null | string;
+                    userId: string;
+                  };
+                  model: "session";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId: string;
+                    createdAt: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt: number;
+                    userId: string;
+                  };
+                  model: "account";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    identifier: string;
+                    updatedAt: number;
+                    value: string;
+                  };
+                  model: "verification";
+                }
+              | {
+                  data: { backupCodes: string; secret: string; userId: string };
+                  model: "twoFactor";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthApplication";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthAccessToken";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthConsent";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt?: null | number;
+                    privateKey: string;
+                    publicKey: string;
+                  };
+                  model: "jwks";
+                }
+              | {
+                  data: { count: number; key: string; lastRequest: number };
+                  model: "rateLimit";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user_custom";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user_table";
+                }
+              | { data: { oneToOne: string }; model: "oneToOneTable" }
+              | {
+                  data: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  model: "one_to_one_table";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  model: "testModel";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name: string;
+                    slug: string;
+                    updatedAt?: null | number;
+                  };
+                  model: "organization";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    organizationId: string;
+                    role: string;
+                    updatedAt?: null | number;
+                    userId: string;
+                  };
+                  model: "member";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    name: string;
+                    organizationId: string;
+                    updatedAt?: null | number;
+                  };
+                  model: "team";
+                }
+              | {
+                  data: {
+                    createdAt?: null | number;
+                    teamId: string;
+                    userId: string;
+                  };
+                  model: "teamMember";
+                }
+              | {
+                  data: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  model: "invitation";
+                };
+            onCreateHandle?: string;
+            select?: Array<string>;
+          },
+          any
+        >;
+        deleteMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        deleteOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+          },
+          any
+        >;
+        findMany: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            limit?: number;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit"
+              | "user_custom"
+              | "user_table"
+              | "oneToOneTable"
+              | "one_to_one_table"
+              | "testModel"
+              | "organization"
+              | "member"
+              | "team"
+              | "teamMember"
+              | "invitation";
+            offset?: number;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+            select?: Array<string>;
+            sortBy?: { direction: "asc" | "desc"; field: string };
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        findOne: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit"
+              | "user_custom"
+              | "user_table"
+              | "oneToOneTable"
+              | "one_to_one_table"
+              | "testModel"
+              | "organization"
+              | "member"
+              | "team"
+              | "teamMember"
+              | "invitation";
+            select?: Array<string>;
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        updateMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  update: { oneToOne?: string };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  update: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  update: {
+                    createdAt?: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name?: string;
+                    slug?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  update: {
+                    createdAt?: number;
+                    organizationId?: string;
+                    role?: string;
+                    updatedAt?: null | number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  update: {
+                    createdAt?: number;
+                    name?: string;
+                    organizationId?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  update: {
+                    createdAt?: null | number;
+                    teamId?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  update: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        updateOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  update: { oneToOne?: string };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  update: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  update: {
+                    createdAt?: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name?: string;
+                    slug?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  update: {
+                    createdAt?: number;
+                    organizationId?: string;
+                    role?: string;
+                    updatedAt?: null | number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  update: {
+                    createdAt?: number;
+                    name?: string;
+                    organizationId?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  update: {
+                    createdAt?: null | number;
+                    teamId?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  update: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+          },
+          any
+        >;
+      };
+      adapterRenameUserTable: {
+        create: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    ipAddress?: null | string;
+                    token: string;
+                    updatedAt: number;
+                    userAgent?: null | string;
+                    userId: string;
+                  };
+                  model: "session";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId: string;
+                    createdAt: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt: number;
+                    userId: string;
+                  };
+                  model: "account";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt: number;
+                    identifier: string;
+                    updatedAt: number;
+                    value: string;
+                  };
+                  model: "verification";
+                }
+              | {
+                  data: { backupCodes: string; secret: string; userId: string };
+                  model: "twoFactor";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthApplication";
+                }
+              | {
+                  data: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthAccessToken";
+                }
+              | {
+                  data: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  model: "oauthConsent";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    expiresAt?: null | number;
+                    privateKey: string;
+                    publicKey: string;
+                  };
+                  model: "jwks";
+                }
+              | {
+                  data: { count: number; key: string; lastRequest: number };
+                  model: "rateLimit";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user_custom";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    createdAt: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  model: "user_table";
+                }
+              | { data: { oneToOne: string }; model: "oneToOneTable" }
+              | {
+                  data: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  model: "one_to_one_table";
+                }
+              | {
+                  data: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  model: "testModel";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name: string;
+                    slug: string;
+                    updatedAt?: null | number;
+                  };
+                  model: "organization";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    organizationId: string;
+                    role: string;
+                    updatedAt?: null | number;
+                    userId: string;
+                  };
+                  model: "member";
+                }
+              | {
+                  data: {
+                    createdAt: number;
+                    name: string;
+                    organizationId: string;
+                    updatedAt?: null | number;
+                  };
+                  model: "team";
+                }
+              | {
+                  data: {
+                    createdAt?: null | number;
+                    teamId: string;
+                    userId: string;
+                  };
+                  model: "teamMember";
+                }
+              | {
+                  data: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  model: "invitation";
+                };
+            onCreateHandle?: string;
+            select?: Array<string>;
+          },
+          any
+        >;
+        deleteMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        deleteOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onDeleteHandle?: string;
+          },
+          any
+        >;
+        findMany: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            limit?: number;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit"
+              | "user_custom"
+              | "user_table"
+              | "oneToOneTable"
+              | "one_to_one_table"
+              | "testModel"
+              | "organization"
+              | "member"
+              | "team"
+              | "teamMember"
+              | "invitation";
+            offset?: number;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+            select?: Array<string>;
+            sortBy?: { direction: "asc" | "desc"; field: string };
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        findOne: FunctionReference<
+          "query",
+          "internal",
+          {
+            join?: any;
+            model:
+              | "user"
+              | "session"
+              | "account"
+              | "verification"
+              | "twoFactor"
+              | "oauthApplication"
+              | "oauthAccessToken"
+              | "oauthConsent"
+              | "jwks"
+              | "rateLimit"
+              | "user_custom"
+              | "user_table"
+              | "oneToOneTable"
+              | "one_to_one_table"
+              | "testModel"
+              | "organization"
+              | "member"
+              | "team"
+              | "teamMember"
+              | "invitation";
+            select?: Array<string>;
+            where?: Array<{
+              connector?: "AND" | "OR";
+              field: string;
+              operator?:
+                | "lt"
+                | "lte"
+                | "gt"
+                | "gte"
+                | "eq"
+                | "in"
+                | "not_in"
+                | "ne"
+                | "contains"
+                | "starts_with"
+                | "ends_with";
+              value:
+                | string
+                | number
+                | boolean
+                | Array<string>
+                | Array<number>
+                | null;
+            }>;
+          },
+          any
+        >;
+        updateMany: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  update: { oneToOne?: string };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  update: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  update: {
+                    createdAt?: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name?: string;
+                    slug?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  update: {
+                    createdAt?: number;
+                    organizationId?: string;
+                    role?: string;
+                    updatedAt?: null | number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  update: {
+                    createdAt?: number;
+                    name?: string;
+                    organizationId?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  update: {
+                    createdAt?: null | number;
+                    teamId?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  update: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+            paginationOpts: {
+              cursor: string | null;
+              endCursor?: string | null;
+              id?: number;
+              maximumBytesRead?: number;
+              maximumRowsRead?: number;
+              numItems: number;
+            };
+          },
+          any
+        >;
+        updateOne: FunctionReference<
+          "mutation",
+          "internal",
+          {
+            input:
+              | {
+                  model: "user";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "session";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    ipAddress?: null | string;
+                    token?: string;
+                    updatedAt?: number;
+                    userAgent?: null | string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "expiresAt"
+                      | "token"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "ipAddress"
+                      | "userAgent"
+                      | "userId"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "account";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    accountId?: string;
+                    createdAt?: number;
+                    idToken?: null | string;
+                    password?: null | string;
+                    providerId?: string;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scope?: null | string;
+                    updatedAt?: number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accountId"
+                      | "providerId"
+                      | "userId"
+                      | "accessToken"
+                      | "refreshToken"
+                      | "idToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "scope"
+                      | "password"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "verification";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: number;
+                    identifier?: string;
+                    updatedAt?: number;
+                    value?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "identifier"
+                      | "value"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "twoFactor";
+                  update: {
+                    backupCodes?: string;
+                    secret?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "secret" | "backupCodes" | "userId" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthApplication";
+                  update: {
+                    clientId?: null | string;
+                    clientSecret?: null | string;
+                    createdAt?: null | number;
+                    disabled?: null | boolean;
+                    icon?: null | string;
+                    metadata?: null | string;
+                    name?: null | string;
+                    redirectUrls?: null | string;
+                    type?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "icon"
+                      | "metadata"
+                      | "clientId"
+                      | "clientSecret"
+                      | "redirectUrls"
+                      | "type"
+                      | "disabled"
+                      | "userId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthAccessToken";
+                  update: {
+                    accessToken?: null | string;
+                    accessTokenExpiresAt?: null | number;
+                    clientId?: null | string;
+                    createdAt?: null | number;
+                    refreshToken?: null | string;
+                    refreshTokenExpiresAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "accessToken"
+                      | "refreshToken"
+                      | "accessTokenExpiresAt"
+                      | "refreshTokenExpiresAt"
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oauthConsent";
+                  update: {
+                    clientId?: null | string;
+                    consentGiven?: null | boolean;
+                    createdAt?: null | number;
+                    scopes?: null | string;
+                    updatedAt?: null | number;
+                    userId?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "clientId"
+                      | "userId"
+                      | "scopes"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "consentGiven"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "jwks";
+                  update: {
+                    createdAt?: number;
+                    expiresAt?: null | number;
+                    privateKey?: string;
+                    publicKey?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "publicKey"
+                      | "privateKey"
+                      | "createdAt"
+                      | "expiresAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "rateLimit";
+                  update: {
+                    count?: number;
+                    key?: string;
+                    lastRequest?: number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "key" | "count" | "lastRequest" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_custom";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "user_table";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    createdAt?: number;
+                    customField?: null | string;
+                    dateField?: null | number;
+                    displayUsername?: null | string;
+                    email?: null | string;
+                    emailVerified?: boolean;
+                    email_address?: null | string;
+                    image?: null | string;
+                    isAnonymous?: null | boolean;
+                    name?: string;
+                    numericField?: null | number;
+                    phoneNumber?: null | string;
+                    phoneNumberVerified?: null | boolean;
+                    testField?: null | string;
+                    twoFactorEnabled?: null | boolean;
+                    updatedAt?: number;
+                    userId?: null | string;
+                    username?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "email"
+                      | "email_address"
+                      | "emailVerified"
+                      | "image"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "twoFactorEnabled"
+                      | "isAnonymous"
+                      | "username"
+                      | "displayUsername"
+                      | "phoneNumber"
+                      | "phoneNumberVerified"
+                      | "userId"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "customField"
+                      | "numericField"
+                      | "dateField"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "oneToOneTable";
+                  update: { oneToOne?: string };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "one_to_one_table";
+                  update: {
+                    oneToOne?: null | string;
+                    one_to_one?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "oneToOne" | "one_to_one" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "testModel";
+                  update: {
+                    cbDefaultValueField?: null | string;
+                    json?: any;
+                    nullableReference?: null | string;
+                    numberArray?: null | Array<number>;
+                    stringArray?: null | Array<string>;
+                    testField?: null | string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "nullableReference"
+                      | "testField"
+                      | "cbDefaultValueField"
+                      | "stringArray"
+                      | "numberArray"
+                      | "json"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "organization";
+                  update: {
+                    createdAt?: number;
+                    logo?: null | string;
+                    metadata?: null | string;
+                    name?: string;
+                    slug?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "slug"
+                      | "logo"
+                      | "metadata"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "member";
+                  update: {
+                    createdAt?: number;
+                    organizationId?: string;
+                    role?: string;
+                    updatedAt?: null | number;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "organizationId"
+                      | "userId"
+                      | "role"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "team";
+                  update: {
+                    createdAt?: number;
+                    name?: string;
+                    organizationId?: string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "name"
+                      | "organizationId"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "teamMember";
+                  update: {
+                    createdAt?: null | number;
+                    teamId?: string;
+                    userId?: string;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field: "teamId" | "userId" | "createdAt" | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                }
+              | {
+                  model: "invitation";
+                  update: {
+                    createdAt?: null | number;
+                    email?: null | string;
+                    expiresAt?: null | number;
+                    inviterId?: null | string;
+                    organizationId?: null | string;
+                    role?: null | string;
+                    status?: null | string;
+                    teamId?: null | string;
+                    updatedAt?: null | number;
+                  };
+                  where?: Array<{
+                    connector?: "AND" | "OR";
+                    field:
+                      | "email"
+                      | "role"
+                      | "status"
+                      | "organizationId"
+                      | "teamId"
+                      | "inviterId"
+                      | "expiresAt"
+                      | "createdAt"
+                      | "updatedAt"
+                      | "_id";
+                    operator?:
+                      | "lt"
+                      | "lte"
+                      | "gt"
+                      | "gte"
+                      | "eq"
+                      | "in"
+                      | "not_in"
+                      | "ne"
+                      | "contains"
+                      | "starts_with"
+                      | "ends_with";
+                    value:
+                      | string
+                      | number
+                      | boolean
+                      | Array<string>
+                      | Array<number>
+                      | null;
+                  }>;
+                };
+            onUpdateHandle?: string;
+          },
+          any
+        >;
+      };
     };
   };
   migrations: {

--- a/packages/backend/convex/auth.ts
+++ b/packages/backend/convex/auth.ts
@@ -8,14 +8,21 @@ import { components } from "./_generated/api";
 import { query } from "./_generated/server";
 import authConfig from "./auth.config";
 
-const siteUrl = process.env.SITE_URL!;
-
 export const authComponent = createClient<DataModel>(components.betterAuth);
 
 function createAuth(ctx: GenericCtx<DataModel>) {
   return betterAuth({
-    baseURL: siteUrl,
-    trustedOrigins: [siteUrl],
+    baseURL: {
+      allowedHosts: [
+        "scrollect.app",
+        "www.scrollect.app",
+        "*-tomaszgl69gmailcoms-projects.vercel.app",
+        "*.convex.site",
+        "localhost:3000",
+      ],
+      protocol: "auto",
+      fallback: process.env.SITE_URL ?? "https://scrollect.app",
+    },
     database: authComponent.adapter(ctx),
     emailAndPassword: {
       enabled: true,

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@ai-sdk/google": "^3.0.53",
     "@ai-sdk/openai": "^3.0.48",
-    "@convex-dev/better-auth": "^0.10.13",
+    "@convex-dev/better-auth": "^0.11.4",
     "@convex-dev/migrations": "^0.3.1",
     "@convex-dev/polar": "^0.9.0",
     "@convex-dev/rate-limiter": "^0.3.2",


### PR DESCRIPTION
## Summary
- Upgrade `better-auth` 1.4.9 → 1.5.6 and `@convex-dev/better-auth` 0.10.13 → 0.11.4; switch the auth config to the new `baseURL.allowedHosts` pattern so Convex previews and prod share one config, dropping the `SITE_URL` env var (and its CI seeding step).
- Remove the `SourceDetailSheet` popover/sheet; the whole card now opens the detail panel and the library link lives inside the panel. Drop loader-based `useSuspenseQuery` blocking on the authenticated layout, settings, and library routes — use skeletons while user data loads.
- Add `.codex/config.toml` to enable the experimental Claude Code agent-teams flag for Codex shells.

## Test plan
- [ ] `bun turbo dev --filter @scrollect/web` → sign in, click a feed card, confirm the detail panel opens and "View in library" routes through.
- [ ] E2E: `bookmarked-cards-section.spec.ts` and `source-provenance.spec.ts` pass locally.
- [ ] Convex preview deploys without `SITE_URL` and sign-in still works on the preview URL.
- [ ] `/app/settings` renders email/name via skeleton → data transition without a full-page pending spinner.