### PR TITLE
feat(#189): extract document metadata during parsing

### DIFF
--- a/.github/workflows/deploy-marker-worker.yml
+++ b/.github/workflows/deploy-marker-worker.yml
@@ -1,0 +1,118 @@
+name: Deploy Marker Worker
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - ".github/workflows/deploy-marker-worker.yml"
+      - "services/marker-api/**"
+  workflow_dispatch:
+
+env:
+  MARKER_IMAGE_NAME: tomaszgoral/scrollect-marker
+
+jobs:
+  deploy:
+    name: Build, push, and update RunPod
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image tags
+        id: image
+        run: |
+          SHA_TAG="${GITHUB_SHA::12}"
+          echo "sha_tag=${SHA_TAG}" >> "$GITHUB_OUTPUT"
+          echo "sha_ref=${MARKER_IMAGE_NAME}:${SHA_TAG}" >> "$GITHUB_OUTPUT"
+          echo "latest_ref=${MARKER_IMAGE_NAME}:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Marker image
+        uses: docker/build-push-action@v6
+        with:
+          context: services/marker-api
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.image.outputs.sha_ref }}
+            ${{ steps.image.outputs.latest_ref }}
+
+      - name: Update RunPod template
+        env:
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+          RUNPOD_MARKER_TEMPLATE_ID: ${{ secrets.RUNPOD_MARKER_TEMPLATE_ID }}
+          MARKER_IMAGE_REF: ${{ steps.image.outputs.sha_ref }}
+        run: |
+          node <<'EOF'
+          const apiKey = process.env.RUNPOD_API_KEY;
+          const templateId = process.env.RUNPOD_MARKER_TEMPLATE_ID;
+          const imageName = process.env.MARKER_IMAGE_REF;
+
+          if (!apiKey || !templateId) {
+            throw new Error("RUNPOD_API_KEY and RUNPOD_MARKER_TEMPLATE_ID secrets are required");
+          }
+
+          async function request(path, options = {}) {
+            const response = await fetch(`https://rest.runpod.io/v1${path}`, {
+              ...options,
+              headers: {
+                authorization: `Bearer ${apiKey}`,
+                ...(options.body ? { "content-type": "application/json" } : {}),
+                ...options.headers,
+              },
+            });
+            const payload = await response.json();
+            if (!response.ok) {
+              throw new Error(JSON.stringify(payload));
+            }
+            return payload;
+          }
+
+          const template = await request(
+            `/templates/${templateId}?includeEndpointBoundTemplates=true`,
+          );
+
+          const update = {
+            containerDiskInGb: template.containerDiskInGb,
+            containerRegistryAuthId: template.containerRegistryAuthId,
+            dockerEntrypoint: template.dockerEntrypoint ?? [],
+            dockerStartCmd: template.dockerStartCmd ?? [],
+            env: template.env ?? {},
+            imageName,
+            isPublic: template.isPublic ?? false,
+            name: template.name,
+            ports: template.ports ?? [],
+            readme: template.readme ?? "",
+            volumeInGb: template.volumeInGb ?? 0,
+            volumeMountPath: template.volumeMountPath ?? "/workspace",
+          };
+
+          for (const [key, value] of Object.entries(update)) {
+            if (value === undefined || value === null) {
+              delete update[key];
+            }
+          }
+
+          const updatedTemplate = await request(`/templates/${templateId}`, {
+            method: "PATCH",
+            body: JSON.stringify(update),
+          });
+
+          console.log(`Updated RunPod template ${updatedTemplate.id}`);
+          console.log(`Template image: ${updatedTemplate.imageName}`);
+          console.log("RunPod will roll associated endpoints for this template.");
+          EOF

--- a/packages/backend/convex/documents.ts
+++ b/packages/backend/convex/documents.ts
@@ -342,6 +342,28 @@ export const updateTitle = internalMutation({
   },
 });
 
