### PR TITLE
chore(#224): add backend domain architecture skill

### DIFF
--- a/.agents/agents/backend-public-api-reviewer.md
+++ b/.agents/agents/backend-public-api-reviewer.md
@@ -1,0 +1,114 @@
+---
+name: backend-public-api-reviewer
+description: |
+  Review new or changed Scrollect backend API contracts before implementation hardens around them.
+  Use this agent whenever work adds or changes a public Convex function, internal function, provider
+  port, service context, service method, exported use-case function, shared DTO, validator contract,
+  or backend-facing error/result shape. Public means callable outside the defining module or layer,
+  not necessarily internet-public.
+
+  <example>User: "Review this new submitDocument mutation signature before I implement it"</example>
+  <example>User: "Check whether this PipelineServiceContext API is the right shape"</example>
+  <example>User: "I'm adding a new provider method for card generation; critique the contract"</example>
+model: inherit
+---
+
+# Backend Public API Reviewer
+
+You review Scrollect backend API contracts before other code depends on them. You are not checking
+whether the implementation is clever. You are checking whether the contract will be easy to call
+correctly, hard to misuse, and stable enough for the current feature.
+
+## What Counts As Public
+
+Public means callable outside the defining module or architectural layer:
+
+- exported Convex queries, mutations, actions, HTTP actions, and internal functions
+- function `args` and `returns` validators
+- provider ports and capability interfaces
+- service contexts, service factories, and service methods
+- exported pure use-case functions in `packages/backend/src/`
+- shared input, output, plan, result, DTO, and error types
+
+Private helpers used inside one file, test-only factories, and implementation-only refactors are out
+of scope unless they leak into a public contract.
+
+## Required Context
+
+Before reviewing, ask for or infer:
+
+- the proposed signature or validator shape
+- the current caller and any near-term caller already in scope
+- whether the contract lives at the Convex edge, pure domain layer, provider port, service context,
+  or adapter
+- expected auth, authorization, idempotency, retry, pagination, and error behavior
+- tests that will lock down the caller-visible behavior
+
+## Review Checklist
+
+- **Domain language:** Names describe Scrollect behavior, not technical plumbing. Prefer
+  `planCardGeneration`, `deleteDocumentVectors`, or `createFeedCards` over `process`, `manager`, or
+  `run`.
+- **Caller ergonomics:** Call sites should read clearly. Use an object parameter for more than three
+  values, and group related values by domain meaning rather than transport shape.
+- **Boundary fit:** Convex APIs own auth, validation, persistence, scheduling, logging, analytics,
+  and recovery. Pure use cases own policy and planning over plain data. Provider ports describe
+  capabilities, not SDK calls.
+- **Contract narrowness:** The API exposes the smallest current capability that hides real
+  complexity. Flag generic options bags, speculative flags, future-only fields, and broad service
+  contexts.
+- **Misuse resistance:** Invalid states should be unrepresentable when practical. Required values are
+  required, unions are explicit, IDs are domain-specific, and boolean combinations do not encode a
+  hidden state machine.
+- **Return shape:** Results are typed around caller decisions. Avoid returning whole rows, provider
+  raw responses, or mixed success/error shapes unless the caller genuinely needs them.
+- **Errors and recovery:** Error behavior is named. Convex callers know whether failure is user
+  visible, retryable, recoverable by scheduler, or an internal invariant violation.
+- **Security and privacy:** Public Convex functions require auth and row-level authorization unless
+  intentionally anonymous. Returned data excludes private fields and cross-user leakage.
+- **Scale:** User-facing reads are bounded or paginated. Contracts do not require unbounded caller
+  loops, N+1 reads, or passing large content blobs when IDs or summaries are enough.
+- **Testability:** The contract can be exercised with focused tests and mocked ports without
+  constructing Convex runtime or external SDKs in pure domain tests.
+- **Compatibility:** Existing public names and shapes stay stable unless the task intentionally
+  migrates callers. If compatibility breaks, the migration path is explicit.
+
+## Findings To Prioritize
+
+Flag these even if the implementation could technically work:
+
+- a Convex function whose validator accepts transport-shaped or ambiguous objects instead of a
+  domain command
+- a service context that bundles unrelated capabilities "just in case"
+- a provider port that exposes raw SDK parameters or returns raw SDK responses
+- a public function that requires the caller to remember sequencing, status transitions, or cleanup
+- a return type that leaks private fields or forces every caller to defensively filter data
+- a boolean flag or optional field that creates multiple modes without naming them
+- a contract that exists only for a future caller not included in the current task
+
+## Output Format
+
+Start with one of:
+
+- `Verdict: accept`
+- `Verdict: accept with changes`
+- `Verdict: redesign before implementation`
+
+Then list findings in priority order:
+
+- **Location:** file and API name
+- **Issue:** what contract risk exists and why it matters
+- **Recommendation:** the concrete signature, validator, naming, or boundary change to make
+
+End with **Contract Notes**:
+
+- current callers this API serves
+- assumptions you made
+- tests that should lock the contract down
+
+## Constraints
+
+- You do NOT edit code. You provide recommendations in conversation.
+- Review the public contract first. Mention implementation details only when they prove the contract
+  will be hard to use, test, secure, or evolve.
+- Prefer small, boring APIs over elegant frameworks.

--- a/.agents/skills/backend-domain-architecture/SKILL.md
+++ b/.agents/skills/backend-domain-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-domain-architecture
-description: Scrollect backend architecture design gate for packages/backend architectural decisions. Use when deciding where backend logic belongs, extracting pure domain logic from Convex, designing provider ports or service contexts, refactoring oversized domain modules, resolving duplicated orchestration, or reviewing DDD/SOLID/DRY/YAGNI tradeoffs. Also trigger on explicit architecture review/critique requests for backend work. Do not use for routine Convex edits that only need backend-development; use both skills when the architectural decision touches Convex functions, pipeline stages, schema-facing work, or provider wiring.
+description: Scrollect backend architecture design gate for packages/backend architectural decisions. Use when deciding where backend logic belongs, extracting pure domain logic from Convex, creating or changing public backend APIs, designing provider ports or service contexts, refactoring oversized domain modules, resolving duplicated orchestration, or reviewing DDD/SOLID/DRY/YAGNI tradeoffs. Also trigger on explicit architecture review/critique requests for backend work. Do not use for routine Convex edits that only need backend-development; use both skills when the architectural decision touches Convex functions, pipeline stages, schema-facing work, provider wiring, or service contracts.
 ---
 
 # Backend Domain Architecture
@@ -20,10 +20,11 @@ Before proposing architecture or editing backend files:
 2. Identify the domain words the code should use: documents, pipeline, feed, tags, entitlements,
    auth, billing, highlights, connections, or another explicit Scrollect concept.
 3. Decide which companion skills apply.
-4. Decide whether the task is an implementation change, a refactor, or a review/critique.
-5. If the user asks for review, critique, or validation, read
+4. Decide whether the task creates or changes a public backend API contract.
+5. Decide whether the task is an implementation change, a refactor, or a review/critique.
+6. If the user asks for review, critique, or validation, read
    `references/architecture-review-rubric.md` before writing findings.
-6. If the task needs concrete Scrollect examples, read `references/scrollect-pattern-examples.md`.
+7. If the task needs concrete Scrollect examples, read `references/scrollect-pattern-examples.md`.
 
 ## Companion Skills
 
@@ -42,6 +43,9 @@ Use this skill with other skills when their rules materially apply:
   backfills, or zero-downtime data shape.
 - `ai-sdk`: when the boundary involves LLM calls, structured output, tool calling, embeddings, model
   selection, or provider behavior.
+- `.agents/agents/backend-public-api-reviewer.md`: spawn this reviewer whenever the change creates
+  or changes a public backend API contract. Public means callable outside the defining module or
+  layer, not necessarily internet-public.
 
 Do not invoke every related skill by habit. Use the smallest set that catches the real risk.
 
@@ -141,6 +145,35 @@ When adding or reshaping a provider port, service context, or domain use-case in
 For large interface decisions, use subagents to generate genuinely different options. For small
 ports, do the comparison inline and keep moving.
 
+## Public API Review Gate
+
+Before implementing a new or changed public backend API, spawn a dedicated public API reviewer
+subagent from `.agents/agents/backend-public-api-reviewer.md` and incorporate the feedback before
+finalizing the API shape.
+
+Public backend API means any contract that another module, layer, or caller depends on:
+
+- exported Convex queries, mutations, actions, HTTP actions, and internal functions
+- new or changed `args` or `returns` validators for backend functions
+- provider ports, service contexts, concrete service factories, and service methods
+- exported pure use-case functions from `src/` that are called outside their local module
+- shared DTOs, plan/result types, error shapes, and capability interfaces
+
+Do not trigger this gate for private helpers that are used only inside one file, test-only factories,
+or mechanical implementation changes that keep an existing contract stable.
+
+Give the reviewer enough context to judge the API, not just the diff:
+
+- the intended current caller and any near-term caller already in scope
+- the proposed function or interface signature
+- whether the API is Convex edge, pure domain logic, provider port, service context, or adapter
+- expected authorization, idempotency, pagination, retry, and error behavior
+- what tests will lock the contract down
+
+Treat the reviewer as a design checkpoint, not a veto machine. If you reject feedback, state why the
+current contract is still easier to use correctly, harder to misuse, and aligned with Scrollect's
+backend boundaries.
+
 ## Domain Modeling Rules
 
 ### Ubiquitous Language
@@ -235,6 +268,8 @@ Answer these before changing backend architecture:
 - Is this Convex edge behavior, pure domain logic, provider implementation, or provider wiring?
 - Does any new `src/` code import Convex runtime APIs or generated Convex modules? If yes, redesign.
 - Is there an existing port or service context to reuse?
+- Does this create or change a public backend API? If yes, what should the
+  `backend-public-api-reviewer` inspect before the contract is finalized?
 - Are retries, recovery, scheduler boundaries, and state transitions still owned by Convex code?
 - Is external I/O completed before status transitions that imply durable completion?
 - Is this abstraction serving a current caller and testable need?
@@ -248,12 +283,14 @@ When implementing or refactoring:
 2. If behavior changes and a focused test is practical, use `tdd`: write or update the smallest
    failing test first, then make it pass.
 3. Move only the boundary that the task requires. Avoid opportunistic domain reshuffles.
-4. Keep exported Convex function names stable unless the API change is intentional.
-5. Prefer extracting pure logic before introducing a service context. Add the context only when the
+4. If creating or changing a public backend API, run the Public API Review Gate before committing to
+   the final signature.
+5. Keep exported Convex function names stable unless the API change is intentional.
+6. Prefer extracting pure logic before introducing a service context. Add the context only when the
    use case needs external capabilities or clearer tests.
-6. Keep persistence, scheduling, retries, and recovery at the Convex edge.
-7. Run focused tests for pure logic and the repo checks appropriate to the changed files.
-8. If Convex schema or functions changed, follow `backend-development` and deploy with
+7. Keep persistence, scheduling, retries, and recovery at the Convex edge.
+8. Run focused tests for pure logic and the repo checks appropriate to the changed files.
+9. If Convex schema or functions changed, follow `backend-development` and deploy with
    `cd packages/backend && npx convex dev --once`.
 
 ## Review Flow
@@ -287,6 +324,8 @@ Use this checklist during review:
 - No speculative schema, index, provider, export, or generic framework was added.
 - Existing `backend-development` rules still hold for auth, validators, wide events, indexed
   queries, bounded user-facing reads, batch operations, and pipeline safety.
+- New or changed public API contracts were reviewed by `backend-public-api-reviewer`, or the review
+  was intentionally skipped because the contract remained private or unchanged.
 - Tests match the risk: pure logic gets unit tests; Convex behavior gets targeted integration or
   E2E coverage only when it is stable and maintainable.
 

--- a/.agents/skills/backend-domain-architecture/SKILL.md
+++ b/.agents/skills/backend-domain-architecture/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: backend-domain-architecture
+description: Scrollect backend architecture design gate for packages/backend architectural decisions. Use when deciding where backend logic belongs, extracting pure domain logic from Convex, designing provider ports or service contexts, refactoring oversized domain modules, resolving duplicated orchestration, or reviewing DDD/SOLID/DRY/YAGNI tradeoffs. Also trigger on explicit architecture review/critique requests for backend work. Do not use for routine Convex edits that only need backend-development; use both skills when the architectural decision touches Convex functions, pipeline stages, schema-facing work, or provider wiring.
+---
+
+# Backend Domain Architecture
+
+Use this skill as the design-quality gate before editing or reviewing Scrollect backend code. It
+turns generic architecture ideas into project-specific rules for `packages/backend`.
+
+The goal is not architecture theater. The goal is backend code that says what Scrollect means:
+saved documents become learning material, the pipeline turns material into cards, and the feed
+serves useful knowledge at the right time.
+
+## Mandatory Preparation
+
+Before proposing architecture or editing backend files:
+
+1. Read the existing code around the target domain. Do not infer boundaries from filenames alone.
+2. Identify the domain words the code should use: documents, pipeline, feed, tags, entitlements,
+   auth, billing, highlights, connections, or another explicit Scrollect concept.
+3. Decide which companion skills apply.
+4. Decide whether the task is an implementation change, a refactor, or a review/critique.
+5. If the user asks for review, critique, or validation, read
+   `references/architecture-review-rubric.md` before writing findings.
+6. If the task needs concrete Scrollect examples, read `references/scrollect-pattern-examples.md`.
+
+## Companion Skills
+
+Use this skill with other skills when their rules materially apply:
+
+- `backend-development`: always for Convex functions, pipeline stages, provider wiring,
+  validators, schema-facing work, backend testing conventions, and files under
+  `packages/backend/convex/`.
+- `tdd`: for behavior changes in pure logic, provider contracts, pipeline planning, feed scoring,
+  deletion flows, and bug fixes where a focused regression test is practical.
+- `wide-event-logging`: when adding side effects, observability, pipeline diagnostics, or replacing
+  ad-hoc logs in Convex code.
+- `convex-security-check`: for auth, authorization, row-level access, private data, webhooks,
+  function exposure, or multi-user boundaries.
+- `convex-schema-validator` and `convex-migrations`: when changing tables, validators, indexes,
+  backfills, or zero-downtime data shape.
+- `ai-sdk`: when the boundary involves LLM calls, structured output, tool calling, embeddings, model
+  selection, or provider behavior.
+
+Do not invoke every related skill by habit. Use the smallest set that catches the real risk.
+
+## Architecture Score
+
+For architecture review or design critique, give a 0-10 score and concrete steps to reach 10.
+
+A 10/10 Scrollect backend design has:
+
+- clear Scrollect domain language
+- explicit Convex, domain logic, and provider boundaries
+- dependencies pointing inward toward domain decisions
+- external systems behind typed ports when that improves testability or replaceability
+- no speculative abstractions, schemas, indexes, providers, or exports
+- focused tests for the riskiest domain behavior
+- no conflict with `backend-development` operational safety rules
+
+If the score is below 8, name the top two changes that would most improve it.
+
+## Architecture Map
+
+Treat `packages/backend` as three architectural zones:
+
+- `convex/`: the Convex edge. It exports queries, mutations, actions, HTTP handlers, schemas,
+  validators, auth helpers, logging, and Convex-specific adapters.
+- `src/`: non-Convex TypeScript domain logic plus provider implementations. Domain logic here
+  should be pure when practical; provider implementations may call SDKs and external services. Code
+  here should not import Convex runtime APIs or generated Convex types.
+- `tests/`: focused tests for pure logic, provider behavior, and backend workflows.
+
+Providers are an architectural layer, not a product domain. They should adapt external systems into
+Scrollect language through ports and service contexts.
+
+## Dependency Rule
+
+Dependencies should point inward toward domain decisions:
+
+- `convex/` may import `src/` logic and provider types.
+- `src/providers/` may implement SDK or network adapters.
+- `src/pipeline/logic`, `src/feed/logic`, and `src/logic` should not import Convex generated APIs,
+  Convex validators, `ctx`, SDK construction, environment variables, or `WideEvent`.
+- Pure domain logic should depend on typed capabilities, not concrete providers.
+
+When this direction feels hard, treat it as a design signal. Either the domain code is doing too
+much persistence work, or the Convex handler is hiding a domain decision that should be named.
+
+## Controller / Orchestration / Service
+
+Use this as the default shape:
+
+1. **Controller at the Convex edge**: authenticate, validate args, read/write Convex state,
+   schedule work, emit `WideEvent`s, capture analytics, and translate Convex IDs or validators.
+2. **Orchestration in pure domain code when reusable or policy-heavy**: decide what should happen,
+   order provider calls through typed ports, compute plans, normalize inputs, and return records or
+   metrics that the Convex edge can persist.
+3. **Services behind typed ports**: external systems and LLMs enter through interfaces in
+   `src/providers/types.ts`; concrete wiring happens at the edge, usually in
+   `convex/pipeline/services.ts` or a similarly local factory.
+
+This is Scrollect's practical version of Clean/Hexagonal Architecture. Adapt the dependency rule,
+ports, and adapters to the current Convex-first backend. Do not impose a generic folder template.
+
+Keep simple Convex functions simple. Do not extract a one-off `ctx.db.patch` into `src/` just to
+make the layers look symmetrical.
+
+## Placement Decision Tree
+
+Ask these questions in order:
+
+1. Does it need `ctx.db`, `ctx.storage`, `ctx.scheduler`, `ctx.runQuery`, `ctx.runMutation`,
+   `ctx.runAction`, Convex validators, generated `api`, generated `Id`, auth helpers, or
+   `WideEvent`? Keep that part in `convex/`.
+2. Can the rule be expressed over plain TypeScript inputs and outputs? Put it in `src/`.
+3. Does it call OpenAI, Qdrant, Marker, PostHog, Polar, Decodo, storage, or another external system?
+   Define or reuse a typed port, then wire the concrete adapter at the edge.
+4. Is it duplicated domain policy used by multiple Convex functions? Extract to `src/`.
+5. Is it duplicated shape only, with different domain meaning? Leave it alone or name two separate
+   domain helpers.
+6. Does it need a new schema field, index, provider, or export only for a future idea? Do not add it
+   yet.
+
+## Interface Design
+
+When adding or reshaping a provider port, service context, or domain use-case interface, do a small
+"design it twice" pass before coding:
+
+1. Name the callers: Convex action, internal mutation, pure logic test, provider implementation, or
+   future scheduled workflow.
+2. List the operations the caller really needs now.
+3. Sketch two materially different shapes:
+   - narrow: the smallest interface that serves the current use case
+   - flexible: the shape that would support the likely next nearby use case
+4. Compare them in prose: ease of correct use, ease of misuse, testability, implementation
+   efficiency, and how much complexity the interface hides.
+5. Choose the narrowest shape that still has enough depth to hide real complexity.
+
+For large interface decisions, use subagents to generate genuinely different options. For small
+ports, do the comparison inline and keep moving.
+
+## Domain Modeling Rules
+
+### Ubiquitous Language
+
+Use Scrollect words in modules, functions, variables, and events. Prefer `planDraftGeneration`,
+`deleteDocumentVectors`, or `scoreDrafts` over `processData`, `manager`, `handlerHelper`, or
+`utils`.
+
+If a concept is hard to name without a technical placeholder, pause and identify the domain action
+or capability it represents.
+
+### Bounded Contexts
+
+Bounded contexts are model boundaries, not deployment boundaries. Keep the monorepo and Convex
+deployment shape unless the task explicitly requires a larger structural change.
+
+Current contexts include documents, pipeline, feed, tags, entitlements, auth, billing, highlights,
+and connections. The same row can be viewed differently by different contexts; translate at the
+boundary rather than passing a bloated universal model everywhere.
+
+### Core / Supporting / Generic
+
+Scrollect's core domain is the personal learning pipeline and feed: turning saved content into
+useful learning cards and deciding what to serve next. Invest the deepest modeling there.
+
+Supporting and generic domains should stay appropriately thin:
+
+- auth and billing integrate proven tools and enforce Scrollect-specific policy
+- providers adapt external systems into Scrollect language
+- migrations and admin utilities should be explicit and boring
+
+### Entities, Values, and Consistency
+
+Use DDD ideas without forcing object-oriented ceremony onto Convex rows:
+
+- durable records with identity, such as documents, card drafts, tags, highlights, and processing
+  jobs, are entity-like
+- computed inputs, scores, plans, filters, vector IDs, and provider result shapes are value-like
+- a Convex mutation or internal mutation group is the immediate consistency boundary
+- scheduled actions and retries are how eventual work crosses boundaries
+
+Do not introduce aggregate classes unless behavior and tests clearly benefit. A well-named pure
+function over plain data is often the right Scrollect shape.
+
+### Domain Events
+
+Do not create an event system by default. Use domain-event thinking to name facts and transitions:
+`pipeline.stage_completed`, `pipeline.stage_failed`, `documentActions.deleteDocument`, and similar
+wide events or analytics events should describe what happened in Scrollect language.
+
+Only add a new event or event-like abstraction when another current workflow consumes it or when it
+materially improves observability.
+
+## Design Principles
+
+### SOLID
+
+Keep each module focused on one reason to change. Split a file when it mixes transport, persistence,
+provider wiring, and domain policy. Depend on abstractions at external boundaries, but do not wrap
+internal functions in interfaces just because SOLID sounds impressive.
+
+### DRY With Judgment
+
+Deduplicate repeated domain decisions and repeated workflows. Leave duplication alone when it is
+only structural coincidence, when a helper would hide important domain language, or when two domains
+are likely to evolve differently.
+
+### YAGNI
+
+Avoid speculative schemas, indexes, providers, service contexts, exports, and generic abstractions.
+Add an abstraction only when there is a current caller, a testable payoff, or repeated logic already
+making changes risky.
+
+### Modularity
+
+Prefer small domain files over god files. Split by responsibility, not just by line count. When
+refactoring Convex functions, preserve stable exported function names unless the API change is part
+of the task.
+
+### Parameter Shape
+
+Do not create functions with more than three positional parameters. Use an object parameter so call
+sites name the values they pass.
+
+## Pre-Edit Checklist
+
+Answer these before changing backend architecture:
+
+- Which companion skills apply?
+- Which backend domain owns this change?
+- What Scrollect domain words should appear in the code?
+- Is this Convex edge behavior, pure domain logic, provider implementation, or provider wiring?
+- Does any new `src/` code import Convex runtime APIs or generated Convex modules? If yes, redesign.
+- Is there an existing port or service context to reuse?
+- Are retries, recovery, scheduler boundaries, and state transitions still owned by Convex code?
+- Is external I/O completed before status transitions that imply durable completion?
+- Is this abstraction serving a current caller and testable need?
+- What focused tests would catch a behavior change?
+
+## Implementation Flow
+
+When implementing or refactoring:
+
+1. Load the companion skills identified in the pre-edit checklist.
+2. If behavior changes and a focused test is practical, use `tdd`: write or update the smallest
+   failing test first, then make it pass.
+3. Move only the boundary that the task requires. Avoid opportunistic domain reshuffles.
+4. Keep exported Convex function names stable unless the API change is intentional.
+5. Prefer extracting pure logic before introducing a service context. Add the context only when the
+   use case needs external capabilities or clearer tests.
+6. Keep persistence, scheduling, retries, and recovery at the Convex edge.
+7. Run focused tests for pure logic and the repo checks appropriate to the changed files.
+8. If Convex schema or functions changed, follow `backend-development` and deploy with
+   `cd packages/backend && npx convex dev --once`.
+
+## Review Flow
+
+When reviewing a backend design or implementation:
+
+1. Gather context: changed files, relevant domain, existing tests, linked issues or ADRs, and
+   companion skills used.
+2. Score the architecture from 0 to 10 using `references/architecture-review-rubric.md`.
+3. Lead with findings ordered by risk.
+4. For each finding, name the violated boundary or design rule and give a small repair path.
+5. Call out over-engineering separately from under-engineering.
+6. End with what would make the score a 10.
+
+Be direct. Vague architecture feedback wastes time.
+
+## Review Checklist
+
+Use this checklist during review:
+
+- Convex handlers are thin enough: auth, validation, reads/writes, scheduling, logging, analytics,
+  and persistence stay there; domain policy does not accumulate there.
+- Pure logic in `src/` has no Convex runtime imports and is testable with plain objects or mocked
+  service contexts.
+- Provider code is behind typed ports; concrete SDK construction and environment-based stubs are
+  wired at the edge.
+- Dependency direction is preserved: domain logic does not know about frameworks, generated Convex
+  APIs, SDK construction, or environment variables.
+- Names use Scrollect domain language instead of technical placeholders.
+- No junk-drawer module, god file, or coincidental helper was added.
+- No speculative schema, index, provider, export, or generic framework was added.
+- Existing `backend-development` rules still hold for auth, validators, wide events, indexed
+  queries, bounded user-facing reads, batch operations, and pipeline safety.
+- Tests match the risk: pure logic gets unit tests; Convex behavior gets targeted integration or
+  E2E coverage only when it is stable and maintainable.
+
+## Pattern Examples
+
+For implementation-specific examples with current paths, read
+`references/scrollect-pattern-examples.md`.
+
+### Document Deletion Cascade
+
+A document deletion action should own auth, logging, status transitions, recovery, and cascade
+mutation boundaries. Provider-independent vector deletion policy should live in pure logic behind
+a typed vector-deletion service. Tests should exercise the pure deletion use case with mocked vector
+stores.
+
+This pattern avoids duplicating vector cleanup logic across user deletion, document deletion, and
+retry paths while keeping Convex state transitions in Convex.
+
+### Pipeline Logic Extraction
+
+Pipeline stages should keep scheduling, retries, status recovery, and persistence at the Convex edge.
+Planning, scoring, prompt-independent selection, grouping, and provider-independent generation rules
+belong in pure logic. Provider calls should flow through service contexts so tests can use stubs.
+
+### Feed Serving Scoring
+
+Feed serving should own user auth, bounded Convex reads, mutation writes, analytics capture, and
+replenishment scheduling. Ranking math and analytics metric calculations should be pure functions
+over plain draft/document inputs.
+
+### Provider Boundary
+
+Provider ports should be capability-focused: embed text, upsert vectors, search summaries, generate
+cards, validate cards. Concrete SDK construction and environment-based stub selection should happen
+at the Convex edge, not inside pure domain logic.
+
+## Avoid These Traps
+
+- Do not say "all orchestration belongs in `src/`." Convex orchestration is legitimate when it
+  coordinates transactions, scheduling, recovery, and internal functions.
+- Do not implement a generic Clean Architecture directory template. Respect Scrollect's current
+  Convex-first architecture.
+- Do not make service contexts mandatory ceremony. They are useful when they reduce coupling or
+  make domain logic testable.
+- Do not copy `backend-development`. Reference it and keep this skill about architectural judgment.
+- Do not split files mechanically. A small file with the wrong responsibility is still wrong; a
+  larger file can be acceptable when it protects a stable Convex API and has clear internal
+  structure.
+- Do not hide domain language behind generic names like `manager`, `processor`, `helper`, or
+  `utils`. Name the use case or capability directly.

--- a/.agents/skills/backend-domain-architecture/references/architecture-review-rubric.md
+++ b/.agents/skills/backend-domain-architecture/references/architecture-review-rubric.md
@@ -1,0 +1,67 @@
+# Architecture Review Rubric
+
+Use this reference when reviewing or critiquing Scrollect backend architecture. Score each dimension
+0-2, then sum to a 0-10 architecture health score.
+
+## Scoring Table
+
+| Dimension              | 0                                                             | 1                                        | 2                                                            |
+| ---------------------- | ------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------ |
+| Domain language        | Generic technical names hide intent                           | Some domain names, some placeholders     | Scrollect concepts are explicit and consistent               |
+| Boundary placement     | Convex, domain, and provider code are mixed                   | Boundaries mostly hold with some leakage | Convex edge, pure logic, and providers are clearly separated |
+| Dependency direction   | Domain logic imports frameworks, SDKs, env, or Convex runtime | Mostly clean with isolated leaks         | Dependencies point inward toward domain decisions            |
+| Abstraction discipline | Speculative or generic abstractions appear                    | Some abstractions have unclear payoff    | Abstractions have current callers and testable value         |
+| Testability            | Behavior requires full runtime to test                        | Some logic is unit-testable              | Risky domain behavior is covered by focused tests or mocks   |
+
+## Report Template
+
+Use this shape for architecture review responses:
+
+```markdown
+Architecture Health: X/10
+
+Findings
+
+- [P1] Finding title
+  Why it matters:
+  Repair:
+
+What Works
+
+- Specific strength worth preserving.
+
+To Reach 10/10
+
+- Highest-impact change.
+- Next-highest-impact change.
+```
+
+## Priority Guide
+
+- `P0`: Data loss, security breach, or impossible-to-recover pipeline failure.
+- `P1`: Boundary violation likely to cause bugs, retries failing, auth mistakes, or hard-to-test
+  core logic.
+- `P2`: Maintainability issue that will make the next backend change harder or risk duplication.
+- `P3`: Naming, organization, or clarity issue that is small but worth fixing while nearby.
+
+## Red Flags
+
+- `src/` imports from `convex/_generated`, `convex/values`, or Convex server helpers.
+- A Convex action contains scoring, planning, ranking, prompt assembly, or provider-independent
+  business rules that could be unit tested.
+- A domain helper accepts `ctx` when it only needs plain data.
+- A new provider is instantiated inside pure logic.
+- A new service context has one caller and no testing benefit.
+- A helper name is generic because the domain concept was not understood.
+- A schema/index/provider/export is added for a future use case that is not part of the current
+  task.
+- A refactor moves exported Convex function names without a clear migration reason.
+
+## Positive Signals
+
+- The code reads in Scrollect language.
+- Provider ports are small and capability-focused.
+- Convex handlers own the runtime boundary and little else.
+- Pure logic returns records, plans, metrics, or decisions for the edge to persist.
+- Tests can exercise the important behavior without Convex or network services.
+- Duplication was removed because it represented the same domain decision, not just similar syntax.

--- a/.agents/skills/backend-domain-architecture/references/scrollect-pattern-examples.md
+++ b/.agents/skills/backend-domain-architecture/references/scrollect-pattern-examples.md
@@ -1,0 +1,120 @@
+# Scrollect Pattern Examples
+
+These examples point to the current backend as of the skill creation. Treat paths as examples of the
+pattern, not permanent contracts. If the code moves, preserve the architectural shape.
+
+## Document Deletion Cascade
+
+Current files:
+
+- `packages/backend/convex/documentActions.ts`
+- `packages/backend/src/logic/documentDeletion.ts`
+- `packages/backend/src/providers/types.ts`
+- `packages/backend/convex/pipeline/services.ts`
+- `packages/backend/tests/logic/documentDeletion.test.ts`
+
+Pattern:
+
+- The public action owns authentication, `WideEvent`, document status transitions, recovery, retry,
+  and internal mutation orchestration.
+- The pure use case accepts plain embedding IDs and `VectorDeletionServices`.
+- Provider factories create concrete vector stores at the Convex edge.
+- Unit tests mock `VectorStore` and `SummaryVectorStore`.
+
+Why it is good:
+
+- external vector deletion policy can be reused without duplicating provider calls
+- Convex state transitions stay in Convex
+- tests do not need Qdrant or Convex runtime
+
+Watch-outs:
+
+- do not move `ctx.runMutation` cascade calls into `src/`
+- do not instantiate Qdrant stores in pure deletion logic
+- do not set terminal document status before external cleanup that must succeed
+
+## Card Draft Pipeline
+
+Current files:
+
+- `packages/backend/convex/pipeline/cardDraftGeneration.ts`
+- `packages/backend/convex/pipeline/cardDraftSectionGeneration.ts`
+- `packages/backend/src/pipeline/logic/draftGenerationPlan.ts`
+- `packages/backend/src/pipeline/logic/cardDraftGeneration.ts`
+- `packages/backend/convex/pipeline/services.ts`
+
+Pattern:
+
+- Convex actions fetch documents/sections, handle learning-goal waits, create jobs, schedule
+  batches, record metrics, persist drafts, retry failures, and mark job completion.
+- Pure logic plans draft counts, selects card types, scores section candidates, selects chunks,
+  validates type data, and builds draft records.
+- Service contexts inject LLMs and validators where the pure use case needs external capability.
+
+Why it is good:
+
+- generation policy can evolve under unit tests
+- Convex exports remain stable while internals move
+- provider calls are isolated behind typed service contexts
+
+Watch-outs:
+
+- do not make planning depend on Convex rows directly if plain input objects would work
+- do not hide scheduler retry decisions inside pure logic
+- do not add a service context for a helper that has no external dependency
+
+## Feed Serving Scoring
+
+Current files:
+
+- `packages/backend/convex/feed/serving.ts`
+- `packages/backend/src/feed/logic/scoring.ts`
+- `packages/backend/src/feed/logic/servingAnalyticsMetrics.ts`
+
+Pattern:
+
+- The Convex mutation owns user auth, bounded queries, joining just enough data, mutation writes,
+  analytics capture, and replenishment scheduling.
+- Pure scoring and analytics helpers operate over plain draft/document inputs.
+- The boundary protects real-time Convex behavior while making ranking math testable.
+
+Why it is good:
+
+- ranking can be tested without a live Convex deployment
+- feed-serving policy is not trapped inside one large mutation
+- Convex still owns the transaction and subscription-relevant data flow
+
+Watch-outs:
+
+- keep user-facing queries bounded
+- do not make scoring fetch its own data
+- do not duplicate ranking constants in Convex and pure logic
+
+## Provider Boundary
+
+Current files:
+
+- `packages/backend/src/providers/types.ts`
+- `packages/backend/src/providers/*`
+- `packages/backend/convex/pipeline/services.ts`
+- `packages/backend/src/providers/stubs.ts`
+
+Pattern:
+
+- `src/providers/types.ts` names capabilities such as embedding, vector storage, summary vector
+  storage, LLM generation, validation, analytics, extraction, and metadata inference.
+- Concrete providers implement those capabilities.
+- Convex edge factories choose production or stub implementations.
+- Pure use cases receive service contexts instead of constructing providers.
+
+Why it is good:
+
+- tests can inject mocks or stubs
+- external SDK churn stays out of domain logic
+- capability names stay close to Scrollect use cases
+
+Watch-outs:
+
+- keep ports small and capability-focused
+- avoid one giant provider context for unrelated domains
+- do not leak provider response shapes into feed or pipeline domain logic

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -26,6 +26,7 @@ You analyze changed files and dispatch review to the appropriate agent(s).
 3. **Spawn reviewer agent(s):**
    - Frontend changes → spawn `code-reviewer-frontend` agent
    - Backend changes → spawn `code-reviewer-backend` agent
+   - Changes in public Convex function, internal function, provider port, service context, service method → spawn `backend-public-api-reviewer` agent
    - Cross-cutting changes → spawn both + `architect-reviewer` agent
    - Spawn agents in parallel when multiple reviewers are needed
 

--- a/.agents/skills/team-agent-prompt/SKILL.md
+++ b/.agents/skills/team-agent-prompt/SKILL.md
@@ -115,16 +115,17 @@ Agent definitions live in `.agents/agents/`. **Read each agent's file** for thei
 
 Available agents:
 
-| Agent file                                 | Role                     | Edits code? | When to include                                                     |
-| ------------------------------------------ | ------------------------ | ----------- | ------------------------------------------------------------------- |
-| `.agents/agents/architect.md`              | System design, ADRs      | Yes         | Schema changes, new modules, data flow design, integration patterns |
-| `.agents/agents/project-manager.md`        | Backlog, issues, specs   | No          | Feature scoping, acceptance criteria, prioritization                |
-| `.agents/agents/frontend-developer.md`     | Frontend implementation  | Yes         | UI components, pages, scroll behavior, form handling                |
-| `.agents/agents/backend-developer.md`      | Backend implementation   | Yes         | Convex functions, schema, pipeline, auth, AI/embeddings             |
-| `.agents/agents/qa.md`                     | Test strategy, E2E tests | Yes         | Always — every feature needs tests                                  |
-| `.agents/agents/architect-reviewer.md`     | Architectural review     | No          | Cross-cutting concerns, scalability, design pattern review          |
-| `.agents/agents/code-reviewer-frontend.md` | Frontend code review     | No          | React/TanStack pattern review                                       |
-| `.agents/agents/code-reviewer-backend.md`  | Backend code review      | No          | Convex pattern review                                               |
+| Agent file                                      | Role                     | Edits code? | When to include                                                     |
+| ----------------------------------------------- | ------------------------ | ----------- | ------------------------------------------------------------------- |
+| `.agents/agents/architect.md`                   | System design, ADRs      | Yes         | Schema changes, new modules, data flow design, integration patterns |
+| `.agents/agents/project-manager.md`             | Backlog, issues, specs   | No          | Feature scoping, acceptance criteria, prioritization                |
+| `.agents/agents/frontend-developer.md`          | Frontend implementation  | Yes         | UI components, pages, scroll behavior, form handling                |
+| `.agents/agents/backend-developer.md`           | Backend implementation   | Yes         | Convex functions, schema, pipeline, auth, AI/embeddings             |
+| `.agents/agents/qa.md`                          | Test strategy, E2E tests | Yes         | Always — every feature needs tests                                  |
+| `.agents/agents/architect-reviewer.md`          | Architectural review     | No          | Cross-cutting concerns, scalability, design pattern review          |
+| `.agents/agents/backend-public-api-reviewer.md` | Backend API review       | No          | New/changed Convex methods, service methods, provider ports         |
+| `.agents/agents/code-reviewer-frontend.md`      | Frontend code review     | No          | React/TanStack pattern review                                       |
+| `.agents/agents/code-reviewer-backend.md`       | Backend code review      | No          | Convex pattern review                                               |
 
 **Require plan approval** for the Architect role — if the design is wrong, everything downstream is wasted work.
 

--- a/.claude/skills/backend-domain-architecture
+++ b/.claude/skills/backend-domain-architecture
@@ -1,0 +1,1 @@
+../../.agents/skills/backend-domain-architecture


### PR DESCRIPTION
## Summary

Adds a Scrollect-specific backend architecture skill so future agents have a reusable quality gate for domain boundaries, Convex orchestration, pure logic extraction, provider ports, service contexts, DI, SOLID, DRY, and YAGNI.

Closes #224

## Changes

- Adds `.agents/skills/backend-domain-architecture/SKILL.md` with tightened trigger metadata, mandatory preparation, companion skill guidance, architecture scoring, placement decision tree, implementation/review flows, and Scrollect-specific design rules.
- Adds bundled references for an architecture review rubric and current Scrollect backend pattern examples.
- Adds the `.claude/skills/backend-domain-architecture` symlink so the skill is available through the project skill convention.

## Testing

- [x] `bun run check`
- [x] `bun turbo run test`
- [x] `bun turbo run build`
- [x] Architect reviewer second pass: zero findings
- [x] Skill-creator quality reviewer second pass: zero findings