### PR TITLE
refactor(backend): unify document deletion cascade

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as chunks from "../chunks.js";
 import type * as connectionPairs from "../connectionPairs.js";
 import type * as documentActions from "../documentActions.js";
 import type * as documents from "../documents.js";
+import type * as documents_deletion from "../documents/deletion.js";
 import type * as entitlementGrants from "../entitlementGrants.js";
 import type * as entitlements from "../entitlements.js";
 import type * as feed_learningGoal from "../feed/learningGoal.js";
@@ -83,6 +84,7 @@ declare const fullApi: ApiFromModules<{
   connectionPairs: typeof connectionPairs;
   documentActions: typeof documentActions;
   documents: typeof documents;
+  "documents/deletion": typeof documents_deletion;
   entitlementGrants: typeof entitlementGrants;
   entitlements: typeof entitlements;
   "feed/learningGoal": typeof feed_learningGoal;

--- a/packages/backend/convex/accountActions.ts
+++ b/packages/backend/convex/accountActions.ts
@@ -3,11 +3,70 @@
 import { v } from "convex/values";
 
 import { components, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import type { ActionCtx } from "./_generated/server";
 import { action } from "./_generated/server";
 import { requireAuth } from "./lib/functions";
 import { WideEvent } from "./lib/logging";
-import { deleteDocumentVectors } from "../src/logic/documentDeletion";
-import { createVectorDeletionServices } from "./pipeline/services";
+import type { VectorDeletionServices } from "../src/providers/types";
+import { executeDocumentDeletionCascade, markDocumentDeletionFailed } from "./documents/deletion";
+
+type AccountDocumentDeletionCtx = Pick<ActionCtx, "runQuery" | "runMutation">;
+
+type DeletionEventRecorder = {
+  set(keyOrObj: string | Record<string, unknown>, value?: unknown): unknown;
+};
+
+export async function deleteAccountDocuments({
+  ctx,
+  userId,
+  documentIds,
+  evt,
+  services,
+}: {
+  ctx: AccountDocumentDeletionCtx;
+  userId: string;
+  documentIds: Id<"documents">[];
+  evt: DeletionEventRecorder;
+  services?: VectorDeletionServices;
+}): Promise<{ deletedDocumentCount: number; failedDocuments: Id<"documents">[] }> {
+  const failedDocuments: Id<"documents">[] = [];
+  let deletedDocumentCount = 0;
+
+  for (const documentId of documentIds) {
+    try {
+      const data = await ctx.runQuery(internal.documents.getDocumentDeletionData, {
+        documentId,
+      });
+      if (!data) continue;
+      if (data.document.userId !== userId) continue;
+
+      await executeDocumentDeletionCascade({
+        ctx,
+        documentId,
+        userId,
+        data,
+        services,
+      });
+      deletedDocumentCount++;
+    } catch (error) {
+      failedDocuments.push(documentId);
+      evt.set("documentError", {
+        documentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      const recovery = await markDocumentDeletionFailed({ ctx, documentId, error });
+      if (recovery.recoveryError) {
+        evt.set("documentRecoveryError", {
+          documentId,
+          error: recovery.recoveryError,
+        });
+      }
+    }
+  }
+
+  return { deletedDocumentCount, failedDocuments };
+}
 
 export const deleteAccount = action({
   args: {},
@@ -24,49 +83,17 @@ export const deleteAccount = action({
       });
       evt.set("documentCount", documentIds.length);
 
-      const services = createVectorDeletionServices();
-      const failedDocuments: string[] = [];
-
-      for (const documentId of documentIds) {
-        try {
-          const data = await ctx.runQuery(internal.documents.getDocumentDeletionData, {
-            documentId,
-          });
-          if (!data) continue;
-          if (data.document.userId !== user._id) continue;
-
-          await deleteDocumentVectors({
-            input: {
-              chunkEmbeddingIds: data.chunkEmbeddingIds,
-              sectionSummaryEmbeddingIds: data.sectionSummaryEmbeddingIds,
-              documentSummaryEmbeddingId: data.document.summaryEmbeddingId,
-            },
-            services,
-          });
-
-          await ctx.runMutation(internal.documents.cascadeDeletePosts, {
-            documentId,
-            userId: user._id,
-          });
-          await ctx.runMutation(internal.documents.cascadeDeleteChunksAndSummaries, {
-            documentId,
-            userId: user._id,
-          });
-          await ctx.runMutation(internal.documents.cascadeDeleteDocument, {
-            documentId,
-          });
-        } catch (error) {
-          failedDocuments.push(documentId);
-          evt.set("documentError", {
-            documentId,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
+      const { deletedDocumentCount, failedDocuments } = await deleteAccountDocuments({
+        ctx,
+        userId: user._id,
+        documentIds,
+        evt,
+      });
 
       if (failedDocuments.length > 0) {
         evt.set("failedDocuments", failedDocuments);
       }
+      evt.set("deletedDocumentCount", deletedDocumentCount);
 
       const remainingResult = await ctx.runMutation(internal.account.deleteRemainingUserData, {
         userId: user._id,

--- a/packages/backend/convex/documentActions.ts
+++ b/packages/backend/convex/documentActions.ts
@@ -8,117 +8,20 @@ import type { ActionCtx } from "./_generated/server";
 import { action, internalAction } from "./_generated/server";
 import { requireAuth } from "./lib/functions";
 import { WideEvent } from "./lib/logging";
-import { deleteDocumentVectors } from "../src/logic/documentDeletion";
 import { createEmbeddingProvider } from "./pipeline/helpers";
-import { createVectorDeletionServices } from "./pipeline/services";
+import { executeDocumentDeletionCascade, markDocumentDeletionFailed } from "./documents/deletion";
 
-type DeletionData = {
-  document: {
-    _id: Id<"documents">;
-    userId: string;
-    storageId?: Id<"_storage">;
-    summaryEmbeddingId?: string;
-  };
-  chunkEmbeddingIds: string[];
-  sectionSummaryEmbeddingIds: string[];
-};
-
-async function executeDeletionCascade(
+async function captureDeletionFailure(
   ctx: ActionCtx,
-  {
-    documentId,
-    userId,
-    data,
-    evt,
-  }: {
-    documentId: Id<"documents">;
-    userId: string;
-    data: DeletionData;
-    evt: WideEvent;
-  },
+  opts: { documentId: Id<"documents">; error: unknown; evt: WideEvent },
 ) {
-  await ctx.runMutation(internal.documents.updateStatus, {
-    id: documentId,
-    status: "deleting",
+  const recovery = await markDocumentDeletionFailed({
+    ctx,
+    documentId: opts.documentId,
+    error: opts.error,
   });
-
-  const services = createVectorDeletionServices();
-  const deletionResult = await deleteDocumentVectors({
-    input: {
-      chunkEmbeddingIds: data.chunkEmbeddingIds,
-      sectionSummaryEmbeddingIds: data.sectionSummaryEmbeddingIds,
-      documentSummaryEmbeddingId: data.document.summaryEmbeddingId,
-    },
-    services,
-  });
-
-  evt.set({
-    chunkVectorCount: deletionResult.deletedChunkVectorCount,
-    summaryVectorCount: deletionResult.deletedSummaryVectorCount,
-  });
-
-  const [highlightResult, postResult, connectionPairResult] = await Promise.all([
-    ctx.runMutation(internal.highlights.cascadeDeleteHighlights, {
-      documentId,
-      userId,
-    }),
-    ctx.runMutation(internal.documents.cascadeDeletePosts, {
-      documentId,
-      userId,
-    }),
-    ctx.runMutation(internal.connectionPairs.cascadeDeleteByDocumentId, {
-      documentId,
-    }),
-  ]);
-
-  const chunkResult = await ctx.runMutation(internal.documents.cascadeDeleteChunksAndSummaries, {
-    documentId,
-    userId,
-  });
-
-  const docResult = await ctx.runMutation(internal.documents.cascadeDeleteDocument, {
-    documentId,
-  });
-
-  evt.set({
-    deleted: {
-      highlights: highlightResult.deletedHighlights,
-      posts: postResult.deletedPosts,
-      bookmarks: postResult.deletedBookmarks,
-      connectionPairs: connectionPairResult.deletedConnectionPairs,
-      chunks: chunkResult.deletedChunks,
-      sectionSummaries: chunkResult.deletedSectionSummaries,
-      processingJobs: chunkResult.deletedProcessingJobs,
-      cardDrafts: chunkResult.deletedCardDrafts,
-      reactionFeedback: chunkResult.deletedReactionFeedback,
-      orphanedTags: docResult.deletedOrphanedTags,
-    },
-  });
-}
-
-async function setDeletionErrorStatus(
-  ctx: ActionCtx,
-  {
-    documentId,
-    error,
-    evt,
-  }: {
-    documentId: Id<"documents">;
-    error: unknown;
-    evt: WideEvent;
-  },
-) {
-  try {
-    await ctx.runMutation(internal.documents.updateStatus, {
-      id: documentId,
-      status: "error",
-      failedAt: "deleting",
-      errorMessage: error instanceof Error ? error.message : "Unknown error",
-    });
-  } catch (recoveryError) {
-    // Recovery may fail if cascadeDeleteDocument already deleted the document row.
-    // This is expected — the document is gone, so there's nothing to mark as errored.
-    evt.set("recoveryError", String(recoveryError));
+  if (recovery.recoveryError) {
+    opts.evt.set("recoveryError", recovery.recoveryError);
   }
 }
 
@@ -141,15 +44,16 @@ export const deleteDocument = action({
         throw new Error("Document not found");
       }
 
-      await executeDeletionCascade(ctx, {
+      const deletionResult = await executeDocumentDeletionCascade({
+        ctx,
         documentId: args.documentId,
         userId: user._id,
         data,
-        evt,
       });
+      evt.set(deletionResult);
     } catch (error) {
       evt.setError(error);
-      await setDeletionErrorStatus(ctx, { documentId: args.documentId, error, evt });
+      await captureDeletionFailure(ctx, { documentId: args.documentId, error, evt });
       throw error;
     } finally {
       evt.emit();
@@ -226,15 +130,16 @@ export const retryDeleteDocument = internalAction({
         throw new Error("Document not found");
       }
 
-      await executeDeletionCascade(ctx, {
+      const deletionResult = await executeDocumentDeletionCascade({
+        ctx,
         documentId: args.documentId,
         userId: data.document.userId,
         data,
-        evt,
       });
+      evt.set(deletionResult);
     } catch (error) {
       evt.setError(error);
-      await setDeletionErrorStatus(ctx, { documentId: args.documentId, error, evt });
+      await captureDeletionFailure(ctx, { documentId: args.documentId, error, evt });
       throw error;
     } finally {
       evt.emit();

--- a/packages/backend/convex/documents/deletion.ts
+++ b/packages/backend/convex/documents/deletion.ts
@@ -1,0 +1,129 @@
+"use node";
+
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { ActionCtx } from "../_generated/server";
+import { deleteDocumentVectors } from "../../src/logic/documentDeletion";
+import type { VectorDeletionServices } from "../../src/providers/types";
+import { createVectorDeletionServices } from "../pipeline/services";
+
+export type DocumentDeletionData = {
+  document: {
+    _id: Id<"documents">;
+    userId: string;
+    storageId?: Id<"_storage">;
+    summaryEmbeddingId?: string;
+  };
+  chunkEmbeddingIds: string[];
+  sectionSummaryEmbeddingIds: string[];
+};
+
+export type DocumentDeletionCascadeResult = {
+  chunkVectorCount: number;
+  summaryVectorCount: number;
+  deleted: {
+    highlights: number;
+    posts: number;
+    bookmarks: number;
+    connectionPairs: number;
+    chunks: number;
+    sectionSummaries: number;
+    processingJobs: number;
+    cardDrafts: number;
+    reactionFeedback: number;
+    orphanedTags: number;
+  };
+};
+
+type DocumentDeletionCascadeCtx = Pick<ActionCtx, "runMutation">;
+
+export async function markDocumentDeletionFailed({
+  ctx,
+  documentId,
+  error,
+}: {
+  ctx: DocumentDeletionCascadeCtx;
+  documentId: Id<"documents">;
+  error: unknown;
+}): Promise<{ recoveryError?: string }> {
+  try {
+    await ctx.runMutation(internal.documents.updateStatus, {
+      id: documentId,
+      status: "error",
+      failedAt: "deleting",
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+    });
+    return {};
+  } catch (recoveryError) {
+    // The document may already be gone if row cleanup completed before another step failed.
+    return { recoveryError: String(recoveryError) };
+  }
+}
+
+export async function executeDocumentDeletionCascade({
+  ctx,
+  documentId,
+  userId,
+  data,
+  services = createVectorDeletionServices(),
+}: {
+  ctx: DocumentDeletionCascadeCtx;
+  documentId: Id<"documents">;
+  userId: string;
+  data: DocumentDeletionData;
+  services?: VectorDeletionServices;
+}): Promise<DocumentDeletionCascadeResult> {
+  await ctx.runMutation(internal.documents.updateStatus, {
+    id: documentId,
+    status: "deleting",
+  });
+
+  const vectorDeletion = await deleteDocumentVectors({
+    input: {
+      chunkEmbeddingIds: data.chunkEmbeddingIds,
+      sectionSummaryEmbeddingIds: data.sectionSummaryEmbeddingIds,
+      documentSummaryEmbeddingId: data.document.summaryEmbeddingId,
+    },
+    services,
+  });
+
+  const [highlightResult, postResult, connectionPairResult] = await Promise.all([
+    ctx.runMutation(internal.highlights.cascadeDeleteHighlights, {
+      documentId,
+      userId,
+    }),
+    ctx.runMutation(internal.documents.cascadeDeletePosts, {
+      documentId,
+      userId,
+    }),
+    ctx.runMutation(internal.connectionPairs.cascadeDeleteByDocumentId, {
+      documentId,
+    }),
+  ]);
+
+  const chunkResult = await ctx.runMutation(internal.documents.cascadeDeleteChunksAndSummaries, {
+    documentId,
+    userId,
+  });
+
+  const docResult = await ctx.runMutation(internal.documents.cascadeDeleteDocument, {
+    documentId,
+  });
+
+  return {
+    chunkVectorCount: vectorDeletion.deletedChunkVectorCount,
+    summaryVectorCount: vectorDeletion.deletedSummaryVectorCount,
+    deleted: {
+      highlights: highlightResult.deletedHighlights,
+      posts: postResult.deletedPosts,
+      bookmarks: postResult.deletedBookmarks,
+      connectionPairs: connectionPairResult.deletedConnectionPairs,
+      chunks: chunkResult.deletedChunks,
+      sectionSummaries: chunkResult.deletedSectionSummaries,
+      processingJobs: chunkResult.deletedProcessingJobs,
+      cardDrafts: chunkResult.deletedCardDrafts,
+      reactionFeedback: chunkResult.deletedReactionFeedback,
+      orphanedTags: docResult.deletedOrphanedTags,
+    },
+  };
+}

--- a/packages/backend/tests/logic/accountDeletion.test.ts
+++ b/packages/backend/tests/logic/accountDeletion.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { deleteAccountDocuments } from "../../convex/accountActions";
+import type { Id } from "../../convex/_generated/dataModel";
+import { createMockSummaryStore, createMockVectorStore } from "./mocks";
+
+function createEventRecorder() {
+  const fields: Record<string, unknown> = {};
+  return {
+    fields,
+    evt: {
+      set: vi.fn((keyOrObj: string | Record<string, unknown>, value?: unknown) => {
+        if (typeof keyOrObj === "string") {
+          fields[keyOrObj] = value;
+        } else {
+          Object.assign(fields, keyOrObj);
+        }
+      }),
+    },
+  };
+}
+
+describe("deleteAccountDocuments", () => {
+  it("delegates account document cleanup through the shared cascade", async () => {
+    const documentId = "doc-1" as Id<"documents">;
+    const userId = "user-1";
+    const runQuery = vi.fn().mockResolvedValue({
+      document: {
+        _id: documentId,
+        userId,
+        summaryEmbeddingId: "doc-summary-vec",
+      },
+      chunkEmbeddingIds: ["chunk-vec"],
+      sectionSummaryEmbeddingIds: ["section-vec"],
+    });
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ deletedHighlights: 2 })
+      .mockResolvedValueOnce({ deletedPosts: 3, deletedBookmarks: 4 })
+      .mockResolvedValueOnce({ deletedConnectionPairs: 5 })
+      .mockResolvedValueOnce({
+        deletedChunks: 6,
+        deletedSectionSummaries: 7,
+        deletedProcessingJobs: 8,
+        deletedCardDrafts: 9,
+        deletedReactionFeedback: 10,
+      })
+      .mockResolvedValueOnce({ deletedOrphanedTags: 11 });
+    const vectorDelete = vi.fn();
+    const summaryDelete = vi.fn();
+    const { evt } = createEventRecorder();
+
+    const result = await deleteAccountDocuments({
+      ctx: {
+        runQuery: runQuery as never,
+        runMutation: runMutation as never,
+      },
+      userId,
+      documentIds: [documentId],
+      evt,
+      services: {
+        vectorStore: createMockVectorStore({ delete: vectorDelete }),
+        summaryStore: createMockSummaryStore({ delete: summaryDelete }),
+      },
+    });
+
+    expect(result).toEqual({ deletedDocumentCount: 1, failedDocuments: [] });
+    expect(vectorDelete).toHaveBeenCalledWith(["chunk-vec"]);
+    expect(summaryDelete).toHaveBeenCalledWith(["section-vec", "doc-summary-vec"]);
+    expect(runMutation).toHaveBeenCalledTimes(6);
+    expect(runMutation.mock.calls[1]?.[1]).toEqual({ documentId, userId });
+    expect(runMutation.mock.calls[3]?.[1]).toEqual({ documentId });
+  });
+
+  it("recovers failed cascades out of deleting status", async () => {
+    const documentId = "doc-1" as Id<"documents">;
+    const userId = "user-1";
+    const runQuery = vi.fn().mockResolvedValue({
+      document: { _id: documentId, userId },
+      chunkEmbeddingIds: ["chunk-vec"],
+      sectionSummaryEmbeddingIds: [],
+    });
+    const runMutation = vi.fn().mockResolvedValue(null);
+    const { evt, fields } = createEventRecorder();
+
+    const result = await deleteAccountDocuments({
+      ctx: {
+        runQuery: runQuery as never,
+        runMutation: runMutation as never,
+      },
+      userId,
+      documentIds: [documentId],
+      evt,
+      services: {
+        vectorStore: createMockVectorStore({
+          delete: async () => {
+            throw new Error("vector delete failed");
+          },
+        }),
+        summaryStore: createMockSummaryStore(),
+      },
+    });
+
+    expect(result).toEqual({ deletedDocumentCount: 0, failedDocuments: [documentId] });
+    expect(runMutation).toHaveBeenCalledTimes(2);
+    expect(runMutation.mock.calls[0]?.[1]).toEqual({ id: documentId, status: "deleting" });
+    expect(runMutation.mock.calls[1]?.[1]).toEqual({
+      id: documentId,
+      status: "error",
+      failedAt: "deleting",
+      errorMessage: "vector delete failed",
+    });
+    expect(fields.documentError).toEqual({
+      documentId,
+      error: "vector delete failed",
+    });
+  });
+});

--- a/packages/backend/tests/logic/documentDeletionCascade.test.ts
+++ b/packages/backend/tests/logic/documentDeletionCascade.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Id } from "../../convex/_generated/dataModel";
+import { executeDocumentDeletionCascade } from "../../convex/documents/deletion";
+import { createMockSummaryStore, createMockVectorStore } from "./mocks";
+
+describe("executeDocumentDeletionCascade", () => {
+  it("runs the full document-owned cascade including highlights and connection pairs", async () => {
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ deletedHighlights: 2 })
+      .mockResolvedValueOnce({ deletedPosts: 3, deletedBookmarks: 4 })
+      .mockResolvedValueOnce({ deletedConnectionPairs: 5 })
+      .mockResolvedValueOnce({
+        deletedChunks: 6,
+        deletedSectionSummaries: 7,
+        deletedProcessingJobs: 8,
+        deletedCardDrafts: 9,
+        deletedReactionFeedback: 10,
+      })
+      .mockResolvedValueOnce({ deletedOrphanedTags: 11 });
+    const vectorDelete = vi.fn();
+    const summaryDelete = vi.fn();
+    const documentId = "doc-1" as Id<"documents">;
+    const userId = "user-1";
+
+    const result = await executeDocumentDeletionCascade({
+      ctx: { runMutation: runMutation as never },
+      documentId,
+      userId,
+      data: {
+        document: {
+          _id: documentId,
+          userId,
+          summaryEmbeddingId: "doc-summary-vec",
+        },
+        chunkEmbeddingIds: ["chunk-vec"],
+        sectionSummaryEmbeddingIds: ["section-vec"],
+      },
+      services: {
+        vectorStore: createMockVectorStore({ delete: vectorDelete }),
+        summaryStore: createMockSummaryStore({ delete: summaryDelete }),
+      },
+    });
+
+    expect(vectorDelete).toHaveBeenCalledWith(["chunk-vec"]);
+    expect(summaryDelete).toHaveBeenCalledWith(["section-vec", "doc-summary-vec"]);
+    expect(runMutation).toHaveBeenCalledTimes(6);
+    expect(runMutation.mock.calls[0]?.[1]).toEqual({ id: documentId, status: "deleting" });
+    expect(runMutation.mock.calls[1]?.[1]).toEqual({ documentId, userId });
+    expect(runMutation.mock.calls[3]?.[1]).toEqual({ documentId });
+    expect(result).toEqual({
+      chunkVectorCount: 1,
+      summaryVectorCount: 2,
+      deleted: {
+        highlights: 2,
+        posts: 3,
+        bookmarks: 4,
+        connectionPairs: 5,
+        chunks: 6,
+        sectionSummaries: 7,
+        processingJobs: 8,
+        cardDrafts: 9,
+        reactionFeedback: 10,
+        orphanedTags: 11,
+      },
+    });
+  });
+
+  it("deletes vectors before deleting Convex rows", async () => {
+    const order: string[] = [];
+    const runMutation = vi.fn().mockImplementation(async () => {
+      order.push("mutation");
+      return {
+        deletedHighlights: 0,
+        deletedPosts: 0,
+        deletedBookmarks: 0,
+        deletedConnectionPairs: 0,
+        deletedChunks: 0,
+        deletedSectionSummaries: 0,
+        deletedProcessingJobs: 0,
+        deletedCardDrafts: 0,
+        deletedReactionFeedback: 0,
+        deletedOrphanedTags: 0,
+      };
+    });
+    const documentId = "doc-1" as Id<"documents">;
+    const userId = "user-1";
+
+    await executeDocumentDeletionCascade({
+      ctx: { runMutation: runMutation as never },
+      documentId,
+      userId,
+      data: {
+        document: { _id: documentId, userId },
+        chunkEmbeddingIds: ["chunk-vec"],
+        sectionSummaryEmbeddingIds: [],
+      },
+      services: {
+        vectorStore: createMockVectorStore({
+          delete: async () => {
+            order.push("vector-delete");
+          },
+        }),
+        summaryStore: createMockSummaryStore({
+          delete: async () => {
+            order.push("summary-delete");
+          },
+        }),
+      },
+    });
+
+    expect(order).toEqual([
+      "mutation",
+      "vector-delete",
+      "summary-delete",
+      "mutation",
+      "mutation",
+      "mutation",
+      "mutation",
+      "mutation",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Unifies document deletion and account deletion around one document-domain cascade so account deletion no longer reimplements a partial cleanup path. Closes #223.

## Changes

- Added a shared `executeDocumentDeletionCascade` helper for document-owned cleanup, including vectors, highlights, posts/bookmarks, connection pairs, chunks, summaries, jobs, drafts, feedback, document rows, and orphaned tags.
- Updated `deleteDocument`, `retryDeleteDocument`, and `deleteAccount` to delegate through the shared document deletion path.
- Added deletion failure recovery for account document cascades so failed documents are marked `error` with `failedAt: "deleting"` instead of staying in `deleting`.
- Added focused tests for account deletion delegation, full cascade coverage, vector-before-row cleanup ordering, and deletion recovery.

## Testing

- [x] `bun test tests/logic/accountDeletion.test.ts tests/logic/documentDeletion.test.ts tests/logic/documentDeletionCascade.test.ts`
- [x] `bun run test`
- [x] `bun --bun tsc -p convex/tsconfig.json --noEmit`
- [x] `bun run oxlint packages/backend/convex/accountActions.ts packages/backend/convex/documentActions.ts packages/backend/convex/documents/deletion.ts packages/backend/tests/logic/accountDeletion.test.ts packages/backend/tests/logic/documentDeletionCascade.test.ts`
- [x] `bunx oxfmt --check packages/backend/convex/accountActions.ts packages/backend/convex/documentActions.ts packages/backend/convex/documents/deletion.ts packages/backend/tests/logic/accountDeletion.test.ts packages/backend/tests/logic/documentDeletionCascade.test.ts`
- [x] `npx convex dev --once`

Note: `bun --bun tsc -p packages/backend/tsconfig.json --noEmit` still fails on pre-existing `tests/summarize-logic.test.ts` fixture drift unrelated to this PR.