+export const updateMetadata = internalMutation({
+  args: {
+    id: v.id("documents"),
+    title: v.optional(v.string()),
+    thumbnailUrl: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const update: { title?: string; thumbnailUrl?: string } = {};
+    if (args.title !== undefined) {
+      update.title = args.title;
+    }
+    if (args.thumbnailUrl !== undefined) {
+      update.thumbnailUrl = args.thumbnailUrl;
+    }
+    if (Object.keys(update).length > 0) {
+      await ctx.db.patch(args.id, update);
+    }
+    return null;
+  },
+});
+
 export const list = query({
   args: { paginationOpts: paginationOptsValidator },
   handler: async (ctx, args) => {

--- a/packages/backend/convex/pipeline/chunking.ts
+++ b/packages/backend/convex/pipeline/chunking.ts
@@ -4,21 +4,24 @@ import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
+import type { ActionCtx } from "../_generated/server";
 import { internalAction } from "../_generated/server";
 import { chunkMarkdown } from "../../src/pipeline/chunking";
 import { WideEvent } from "../lib/logging";
-import { captureEvent } from "../../src/providers/analytics";
+import { captureAiUsage, captureEvent } from "../../src/providers/analytics";
 
 import { fanOutEmbedding } from "./embedding";
 import { CHUNK_STORE_BATCH_SIZE, fetchMarkdownBlob } from "./helpers";
 import { detectLanguage } from "../../src/pipeline/languageDetection";
+import { createDocumentMetadataServiceContext } from "./services";
 
 export const chunkAndStore = internalAction({
   args: {
     documentId: v.id("documents"),
     markdownStorageId: v.id("_storage"),
+    inferTitle: v.optional(v.boolean()),
   },
-  handler: async (ctx, { documentId, markdownStorageId }) => {
+  handler: async (ctx, { documentId, markdownStorageId, inferTitle }) => {
     const evt = new WideEvent("pipeline.chunkAndStore");
     evt.set({ documentId, markdownStorageId });
     const startMs = Date.now();
@@ -65,6 +68,19 @@ export const chunkAndStore = internalAction({
       const language = await detectLanguage(markdown);
       evt.set("detectedLanguage", language);
 
+      if (inferTitle && chunks[0]) {
+        await inferDocumentTitleFromFirstChunk({
+          ctx,
+          documentId,
+          currentTitle: doc.title,
+          firstChunk: chunks[0].content,
+          fileType: doc.fileType,
+          language,
+          userId: doc.userId,
+          evt,
+        });
+      }
+
       await ctx.runMutation(internal.documents.updateStatus, {
         id: documentId,
         status: "embedding",
@@ -109,3 +125,48 @@ export const chunkAndStore = internalAction({
     }
   },
 });
+
+async function inferDocumentTitleFromFirstChunk(opts: {
+  ctx: ActionCtx;
+  documentId: Id<"documents">;
+  currentTitle: string;
+  firstChunk: string;
+  fileType: string;
+  language?: string;
+  userId: string;
+  evt: WideEvent;
+}) {
+  try {
+    const services = createDocumentMetadataServiceContext();
+    const result = await services.llm.inferTitle({
+      firstChunk: opts.firstChunk,
+      currentTitle: opts.currentTitle,
+      fileType: opts.fileType,
+      language: opts.language,
+    });
+
+    if (result.title && result.title !== opts.currentTitle) {
+      await opts.ctx.runMutation(internal.documents.updateMetadata, {
+        id: opts.documentId,
+        title: result.title,
+      });
+      opts.evt.set("inferredTitle", true);
+    } else {
+      opts.evt.set("inferredTitle", false);
+    }
+
+    if (result.usage.modelId) {
+      await captureAiUsage({
+        distinctId: opts.userId,
+        operation: "document_title_inference",
+        usage: result.usage,
+        model: result.usage.modelId,
+        documentId: opts.documentId,
+      });
+    }
+  } catch (error) {
+    opts.evt.set({
+      titleInferenceError: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/packages/backend/convex/pipeline/markerWebhookProcessor.ts
+++ b/packages/backend/convex/pipeline/markerWebhookProcessor.ts
@@ -9,6 +9,10 @@ import { internalAction } from "../_generated/server";
 import { WideEvent } from "../lib/logging";
 import { captureEvent } from "../../src/providers/analytics";
 import { storeMarkdownBlob, createMarkerClient } from "./helpers";
+import {
+  cleanDocumentTitle,
+  shouldInferDocumentTitle,
+} from "../../src/pipeline/logic/documentMetadata";
 
 interface RunPodWebhookPayload {
   id: string;
@@ -19,6 +23,12 @@ interface RunPodWebhookPayload {
   output?: {
     markdown?: string;
     document_id?: string;
+    title?: string;
+    author?: string;
+    image_base64?: string;
+    image_mime_type?: string;
+    cover_base64?: string;
+    cover_mime_type?: string;
   };
   error?: string;
 }
@@ -92,10 +102,15 @@ async function handleCompleted(ctx: ActionCtx, body: RunPodWebhookPayload, evt: 
   const parsingDurationMs = doc.runpodSubmittedAt ? Date.now() - doc.runpodSubmittedAt : undefined;
   evt.set({ parsingDurationMs, markdownLength: markdown.length });
 
+  const metadata = await applyParsedMetadata({ ctx, docId, output: body.output, evt });
   const markdownStorageId = await storeMarkdownBlob(ctx, markdown);
   await ctx.scheduler.runAfter(0, internal.pipeline.chunking.chunkAndStore, {
     documentId: docId,
     markdownStorageId,
+    inferTitle: shouldInferDocumentTitle({
+      fileType: doc.fileType,
+      hasParsedTitle: metadata.hasTitle,
+    }),
   });
 
   try {
@@ -117,6 +132,59 @@ async function handleCompleted(ctx: ActionCtx, body: RunPodWebhookPayload, evt: 
   await captureRunPodCost({ jobId: body.id, documentId, userId: doc.userId, evt });
 
   evt.set("result", "complete");
+}
+
+async function applyParsedMetadata(opts: {
+  ctx: ActionCtx;
+  docId: Id<"documents">;
+  output: RunPodWebhookPayload["output"];
+  evt: WideEvent;
+}): Promise<{ hasTitle: boolean; hasThumbnail: boolean }> {
+  const title = cleanDocumentTitle(opts.output?.title);
+  const thumbnailUrl = await storeParsedImage({
+    ctx: opts.ctx,
+    output: opts.output,
+    evt: opts.evt,
+  });
+
+  if (title || thumbnailUrl) {
+    await opts.ctx.runMutation(internal.documents.updateMetadata, {
+      id: opts.docId,
+      ...(title ? { title } : {}),
+      ...(thumbnailUrl ? { thumbnailUrl } : {}),
+    });
+  }
+
+  opts.evt.set({
+    parsedTitle: !!title,
+    parsedAuthor: !!opts.output?.author,
+    parsedThumbnail: !!thumbnailUrl,
+  });
+
+  return { hasTitle: !!title, hasThumbnail: !!thumbnailUrl };
+}
+
+async function storeParsedImage(opts: {
+  ctx: ActionCtx;
+  output: RunPodWebhookPayload["output"];
+  evt: WideEvent;
+}): Promise<string | undefined> {
+  const imageBase64 = opts.output?.image_base64 ?? opts.output?.cover_base64;
+  if (!imageBase64) return undefined;
+
+  try {
+    const mimeType = opts.output?.image_mime_type ?? opts.output?.cover_mime_type ?? "image/jpeg";
+    const imageBytes = Buffer.from(imageBase64, "base64");
+    if (imageBytes.length === 0) return undefined;
+
+    const storageId = await opts.ctx.storage.store(new Blob([imageBytes], { type: mimeType }));
+    return (await opts.ctx.storage.getUrl(storageId)) ?? undefined;
+  } catch (error) {
+    opts.evt.set({
+      parsedImageStorageError: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
 }
 
 const RUNPOD_COST_PER_SEC = 0.00016; // RTX A4500

--- a/packages/backend/convex/pipeline/parsing.ts
+++ b/packages/backend/convex/pipeline/parsing.ts
@@ -8,6 +8,7 @@ import type { ActionCtx } from "../_generated/server";
 import { internalAction } from "../_generated/server";
 import { WideEvent } from "../lib/logging";
 import { captureEvent } from "../../src/providers/analytics";
+import { shouldInferDocumentTitle } from "../../src/pipeline/logic/documentMetadata";
 
 import { storeMarkdownBlob } from "./helpers";
 import type { MarkerClient } from "../../src/providers/marker";
@@ -54,6 +55,7 @@ export async function submitMarkerParsing({
       await ctx.scheduler.runAfter(0, internal.pipeline.chunking.chunkAndStore, {
         documentId,
         markdownStorageId,
+        inferTitle: shouldInferDocumentTitle({ fileType, hasParsedTitle: false }),
       });
       return;
     }
@@ -164,6 +166,7 @@ export async function fetchAndParseMarkdownImpl({
     await ctx.scheduler.runAfter(0, internal.pipeline.chunking.chunkAndStore, {
       documentId,
       markdownStorageId,
+      inferTitle: false,
     });
 
     await captureEvent({

--- a/packages/backend/convex/pipeline/services.ts
+++ b/packages/backend/convex/pipeline/services.ts
@@ -2,6 +2,7 @@
 
 import type {
   ConnectionDiscoveryServiceContext,
+  DocumentMetadataServiceContext,
   DraftGenerationServiceContext,
   EmbeddingServiceContext,
   ExtractionServiceContext,
@@ -14,12 +15,14 @@ import type {
 import { AiSdkCardDraftLlm } from "../../src/providers/cardDraftLlm";
 import { AiSdkCardDraftValidator } from "../../src/providers/cardDraftValidator";
 import { AiSdkConnectionDiscoveryLlm } from "../../src/providers/connectionDiscoveryLlm";
+import { AiSdkDocumentMetadataLlm } from "../../src/providers/documentMetadataLlm";
 import { AiSdkHighlightDraftLlm } from "../../src/providers/highlightDraftLlm";
 import { AiSdkSummarizingLlm } from "../../src/providers/summarizingLlm";
 import {
   StubCardDraftLlm,
   StubCardDraftValidator,
   StubConnectionDiscoveryLlm,
+  StubDocumentMetadataLlm,
   StubHighlightDraftLlm,
   StubThematicLlm,
 } from "../../src/providers/stubs";
@@ -60,6 +63,13 @@ export function createTaggingServiceContext(): TaggingServiceContext {
   return {
     llm: new AiSdkTaggingLlm(),
   };
+}
+
+export function createDocumentMetadataServiceContext(): DocumentMetadataServiceContext {
+  if (process.env.USE_STUB_EXTRACTORS === "true") {
+    return { llm: new StubDocumentMetadataLlm() };
+  }
+  return { llm: new AiSdkDocumentMetadataLlm() };
 }
 
 export function createVectorDeletionServices(): VectorDeletionServices {

--- a/packages/backend/src/pipeline/logic/documentMetadata.ts
+++ b/packages/backend/src/pipeline/logic/documentMetadata.ts
@@ -1,0 +1,32 @@
+const MAX_TITLE_LENGTH = 160;
+const TITLE_FALLBACK_FILE_TYPES = new Set(["pdf", "epub"]);
+
+const GENERIC_TITLES = new Set([
+  "untitled",
+  "untitled document",
+  "document",
+  "document title",
+  "unknown",
+  "unknown title",
+]);
+
+export function shouldInferDocumentTitle(opts: { fileType: string; hasParsedTitle: boolean }) {
+  return TITLE_FALLBACK_FILE_TYPES.has(opts.fileType) && !opts.hasParsedTitle;
+}
+
+export function cleanDocumentTitle(title: string | null | undefined): string | undefined {
+  const normalized = title?.replace(/\s+/g, " ").trim();
+  if (!normalized) return undefined;
+
+  const withoutWrappingQuotes = normalized.replace(/^["']|["']$/g, "").trim();
+  if (!withoutWrappingQuotes) return undefined;
+
+  const lower = withoutWrappingQuotes.toLowerCase();
+  if (GENERIC_TITLES.has(lower)) return undefined;
+
+  return withoutWrappingQuotes.slice(0, MAX_TITLE_LENGTH);
+}
+
+export function firstChunkTitleContext(content: string): string {
+  return content.trim().slice(0, 6_000);
+}

--- a/packages/backend/src/providers/documentMetadataLlm.ts
+++ b/packages/backend/src/providers/documentMetadataLlm.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+import type { DocumentMetadataLlm } from "./types";
+import { type TokenUsage, generate } from "./ai";
+import { buildLanguageInstruction } from "./promptUtils";
+import { cleanDocumentTitle, firstChunkTitleContext } from "../pipeline/logic/documentMetadata";
+
+const titleSchema = z.object({
+  title: z.string().nullable(),
+});
+
+function buildTitlePrompt(language?: string): string {
+  return `You identify document titles for a personal learning app.
+The user uploaded a PDF or EPUB. The parser could not provide a reliable metadata title, so infer the document title from the first content chunk.
+
+Rules:
+- Return the exact title if it is visible in the chunk
+- Prefer the book, paper, article, or report title over chapter or section titles
+- Do not invent a title
+- Return null when the chunk does not contain a clear document title
+- Do not return generic labels like "Document", "Untitled", "Introduction", or "Chapter 1"
+- ${buildLanguageInstruction(language)}
+
+Return a JSON object: { "title": "..." } or { "title": null }`;
+}
+
+export class AiSdkDocumentMetadataLlm implements DocumentMetadataLlm {
+  async inferTitle(opts: {
+    firstChunk: string;
+    currentTitle: string;
+    fileType: string;
+    language?: string;
+  }): Promise<{ title?: string; usage: TokenUsage }> {
+    const { output, usage } = await generate({
+      model: "fast",
+      schema: titleSchema,
+      system: buildTitlePrompt(opts.language),
+      prompt: `File type: ${opts.fileType}
+Current title, usually from the filename: ${opts.currentTitle}
+
+First chunk:
+${firstChunkTitleContext(opts.firstChunk)}`,
+      temperature: 0,
+    });
+
+    return {
+      title: cleanDocumentTitle(output?.title),
+      usage,
+    };
+  }
+}

--- a/packages/backend/src/providers/stubs.ts
+++ b/packages/backend/src/providers/stubs.ts
@@ -4,6 +4,7 @@ import type {
   CardDraftValidator,
   ConnectionDiscoveryLlm,
   ContentExtractor,
+  DocumentMetadataLlm,
   DraftCardType,
   ExtractResult,
   HighlightDraftLlm,
@@ -130,6 +131,21 @@ export class StubYouTubeExtractor implements ContentExtractor {
         provider: "stub",
         thumbnailUrl: "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg",
       },
+    };
+  }
+}
+
+export class StubDocumentMetadataLlm implements DocumentMetadataLlm {
+  async inferTitle(opts: {
+    firstChunk: string;
+    currentTitle: string;
+    fileType: string;
+    language?: string;
+  }): Promise<{ title?: string; usage: TokenUsage }> {
+    const heading = opts.firstChunk.match(/^#\s+(.+)$/m)?.[1]?.trim();
+    return {
+      title: heading || "Stub Document Title",
+      usage: ZERO_USAGE,
     };
   }
 }

--- a/packages/backend/src/providers/types.ts
+++ b/packages/backend/src/providers/types.ts
@@ -167,6 +167,15 @@ export interface TaggingLlm {
   suggestTags(opts: { prompt: string }): Promise<{ tags: string[]; usage: TokenUsage }>;
 }
 
+export interface DocumentMetadataLlm {
+  inferTitle(opts: {
+    firstChunk: string;
+    currentTitle: string;
+    fileType: string;
+    language?: string;
+  }): Promise<{ title?: string; usage: TokenUsage }>;
+}
+
 /** Card types eligible for draft generation (excludes "connection"). Standalone mirror of the Convex validator type. */
 export type DraftCardType = "insight" | "quiz" | "quote" | "summary";
 
@@ -277,6 +286,10 @@ export type ExtractionServiceContext = {
 
 export type TaggingServiceContext = {
   llm: TaggingLlm;
+};
+
+export type DocumentMetadataServiceContext = {
+  llm: DocumentMetadataLlm;
 };
 
 export type DraftGenerationServiceContext = {

--- a/packages/backend/tests/pipeline/logic/documentMetadata.test.ts
+++ b/packages/backend/tests/pipeline/logic/documentMetadata.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cleanDocumentTitle,
+  firstChunkTitleContext,
+  shouldInferDocumentTitle,
+} from "../../../src/pipeline/logic/documentMetadata";
+
+describe("document metadata logic", () => {
+  it("infers titles only for parser-backed document types without parsed titles", () => {
+    expect(shouldInferDocumentTitle({ fileType: "pdf", hasParsedTitle: false })).toBe(true);
+    expect(shouldInferDocumentTitle({ fileType: "epub", hasParsedTitle: false })).toBe(true);
+    expect(shouldInferDocumentTitle({ fileType: "pdf", hasParsedTitle: true })).toBe(false);
+    expect(shouldInferDocumentTitle({ fileType: "text", hasParsedTitle: false })).toBe(false);
+  });
+
+  it("normalizes useful titles and rejects generic titles", () => {
+    expect(cleanDocumentTitle("  The Art of Effective Learning  ")).toBe(
+      "The Art of Effective Learning",
+    );
+    expect(cleanDocumentTitle('"Deep Work"')).toBe("Deep Work");
+    expect(cleanDocumentTitle("Untitled Document")).toBeUndefined();
+    expect(cleanDocumentTitle("Document")).toBeUndefined();
+    expect(cleanDocumentTitle("")).toBeUndefined();
+  });
+
+  it("caps the first chunk context sent to title inference", () => {
+    const content = `  ${"a".repeat(7_000)}  `;
+    expect(firstChunkTitleContext(content)).toHaveLength(6_000);
+  });
+});

--- a/services/marker-api/Dockerfile
+++ b/services/marker-api/Dockerfile
@@ -1,11 +1,16 @@
 FROM nvidia/cuda:12.8.1-runtime-ubuntu24.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 python3-pip python3-venv && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir --break-system-packages \
+    "ebooklib" \
     "marker-pdf[full]" \
+    "pypdf" \
+    "pypdfium2" \
     "runpod" \
     "torch" \
     "torchvision" \

--- a/services/marker-api/README.md
+++ b/services/marker-api/README.md
@@ -28,9 +28,19 @@ Format is auto-routed based on `file_type` in the job input.
 ### Build and push
 
 ```bash
-docker build -t tomaszgoral/scrollect-marker:latest .
+docker build --platform linux/amd64 -t tomaszgoral/scrollect-marker:latest .
 docker push tomaszgoral/scrollect-marker:latest
 ```
+
+The `Deploy Marker Worker` GitHub Action builds the same image for `linux/amd64`, pushes both
+`:latest` and a commit SHA tag, then updates the RunPod Serverless template. RunPod rolls the
+endpoints that use the template after the image is changed. Configure these repository secrets
+before relying on the workflow:
+
+- `DOCKERHUB_USERNAME`
+- `DOCKERHUB_TOKEN`
+- `RUNPOD_API_KEY`
+- `RUNPOD_MARKER_TEMPLATE_ID`
 
 ### Create RunPod endpoint
 
@@ -74,7 +84,11 @@ Success:
 ```json
 {
   "markdown": "# Chapter 1\n\nContent...",
-  "document_id": "abc123"
+  "document_id": "abc123",
+  "title": "Optional parsed document title",
+  "author": "Optional parsed EPUB author",
+  "image_base64": "Optional base64-encoded JPEG/PNG cover or preview",
+  "image_mime_type": "image/jpeg"
 }
 ```
 

--- a/services/marker-api/handler.py
+++ b/services/marker-api/handler.py
@@ -1,5 +1,8 @@
 import os
+import base64
+import mimetypes
 import urllib.request
+from io import BytesIO
 
 import runpod
 from marker.converters.pdf import PdfConverter
@@ -22,6 +25,118 @@ converters = {
 }
 
 DOWNLOAD_TIMEOUT_SECONDS = 120
+IMAGE_MAX_SIZE = (720, 960)
+
+
+def clean_text(value):
+    if not value:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def image_payload(content, mime_type):
+    if not content:
+        return {}
+    return {
+        "image_base64": base64.b64encode(content).decode("ascii"),
+        "image_mime_type": mime_type or "image/jpeg",
+    }
+
+
+def extract_epub_metadata(filepath):
+    try:
+        import ebooklib
+        from ebooklib import epub
+
+        book = epub.read_epub(filepath)
+        metadata = {}
+
+        titles = book.get_metadata("DC", "title")
+        creators = book.get_metadata("DC", "creator")
+        title = clean_text(titles[0][0]) if titles else None
+        author = clean_text(creators[0][0]) if creators else None
+
+        if title:
+            metadata["title"] = title
+        if author:
+            metadata["author"] = author
+
+        cover_item = None
+        for _, attrs in book.get_metadata("OPF", "cover"):
+            cover_id = attrs.get("content")
+            if cover_id:
+                cover_item = book.get_item_with_id(cover_id)
+                break
+
+        if cover_item is None:
+            for item in book.get_items():
+                item_name = item.get_name().lower()
+                item_id = item.get_id().lower()
+                if item.get_type() == ebooklib.ITEM_IMAGE and (
+                    "cover" in item_name or "cover" in item_id
+                ):
+                    cover_item = item
+                    break
+
+        if cover_item is not None:
+            mime_type = (
+                getattr(cover_item, "media_type", None)
+                or mimetypes.guess_type(cover_item.get_name())[0]
+                or "image/jpeg"
+            )
+            metadata.update(image_payload(cover_item.get_content(), mime_type))
+
+        return metadata
+    except Exception:
+        return {}
+
+
+def extract_pdf_title(filepath):
+    try:
+        from pypdf import PdfReader
+
+        reader = PdfReader(filepath)
+        return clean_text(reader.metadata.title if reader.metadata else None)
+    except Exception:
+        return None
+
+
+def extract_pdf_image(filepath):
+    try:
+        import pypdfium2 as pdfium
+
+        pdf = pdfium.PdfDocument(filepath)
+        if len(pdf) == 0:
+            return {}
+
+        page = pdf[0]
+        bitmap = page.render(scale=1.8)
+        image = bitmap.to_pil().convert("RGB")
+        image.thumbnail(IMAGE_MAX_SIZE)
+
+        buffer = BytesIO()
+        image.save(buffer, format="JPEG", quality=82, optimize=True)
+        return image_payload(buffer.getvalue(), "image/jpeg")
+    except Exception:
+        return {}
+
+
+def extract_pdf_metadata(filepath):
+    metadata = {}
+    title = extract_pdf_title(filepath)
+    if title:
+        metadata["title"] = title
+    metadata.update(extract_pdf_image(filepath))
+    return metadata
+
+
+def extract_document_metadata(filepath, file_type):
+    if file_type == "epub":
+        return extract_epub_metadata(filepath)
+    if file_type == "pdf":
+        return extract_pdf_metadata(filepath)
+    return {}
 
 
 def handler(event):
@@ -35,6 +150,8 @@ def handler(event):
 
         urllib.request.urlretrieve(file_url, filepath)
 
+        metadata = extract_document_metadata(filepath, file_type)
+
         converter = converters.get(file_type, pdf_converter)
         rendered = converter(filepath)
         markdown, _, _ = text_from_rendered(rendered)
@@ -45,7 +162,7 @@ def handler(event):
         if not markdown or not markdown.strip():
             return {"document_id": document_id, "error": "Marker produced no markdown output"}
 
-        return {"markdown": markdown, "document_id": document_id}
+        return {"markdown": markdown, "document_id": document_id, **metadata}
     except Exception as e:
         # Always include document_id so the webhook can route failures
         return {"document_id": document_id, "error": str(e)}


### PR DESCRIPTION
## Summary

Adds document metadata extraction to PDF/EPUB parsing so uploaded documents can get a better title and visual thumbnail during ingestion. PDF titles come from file metadata when available, EPUB titles/covers come from EPUB metadata, and parser-missing PDF/EPUB titles fall back to AI inference from the first chunk.

Closes #189

## Changes

- Extract PDF metadata titles and first-page preview images in the Marker worker.
- Extract EPUB title, author, and cover image metadata in the Marker worker.
- Persist parsed titles/thumbnails in Convex before chunking, and run AI title inference from the first chunk when parsed metadata has no usable title.
- Add a GitHub Actions workflow that builds/pushes the Marker Docker image and updates the RunPod template with the commit-SHA image tag.
- Document the Marker worker metadata payload and required Docker/RunPod deployment secrets.

## Testing

- [x] `python3 -m py_compile services/marker-api/handler.py`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-marker-worker.yml"); puts "workflow yaml ok"'`
- [x] `bun run oxlint` (passes with two pre-existing warnings in `packages/backend/tests/pipeline/logic/cardDraftGeneration.test.ts`)
- [x] `bun run oxfmt --check`
- [x] `bun run test tests/pipeline/logic/documentMetadata.test.ts` from `packages/backend`
- [x] `bun turbo run test`
- [x] `bun turbo run build`
- [x] `npx convex dev --once` from `packages/backend`
- [ ] Preview-backed E2E tests are left to CI, where the PR Convex/Vercel preview URLs are available.
