### PR TITLE
feat(web): editorial UI polish pass across landing, app, and detail p…

### DIFF
--- a/apps/e2e/tests/billing.spec.ts
+++ b/apps/e2e/tests/billing.spec.ts
@@ -52,13 +52,16 @@ test.describe("Free-tier billing UX", () => {
     page,
   }) => {
     await expect(page).toHaveURL(APP_SUCCESS_URL);
-    await expect(page.getByText(/welcome to scrollect/i)).toBeVisible();
+    const wizard = page.getByTestId("onboarding-wizard");
+    await expect(wizard).toBeVisible();
+    await expect(wizard.getByText(/welcome to scrollect/i)).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: /turn something you've read into posts/i }),
+      wizard.getByRole("heading", { name: /turn something you['’]ve read\s+into posts/i }),
     ).toBeVisible();
-    await expect(page.getByText("Add content")).toBeVisible();
-    await expect(page.getByText("AI generates posts")).toBeVisible();
-    await expect(page.getByText("Scroll your feed")).toBeVisible();
+    await expect(wizard.getByText("Add content")).toBeVisible();
+    await expect(wizard.getByRole("link", { name: /upload a file/i })).toBeVisible();
+    await expect(wizard.getByRole("link", { name: /paste a url/i })).toBeVisible();
+    await expect(wizard.getByRole("link", { name: /paste text/i })).toBeVisible();
   });
 
   test("Settings shows free-tier usage meter and upgrade dialog opens on CTA", async ({ page }) => {

--- a/apps/e2e/tests/bookmarked-posts-section.spec.ts
+++ b/apps/e2e/tests/bookmarked-posts-section.spec.ts
@@ -15,7 +15,9 @@ async function bookmarkFirstPostAndNavigateToDocument(page: Page) {
   // reliably reach the article's onClick.
   await firstPost.locator('[data-testid="source-badge"]').click();
 
-  const libraryLink = page.getByRole("link", { name: /view in library/i });
+  const detailPanel = page.locator('[data-testid="feed-detail-panel"]');
+  await expect(detailPanel).toBeVisible({ timeout: 10000 });
+  const libraryLink = detailPanel.getByRole("link", { name: /^library$/i });
   await expect(libraryLink).toBeVisible({ timeout: 10000 });
   await libraryLink.click();
 

--- a/apps/e2e/tests/connection-discovery.spec.ts
+++ b/apps/e2e/tests/connection-discovery.spec.ts
@@ -12,7 +12,7 @@ import {
 async function uploadMarkdownFile(page: import("@playwright/test").Page, filename: string) {
   await page.goto("/app/upload");
   await page.waitForLoadState("networkidle");
-  await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
   await page.locator('input[type="file"]').setInputFiles(path.join(FIXTURES_DIR, filename));
   await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 30000 });
   await skipLearningGoalPrompt(page);

--- a/apps/e2e/tests/connection-posts.spec.ts
+++ b/apps/e2e/tests/connection-posts.spec.ts
@@ -24,26 +24,32 @@ test.describe("Connection card rendering (seeded)", { tag: "@seeded" }, () => {
     await expect(connectionCard).toBeVisible({ timeout: 15000 });
   });
 
-  test("connection card shows provenance line with both source titles", async ({ page }) => {
+  test("connection card shows both source titles in the source A/B grid", async ({ page }) => {
     const card = page.locator(cardOfType("connection")).first();
     await expect(card).toBeVisible();
 
-    const provenance = card.locator('[data-testid="connection-provenance"]');
-    await expect(provenance).toBeVisible();
-    await expect(provenance).toContainText("Connecting:");
-    await expect(provenance).toContainText("E2E Seed Document");
-    await expect(provenance).toContainText("E2E Seed Document 2");
+    const sourceA = card.locator('[data-testid="connection-source-a"]');
+    const sourceB = card.locator('[data-testid="connection-source-b"]');
+    await expect(sourceA).toBeVisible();
+    await expect(sourceB).toBeVisible();
+
+    const sourceATitle = (await sourceA.textContent())?.trim() ?? "";
+    const sourceBTitle = (await sourceB.textContent())?.trim() ?? "";
+    const titles = new Set([sourceATitle, sourceBTitle]);
+    expect(titles.has("E2E Seed Document")).toBe(true);
+    expect(titles.has("E2E Seed Document 2")).toBe(true);
   });
 
-  test("connection card header badge shows cross-source label with icon", async ({ page }) => {
+  test("connection card shows source A/B labels with an arrow icon", async ({ page }) => {
     const card = page.locator(cardOfType("connection")).first();
     await expect(card).toBeVisible();
 
-    const header = card.locator('[data-testid="connection-header"]');
-    await expect(header).toBeVisible();
-    await expect(header).toContainText(/Cross-source|Cross-section/);
+    const content = card.locator('[data-testid="connection-content"]');
+    await expect(content).toContainText("Source A");
+    await expect(content).toContainText("Source B");
 
-    const icon = header.locator("svg");
+    // The ArrowLeftRight lucide icon is rendered between the two source blocks
+    const icon = content.locator("svg.lucide-arrow-left-right");
     await expect(icon).toBeVisible();
   });
 
@@ -67,25 +73,19 @@ test.describe("Connection card rendering (seeded)", { tag: "@seeded" }, () => {
     await expect(card.locator('[data-testid="save-button"]')).toBeVisible();
   });
 
-  test("connection card has visual distinction (violet accent, no standard source badge)", async ({
-    page,
-  }) => {
+  test("connection card has visual distinction via the source A/B grid", async ({ page }) => {
     const card = page.locator(cardOfType("connection")).first();
     await expect(card).toBeVisible();
 
     const insightCard = page.locator(cardOfType("insight")).first();
     await expect(insightCard).toBeVisible();
 
-    // Connection card uses connection-header + connection-provenance, not source-badge
-    const connectionHeader = card.locator('[data-testid="connection-header"]');
-    const connectionProvenance = card.locator('[data-testid="connection-provenance"]');
-    const insightBadge = insightCard.locator('[data-testid="source-badge"]');
-    await expect(connectionHeader).toBeVisible();
-    await expect(connectionProvenance).toBeVisible();
-    await expect(insightBadge).toBeVisible();
-
-    // Connection card should NOT have the standard source-badge
-    await expect(card.locator('[data-testid="source-badge"]')).not.toBeVisible();
+    // Connection cards render a dedicated source A/B grid alongside the standard
+    // source-badge footer. Insight cards render only the standard source-badge.
+    await expect(card.locator('[data-testid="connection-source-a"]')).toBeVisible();
+    await expect(card.locator('[data-testid="connection-source-b"]')).toBeVisible();
+    await expect(insightCard.locator('[data-testid="connection-source-a"]')).toHaveCount(0);
+    await expect(insightCard.locator('[data-testid="source-badge"]')).toBeVisible();
   });
 
   test("expand sheet is removed from connection cards", async ({ page }) => {

--- a/apps/e2e/tests/document-deletion.spec.ts
+++ b/apps/e2e/tests/document-deletion.spec.ts
@@ -20,7 +20,7 @@ test.describe("Document deletion", () => {
   test("user can delete a document and it no longer appears in library", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
     await page.locator('input[type="file"]').setInputFiles(path.join(FIXTURES_DIR, "test.md"));
     await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 30000 });

--- a/apps/e2e/tests/epub-upload.spec.ts
+++ b/apps/e2e/tests/epub-upload.spec.ts
@@ -20,7 +20,7 @@ test.describe("EPUB file upload", () => {
   test("user can upload an EPUB file and sees success message", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
     await page
       .locator('[data-testid="file-input"]')
@@ -33,7 +33,7 @@ test.describe("EPUB file upload", () => {
   test("EPUB document reaches ready status and produces chunks", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
     await page
       .locator('[data-testid="file-input"]')

--- a/apps/e2e/tests/feed-document-scope.spec.ts
+++ b/apps/e2e/tests/feed-document-scope.spec.ts
@@ -29,7 +29,9 @@ test.describe("Feed: document scope", { tag: "@seeded" }, () => {
     await expect(documentItem).toBeVisible({ timeout: 15_000 });
     await documentItem.click();
 
-    await page.getByRole("link", { name: /open feed for this document/i }).click();
+    const detailPanel = page.locator('[data-testid="library-detail-panel"]');
+    await expect(detailPanel).toBeVisible({ timeout: 15_000 });
+    await detailPanel.getByRole("link", { name: /open in feed/i }).click();
 
     await expect(page).toHaveURL(/\/app\/feed\?documentId=.+/, { timeout: 15_000 });
     await expect(page.locator('[data-testid="feed-scope-banner"]')).toContainText(

--- a/apps/e2e/tests/feed-interactions.spec.ts
+++ b/apps/e2e/tests/feed-interactions.spec.ts
@@ -85,12 +85,9 @@ test.describe("Feed interactions and pagination", { tag: "@seeded" }, () => {
     await expect(page.locator('[data-testid="post-card"]').first()).toBeVisible();
 
     const endState = page.locator('[data-testid="feed-end-state"]');
-    const feedScroller = page.locator('[data-testid="app-main-scroll"]');
     for (let i = 0; i < 10; i++) {
       const cardCountBefore = await page.locator('[data-testid="post-card"]').count();
-      await feedScroller.evaluate((el) => {
-        el.scrollTop = el.scrollHeight;
-      });
+      await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
       if (await endState.isVisible()) break;
       // Wait for either new content to load (card count increases) or end state to appear
       await Promise.race([
@@ -118,12 +115,28 @@ test.describe("Feed interactions and pagination", { tag: "@seeded" }, () => {
     await page.goto("/app/feed?noAutoGenerate");
     await expect(page.locator('[data-testid="post-card"]').first()).toBeVisible();
 
+    const main = page.locator('[data-testid="app-main-scroll"]');
+    const panel = page.locator('[data-testid="feed-detail-panel"]');
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText("Select a post");
+    await expect
+      .poll(() => main.evaluate((el) => getComputedStyle(el).borderRightWidth))
+      .toBe("0px");
+    await expect
+      .poll(() => panel.evaluate((el) => getComputedStyle(el).borderLeftWidth))
+      .toBe("1px");
+
     await page
       .locator('[data-testid="post-card"]')
       .first()
       .locator('[data-testid="source-badge"]')
       .click();
-    await expect(page.locator('[data-testid="feed-detail-panel"]')).toBeVisible();
+
+    await expect(panel).toBeVisible();
+    await expect(panel).not.toContainText("Select a post");
+    await expect
+      .poll(() => panel.evaluate((el) => getComputedStyle(el).borderLeftWidth))
+      .toBe("1px");
 
     const horizontalOverflow = await page.evaluate(() => {
       const root = document.documentElement;
@@ -134,7 +147,23 @@ test.describe("Feed interactions and pagination", { tag: "@seeded" }, () => {
     expect(horizontalOverflow).toBeLessThanOrEqual(1);
   });
 
-  test("desktop detail panel stays fixed while the feed column scrolls", async ({ page }) => {
+  test("saved page keeps the desktop detail placeholder rail", async ({ page }) => {
+    await page.setViewportSize({ width: 1536, height: 864 });
+    await page.goto("/app/saved");
+
+    const main = page.locator('[data-testid="app-main-scroll"]');
+    const panel = page.locator('[data-testid="feed-detail-panel"]');
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText("Select a post");
+    await expect
+      .poll(() => main.evaluate((el) => getComputedStyle(el).borderRightWidth))
+      .toBe("0px");
+    await expect
+      .poll(() => panel.evaluate((el) => getComputedStyle(el).borderLeftWidth))
+      .toBe("1px");
+  });
+
+  test("desktop detail panel stays fixed while the browser page scrolls", async ({ page }) => {
     await page.setViewportSize({ width: 1536, height: 864 });
     await page.goto("/app/feed?noAutoGenerate");
     await expect(page.locator('[data-testid="post-card"]').first()).toBeVisible();
@@ -146,17 +175,13 @@ test.describe("Feed interactions and pagination", { tag: "@seeded" }, () => {
       .click();
 
     const panel = page.locator('[data-testid="feed-detail-panel"]');
-    const feedScroller = page.locator('[data-testid="app-main-scroll"]');
     await expect(panel).toBeVisible();
-    await expect(feedScroller).toBeVisible();
 
     const initialPanelBox = await panel.boundingBox();
     expect(initialPanelBox).not.toBeNull();
 
-    await feedScroller.evaluate((el) => {
-      el.scrollTop = el.scrollHeight;
-    });
-    await expect.poll(() => feedScroller.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
 
     const scrolledPanelBox = await panel.boundingBox();
     expect(scrolledPanelBox).not.toBeNull();
@@ -167,7 +192,6 @@ test.describe("Feed interactions and pagination", { tag: "@seeded" }, () => {
     expect(
       Math.abs(scrolledPanelBox!.height - (viewport!.height - initialPanelBox!.y)),
     ).toBeLessThanOrEqual(1);
-    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
   });
 
   test("empty state shows when no posts exist", async ({ page }) => {

--- a/apps/e2e/tests/feed-serving.spec.ts
+++ b/apps/e2e/tests/feed-serving.spec.ts
@@ -43,12 +43,9 @@ test.describe("Feed serving performance", { tag: "@seeded" }, () => {
 
     // Scroll to the bottom to trigger infinite scroll / exhaustion
     const endState = page.locator('[data-testid="feed-end-state"]');
-    const feedScroller = page.locator('[data-testid="app-main-scroll"]');
     for (let i = 0; i < 10; i++) {
       const cardCountBefore = await cards.count();
-      await feedScroller.evaluate((el) => {
-        el.scrollTop = el.scrollHeight;
-      });
+      await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
       if (await endState.isVisible()) break;
       await Promise.race([
         endState.waitFor({ state: "visible", timeout: 3000 }).catch(() => {}),

--- a/apps/e2e/tests/freshness.spec.ts
+++ b/apps/e2e/tests/freshness.spec.ts
@@ -4,8 +4,9 @@ import { SEEDED_USER, resetTestData, signInToSeededFeed } from "./helpers";
 
 const CARD = '[data-testid="post-card"]';
 const NEW_BADGE = '[data-testid="new-badge"]';
+const UNREAD_BANNER = '[data-testid="feed-new-posts-banner"]';
 
-test.describe("Freshness badge on feed cards", { tag: "@seeded" }, () => {
+test.describe("Unread generated posts on feed", { tag: "@seeded" }, () => {
   test.setTimeout(60000);
 
   test.beforeEach(async ({ page }) => {
@@ -16,37 +17,37 @@ test.describe("Freshness badge on feed cards", { tag: "@seeded" }, () => {
     await resetTestData(SEEDED_USER.email);
   });
 
-  test("cards from recently uploaded documents display a New badge", async ({ page }) => {
+  test("new batch affordance jumps to unread posts and clears after viewing", async ({ page }) => {
     const cards = page.locator(CARD);
     await expect(cards.first()).toBeVisible({ timeout: 15000 });
-
-    const badgeCount = await page.locator(NEW_BADGE).count();
-    expect(badgeCount).toBeGreaterThan(0);
-  });
-
-  test("New badge contains the text New and is visible", async ({ page }) => {
-    const badge = page.locator(NEW_BADGE).first();
-    await expect(badge).toBeVisible({ timeout: 15000 });
-    await expect(badge).toContainText("New");
-  });
-
-  test("New badge is rendered inside a post card", async ({ page }) => {
-    const firstBadge = page.locator(NEW_BADGE).first();
-    await expect(firstBadge).toBeVisible({ timeout: 15000 });
-
-    const parentCard = firstBadge.locator(`xpath=ancestor::article[@data-testid="post-card"]`);
-    await expect(parentCard).toBeVisible();
-  });
-
-  test("all seeded cards have New badges since documents were just created", async ({ page }) => {
-    const cards = page.locator(CARD);
-    await expect(cards.first()).toBeVisible({ timeout: 15000 });
-
     const totalCards = await cards.count();
-    const totalBadges = await page.locator(NEW_BADGE).count();
+    expect(totalCards).toBeGreaterThan(1);
 
-    // All seeded documents were created moments ago (within 48h), so every card
-    // from those documents should carry a "New" badge.
-    expect(totalBadges).toBe(totalCards);
+    const unreadCard = cards.nth(totalCards - 1);
+    const unreadPostId = await unreadCard.getAttribute("data-post-id");
+    expect(unreadPostId).toBeTruthy();
+
+    await page.evaluate((postId) => {
+      window.scrollTo(0, 0);
+      window.localStorage.setItem(
+        "scrollect.feed.unreadPostBatches.v1",
+        JSON.stringify({
+          all: {
+            postIds: [postId],
+            createdAt: Date.now(),
+          },
+        }),
+      );
+    }, unreadPostId);
+
+    await page.reload();
+
+    await expect(page.locator(UNREAD_BANNER)).toBeVisible({ timeout: 15000 });
+    await expect(page.locator(UNREAD_BANNER)).toContainText("1 new post");
+    await expect(page.locator(NEW_BADGE)).toHaveCount(1);
+
+    await page.locator('[data-testid="feed-jump-to-new-posts"]').click();
+    await expect(page.locator(UNREAD_BANNER)).toBeHidden({ timeout: 5000 });
+    await expect(page.locator(NEW_BADGE)).toHaveCount(0);
   });
 });

--- a/apps/e2e/tests/helpers.ts
+++ b/apps/e2e/tests/helpers.ts
@@ -79,7 +79,8 @@ export async function seedEarlyAdopterGrant(email: string) {
   }
 }
 
-export async function cleanupTestData(email: string) {
+export async function cleanupTestData(email: string | undefined) {
+  if (!email) return;
   try {
     const { ok, status, body } = await convexE2ERequest("/api/e2e-cleanup", email);
     if (!ok) {
@@ -114,7 +115,7 @@ export async function signUp(page: Page): Promise<{ email: string }> {
   await page.goto("/signin");
   await page.waitForLoadState("networkidle");
   await dismissCookieConsent(page);
-  await page.getByRole("button", { name: /sign up/i }).click();
+  await page.getByRole("button", { name: /create an account/i }).click();
   await page.getByLabel("Name").fill(user.name);
   await page.getByLabel("Email").fill(user.email);
   await page.getByLabel("Password").fill(user.password);

--- a/apps/e2e/tests/multi-type-posts.spec.ts
+++ b/apps/e2e/tests/multi-type-posts.spec.ts
@@ -115,30 +115,42 @@ test.describe("Multi-type cards and source provenance", { tag: "@seeded" }, () =
   });
 
   test.describe("Source provenance", () => {
-    test("every card has a source badge or connection provenance", async ({ page }) => {
+    test("every card has a source badge and connection cards also have the A/B source grid", async ({
+      page,
+    }) => {
       const cards = page.locator(CARD);
       const count = await cards.count();
 
       for (let i = 0; i < count; i++) {
         const card = cards.nth(i);
+        await expect(card.locator('[data-testid="source-badge"]')).toBeVisible({ timeout: 5000 });
         const type = await card.getAttribute("data-post-type");
-        // Connection cards use a provenance line instead of the standard source-badge
-        const selector =
-          type === "connection"
-            ? '[data-testid="connection-provenance"]'
-            : '[data-testid="source-badge"]';
-        await expect(card.locator(selector)).toBeVisible({ timeout: 5000 });
+        if (type === "connection") {
+          await expect(card.locator('[data-testid="connection-source-a"]')).toBeVisible({
+            timeout: 5000,
+          });
+          await expect(card.locator('[data-testid="connection-source-b"]')).toBeVisible({
+            timeout: 5000,
+          });
+        }
       }
     });
 
-    test("connection card provenance contains both document titles", async ({ page }) => {
+    test("connection card source grid contains both document titles", async ({ page }) => {
       const card = page.locator(cardOfType("connection")).first();
       await expect(card).toBeVisible();
 
-      const provenance = card.locator('[data-testid="connection-provenance"]');
-      await expect(provenance).toBeVisible();
-      await expect(provenance).toContainText("E2E Seed Document");
-      await expect(provenance).toContainText("E2E Seed Document 2");
+      const sourceA = card.locator('[data-testid="connection-source-a"]');
+      const sourceB = card.locator('[data-testid="connection-source-b"]');
+      await expect(sourceA).toBeVisible();
+      await expect(sourceB).toBeVisible();
+
+      const titles = new Set([
+        (await sourceA.textContent())?.trim() ?? "",
+        (await sourceB.textContent())?.trim() ?? "",
+      ]);
+      expect(titles.has("E2E Seed Document")).toBe(true);
+      expect(titles.has("E2E Seed Document 2")).toBe(true);
     });
   });
 });

--- a/apps/e2e/tests/source-provenance.spec.ts
+++ b/apps/e2e/tests/source-provenance.spec.ts
@@ -29,7 +29,9 @@ test.describe("Source provenance on feed cards", { tag: "@seeded" }, () => {
     // answer buttons that stopPropagation on clicks in their area).
     await firstCard.locator('[data-testid="source-badge"]').click();
 
-    const libraryLink = page.getByRole("link", { name: /view in library/i });
+    const detailPanel = page.locator('[data-testid="feed-detail-panel"]');
+    await expect(detailPanel).toBeVisible({ timeout: 5000 });
+    const libraryLink = detailPanel.getByRole("link", { name: /^library$/i });
     await expect(libraryLink).toBeVisible({ timeout: 5000 });
 
     await libraryLink.click();

--- a/apps/e2e/tests/tagging.spec.ts
+++ b/apps/e2e/tests/tagging.spec.ts
@@ -115,7 +115,9 @@ test.describe(
       });
       await page.locator('[data-testid="tag-option-existing-tag-test"]').click();
       await expect(
-        page.locator('[data-testid="tag-badge-existing-tag-test"][data-tag-source="manual"]'),
+        page
+          .locator('[data-testid="document-tag-section"]')
+          .locator('[data-testid="tag-badge-existing-tag-test"][data-tag-source="manual"]'),
       ).toBeVisible({ timeout: 10000 });
     });
 
@@ -327,26 +329,30 @@ test.describe("Tagging — library filtering (seeded account)", { tag: "@seeded"
     expect(resetCount).toBe(totalCount);
   });
 
-  // P0-11: Document cards show max 2 tags + "+N" overflow
-  test("library document cards show max 2 tags with overflow indicator", async ({ page }) => {
+  // P0-11: Document cards show a capped tag list with overflow indicator when needed
+  test("library document cards cap visible tags at maxVisible with overflow indicator", async ({
+    page,
+  }) => {
     await page.goto("/app/library");
     await page.waitForLoadState("networkidle");
 
     const docCard = page.locator('[data-testid="document-item"]').first();
     await expect(docCard).toBeVisible({ timeout: 10000 });
 
-    // Seeded doc 1 has 3 tags, doc 2 has 3 tags — at least one should show tag-list
     const tagList = docCard.locator('[data-testid="tag-list"]');
     await expect(tagList).toBeVisible({ timeout: 10000 });
 
     const cardTags = tagList.locator('[data-testid^="tag-badge-"]');
     const visibleTagCount = await cardTags.count();
-    expect(visibleTagCount).toBeLessThanOrEqual(2);
+    expect(visibleTagCount).toBeLessThanOrEqual(3);
+    expect(visibleTagCount).toBeGreaterThan(0);
 
-    // With 3 tags and maxVisible=2, overflow should show "+1"
+    // Overflow indicator only renders when the source document has more tags
+    // than the list's maxVisible cap. Accept either state.
     const overflow = tagList.locator('[data-testid="tag-overflow"]');
-    await expect(overflow).toBeVisible();
-    await expect(overflow).toContainText(/\+\d+/);
+    if ((await overflow.count()) > 0) {
+      await expect(overflow).toContainText(/\+\d+/);
+    }
   });
 });
 

--- a/apps/e2e/tests/upload-and-library.spec.ts
+++ b/apps/e2e/tests/upload-and-library.spec.ts
@@ -5,6 +5,7 @@ import {
   FIXTURES_DIR,
   SEEDED_USER,
   cleanupTestData,
+  reseedAccount,
   resetTestData,
   signUp,
   skipLearningGoalPrompt,
@@ -30,13 +31,13 @@ test.describe("Upload and Content Library flow", () => {
       .getByRole("link", { name: /upload/i })
       .click();
     await expect(page).toHaveURL(/\/upload/);
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
   });
 
   test("user can upload a Markdown file and sees success message", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
     await page.locator('input[type="file"]').setInputFiles(path.join(FIXTURES_DIR, "test.md"));
 
@@ -50,7 +51,7 @@ test.describe("Upload and Content Library flow", () => {
   }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
     await page
       .locator('[data-testid="file-input"]')
@@ -91,7 +92,7 @@ test.describe("Upload and Content Library flow", () => {
   test("after upload, user can skip the learning goal prompt", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
     await page
       .locator('[data-testid="file-input"]')
@@ -127,7 +128,7 @@ test.describe("Upload and Content Library flow", () => {
   test("multiple uploads queue a learning goal choice for each document", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
     await page.locator('[data-testid="file-input"]').setInputFiles([
       {
@@ -157,7 +158,7 @@ test.describe("Upload and Content Library flow", () => {
   test("after upload, document appears in library with correct title", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
     await page.locator('input[type="file"]').setInputFiles(path.join(FIXTURES_DIR, "test.md"));
     await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 30000 });
     await skipLearningGoalPrompt(page);
@@ -173,7 +174,7 @@ test.describe("Upload and Content Library flow", () => {
   test("clicking a document in library navigates to detail page", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
     await page.locator('input[type="file"]').setInputFiles(path.join(FIXTURES_DIR, "test.md"));
     await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 30000 });
     await skipLearningGoalPrompt(page);
@@ -208,7 +209,7 @@ test.describe("Upload and Content Library flow", () => {
   test("document detail page shows title and status after processing", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
     await page.locator('input[type="file"]').setInputFiles(path.join(FIXTURES_DIR, "test.md"));
     await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 30000 });
     await skipLearningGoalPrompt(page);
@@ -230,7 +231,7 @@ test.describe("Upload and Content Library flow", () => {
   test("upload page rejects unsupported file types", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
     await page.locator('input[type="file"]').setInputFiles({
       name: "invalid.txt",
@@ -253,7 +254,7 @@ test.describe("File upload size validation", { tag: "@seeded" }, () => {
   test("oversized markdown file shows error toast", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
     // Use markdown (5MB limit) instead of PDF (50MB limit) to stay under
     // Playwright's 50MB in-memory buffer cap for setInputFiles
@@ -271,7 +272,7 @@ test.describe("File upload size validation", { tag: "@seeded" }, () => {
   test("empty file shows error toast", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
     await page.locator('[data-testid="file-input"]').setInputFiles({
       name: "empty.md",
@@ -287,13 +288,58 @@ test.describe("File upload size validation", { tag: "@seeded" }, () => {
   test("upload help text displays accepted types and size limits", async ({ page }) => {
     await page.goto("/app/upload");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
-    const helpText = page.locator('[data-testid="file-drop-zone"]').getByText(/accepts/i);
-    await expect(helpText).toBeVisible();
-    await expect(helpText).toContainText(
-      /Accepts \.pdf \(max \d+\.\d MB\), \.epub \(max \d+\.\d MB\), and \.md \(max \d+\.\d MB\)/,
-    );
+    const dropZone = page.locator('[data-testid="file-drop-zone"]');
+    await expect(dropZone).toBeVisible();
+    await expect(dropZone).toContainText(".pdf");
+    await expect(dropZone).toContainText(".epub");
+    await expect(dropZone).toContainText(".md");
+    await expect(dropZone).toContainText(/\d+(\.\d+)?\s*MB/);
+  });
+});
+
+test.describe("Library desktop layout", { tag: "@seeded" }, () => {
+  test.beforeEach(async () => {
+    await reseedAccount();
+  });
+
+  test.afterEach(async () => {
+    await resetTestData(SEEDED_USER.email);
+  });
+
+  test("right detail divider is a single collapsed border", async ({ page }) => {
+    await page.setViewportSize({ width: 1536, height: 864 });
+    await page.goto("/app/library");
+
+    const main = page.locator('[data-testid="app-main-scroll"]');
+    const panel = page.locator('[data-testid="library-detail-panel"]');
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText("Select a document");
+    await expect
+      .poll(() => main.evaluate((el) => getComputedStyle(el).borderRightWidth))
+      .toBe("0px");
+    await expect
+      .poll(() => panel.evaluate((el) => getComputedStyle(el).borderLeftWidth))
+      .toBe("1px");
+
+    const docButton = page.locator('[data-testid="document-item"]').first();
+    await expect(docButton).toBeVisible({ timeout: 15000 });
+    await docButton.click();
+
+    await expect(panel).toBeVisible();
+    await expect(panel).not.toContainText("Select a document");
+    await expect
+      .poll(() => panel.evaluate((el) => getComputedStyle(el).borderLeftWidth))
+      .toBe("1px");
+
+    const horizontalOverflow = await page.evaluate(() => {
+      const root = document.documentElement;
+      const body = document.body;
+      return Math.max(root.scrollWidth, body.scrollWidth) - root.clientWidth;
+    });
+
+    expect(horizontalOverflow).toBeLessThanOrEqual(1);
   });
 });
 

--- a/apps/e2e/tests/url-ingestion.spec.ts
+++ b/apps/e2e/tests/url-ingestion.spec.ts
@@ -29,7 +29,7 @@ test.describe(
     }) => {
       await page.goto("/app/upload");
       await page.waitForLoadState("networkidle");
-      await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+      await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
       // All three tabs should be visible
       await expect(page.getByRole("tab", { name: /upload file/i })).toBeVisible();
@@ -46,7 +46,7 @@ test.describe(
     test("switching tabs shows the correct content panel", async ({ page }) => {
       await page.goto("/app/upload");
       await page.waitForLoadState("networkidle");
-      await expect(page.getByRole("heading", { name: /upload content/i })).toBeVisible();
+      await expect(page.getByRole("heading", { name: /^upload$/i })).toBeVisible();
 
       await test.step("switch to Paste URL tab", async () => {
         await page.getByRole("tab", { name: /paste url/i }).click();
@@ -73,7 +73,7 @@ test.describe(
           "aria-selected",
           "true",
         );
-        await expect(page.getByText(/drag & drop/i)).toBeVisible();
+        await expect(page.locator('[data-testid="file-drop-zone"]')).toBeVisible();
       });
     });
   },

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -5,31 +5,43 @@ import {
   Sidebar,
   SidebarContent,
   SidebarGroup,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarSeparator,
 } from "@/components/ui/sidebar";
 
 const navLinks = [
-  { to: "/app/feed" as const, label: "Feed", icon: Rss },
-  { to: "/app/saved" as const, label: "Saved", icon: Bookmark },
-  { to: "/app/library" as const, label: "Library", icon: BookOpen },
-  { to: "/app/upload" as const, label: "Upload", icon: Upload },
-];
+  { to: "/app/feed" as const, label: "Feed", icon: Rss, shortcut: "01" },
+  { to: "/app/saved" as const, label: "Saved", icon: Bookmark, shortcut: "02" },
+  { to: "/app/library" as const, label: "Library", icon: BookOpen, shortcut: "03" },
+  { to: "/app/upload" as const, label: "Upload", icon: Upload, shortcut: "04" },
+] as const;
+
+const menuButtonClassName =
+  "group/nav relative h-10 rounded-none pl-5 pr-3 text-[0.9rem] font-medium " +
+  "before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-[2px] before:bg-transparent before:transition-colors " +
+  "hover:bg-accent/40 " +
+  "data-active:bg-primary/8 data-active:text-primary data-active:before:bg-primary " +
+  "dark:data-active:bg-primary/15 " +
+  "[&_svg]:size-[18px] [&_svg]:text-muted-foreground/80 " +
+  "data-active:[&_svg]:text-primary group-hover/nav:[&_svg]:text-foreground";
+
+const sectionLabelClassName =
+  "px-5 pb-2 font-mono text-[10px] font-medium uppercase tracking-[0.28em] text-muted-foreground/60";
 
 export function AppSidebar() {
   return (
     <Sidebar className="top-14 h-[calc(100svh-3.5rem)]">
-      <SidebarContent>
-        <SidebarGroup className="px-3 pt-6">
-          <SidebarMenu className="gap-1">
-            {navLinks.map(({ to, label, icon: Icon }) => (
+      <SidebarContent className="gap-0">
+        <SidebarGroup className="px-0 pt-6 pb-2">
+          <SidebarGroupLabel className={sectionLabelClassName}>Navigate</SidebarGroupLabel>
+          <SidebarMenu className="gap-0.5 px-2">
+            {navLinks.map(({ to, label, icon: Icon, shortcut }) => (
               <SidebarMenuItem key={to}>
                 <SidebarMenuButton
-                  size="lg"
                   tooltip={label}
-                  className="rounded-lg px-3 text-[0.9rem] font-medium data-active:bg-primary/12 data-active:text-primary dark:data-active:bg-primary/20 [&_svg]:size-5"
+                  className={menuButtonClassName}
                   render={
                     <Link
                       to={to}
@@ -39,20 +51,30 @@ export function AppSidebar() {
                   }
                 >
                   <Icon />
-                  <span>{label}</span>
+                  <span className="flex-1">{label}</span>
+                  <span
+                    aria-hidden
+                    className="font-mono text-[10px] tabular-nums tracking-[0.18em] text-muted-foreground/35 group-data-[collapsible=icon]/sidebar-wrapper:hidden"
+                  >
+                    {shortcut}
+                  </span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
             ))}
           </SidebarMenu>
         </SidebarGroup>
-        <SidebarSeparator className="mx-0" />
-        <SidebarGroup className="px-3">
-          <SidebarMenu className="gap-1">
+
+        <div className="my-3 px-5">
+          <div className="h-px bg-border/70" />
+        </div>
+
+        <SidebarGroup className="px-0 pb-2">
+          <SidebarGroupLabel className={sectionLabelClassName}>Account</SidebarGroupLabel>
+          <SidebarMenu className="gap-0.5 px-2">
             <SidebarMenuItem>
               <SidebarMenuButton
-                size="lg"
                 tooltip="Settings"
-                className="rounded-lg px-3 text-[0.9rem] font-medium data-active:bg-primary/12 data-active:text-primary dark:data-active:bg-primary/20 [&_svg]:size-5"
+                className={menuButtonClassName}
                 render={
                   <Link
                     to="/app/settings"
@@ -62,7 +84,7 @@ export function AppSidebar() {
                 }
               >
                 <Settings />
-                <span>Settings</span>
+                <span className="flex-1">Settings</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/apps/web/src/components/auth/auth-editorial-panel.tsx
+++ b/apps/web/src/components/auth/auth-editorial-panel.tsx
@@ -1,0 +1,74 @@
+import { cn } from "@/lib/utils";
+
+type AuthMode = "signin" | "signup";
+
+const copy = {
+  signin: {
+    eyebrow: "Welcome back",
+    heading: (
+      <>
+        Pick up where your <em className="not-italic text-primary">highlights</em> left off.
+      </>
+    ),
+    body: "Your feed is already waiting. New posts, drawn from the books and articles you saved.",
+  },
+  signup: {
+    eyebrow: "Start remembering",
+    heading: (
+      <>
+        Your <em className="not-italic text-primary">personal</em> learning feed starts here.
+      </>
+    ),
+    body: "Save books, articles, and PDFs. Scrollect turns them into a scrollable feed of bite-sized posts you'll actually remember.",
+  },
+} as const;
+
+export function AuthEditorialPanel({ mode }: { mode: AuthMode }) {
+  const content = copy[mode];
+
+  return (
+    <aside
+      className={cn(
+        "relative flex flex-col justify-between overflow-hidden border-b border-border bg-card",
+        "px-5 py-10 sm:px-8",
+        "md:border-b-0 md:border-r md:py-14",
+        "md:pl-[max(2rem,calc((100vw-64rem)/2))] md:pr-12 lg:pr-16 lg:py-20",
+      )}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -left-24 -top-32 size-72 rounded-full bg-primary/15 blur-3xl md:size-96"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -bottom-40 right-[-10%] hidden size-80 rounded-full bg-primary/[0.06] blur-3xl md:block"
+      />
+
+      <div className="relative z-10 flex items-center gap-2.5 text-muted-foreground">
+        <span aria-hidden className="inline-block size-1.5 rounded-full bg-primary" />
+        <span className="font-mono text-[10px] font-medium uppercase tracking-[0.32em]">
+          {content.eyebrow}
+        </span>
+      </div>
+
+      <div
+        key={mode}
+        className="relative z-10 mt-8 max-w-xl animate-in fade-in slide-in-from-bottom-2 duration-500 md:mt-0"
+      >
+        <h2 className="font-logo text-4xl font-semibold leading-[1.02] tracking-[-0.02em] text-balance sm:text-5xl md:text-[3.25rem] md:leading-[1.02] lg:text-[3.75rem] lg:leading-[1]">
+          {content.heading}
+        </h2>
+        <p className="mt-5 max-w-md text-base leading-relaxed text-muted-foreground text-pretty md:mt-6 md:text-lg md:leading-[1.55]">
+          {content.body}
+        </p>
+      </div>
+
+      <div className="relative z-10 mt-10 hidden flex-col gap-4 md:flex">
+        <div className="h-px w-16 bg-border" />
+        <span className="font-mono text-[10px] font-medium uppercase tracking-[0.28em] text-muted-foreground/70">
+          Free during beta · No credit card
+        </span>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/billing/document-usage-meter.tsx
+++ b/apps/web/src/components/billing/document-usage-meter.tsx
@@ -39,16 +39,17 @@ export function DocumentUsageMeter({
 
   if (variant === "compact") {
     return (
-      <div className="flex flex-wrap items-center gap-3 text-xs">
-        <div className="flex items-center gap-2">
-          <span className="font-mono tabular-nums text-foreground">
-            {used} / {limit}
+      <div className="flex flex-col items-start gap-1.5 md:items-end">
+        <div className="flex items-baseline gap-2">
+          <span className="font-mono text-sm font-medium tabular-nums text-foreground">
+            {used}
+            <span className="text-muted-foreground/50"> / {limit}</span>
           </span>
-          <span className="text-muted-foreground">
-            documents {tier === "pro" ? "this cycle" : "used"}
+          <span className="font-mono text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+            {tier === "pro" ? "This cycle" : "Used"}
           </span>
         </div>
-        <div className="h-1.5 w-24 overflow-hidden bg-muted" aria-hidden>
+        <div className="h-1 w-40 overflow-hidden bg-muted" aria-hidden>
           <div
             className={cn("h-full transition-[width] duration-300", barTone)}
             style={{ width: `${percent}%` }}
@@ -58,7 +59,7 @@ export function DocumentUsageMeter({
           <Button
             size="sm"
             variant="outline"
-            className="h-7 border-primary text-primary hover:bg-primary/10"
+            className="mt-1 h-7 border-primary text-primary hover:bg-primary/10"
             onClick={onUpgradeClick}
           >
             Upgrade

--- a/apps/web/src/components/detail-panel.tsx
+++ b/apps/web/src/components/detail-panel.tsx
@@ -1,12 +1,26 @@
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { api } from "@scrollect/backend/convex/_generated/api";
+import { format } from "date-fns";
+import { BookOpen, ExternalLink, Loader2, MousePointerClick, X } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
 import { createContext, useCallback, useContext, useState } from "react";
-import { X } from "lucide-react";
+import Markdown from "react-markdown";
 
+import {
+  DetailRail,
+  DetailRailPlaceholder,
+  DETAIL_RULED_BG_STYLE,
+  RailMarker,
+} from "@/components/detail-rail";
+import { DocumentThumb, FileTypeIcon } from "@/components/documents/document-thumb";
 import { Post } from "@/components/posts";
-import type { PostView } from "@/components/posts/types";
-import { SourceDetailsContent } from "@/components/posts/source-detail-sheet";
+import type { PostType, PostView } from "@/components/posts/types";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@/components/ui/sheet";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
 
 type DetailPanelContextValue = {
   selectedPost: PostView | null;
@@ -44,7 +58,17 @@ export function DetailPanel() {
   if (!ctx) return null;
   const { selectedPost, closeDetail } = ctx;
 
-  if (!selectedPost) return null;
+  if (!selectedPost) {
+    return (
+      <DetailRail testId="feed-detail-panel">
+        <DetailRailPlaceholder
+          icon={MousePointerClick}
+          title="Select a post"
+          description="Click any post in your feed to see its source and context here."
+        />
+      </DetailRail>
+    );
+  }
 
   if (isMobile) {
     return (
@@ -54,7 +78,7 @@ export function DetailPanel() {
           showCloseButton={false}
           className="max-h-[85dvh] overflow-y-auto rounded-t-2xl px-0 pb-[env(safe-area-inset-bottom)]"
         >
-          <div className="mx-auto mb-1 mt-0 h-1 w-10 shrink-0 rounded-full bg-muted-foreground/25" />
+          <div className="mx-auto mt-0 mb-1 h-1 w-10 shrink-0 rounded-full bg-muted-foreground/25" />
           <SheetTitle className="sr-only">Post details</SheetTitle>
           <SheetDescription className="sr-only">Expanded view of learning post.</SheetDescription>
           <div key={selectedPost._id} className="animate-in fade-in duration-200">
@@ -66,36 +90,185 @@ export function DetailPanel() {
   }
 
   return (
-    <aside
-      data-testid="feed-detail-panel"
-      className="hidden h-full min-h-0 min-w-0 overflow-hidden bg-background lg:block"
-    >
+    <DetailRail testId="feed-detail-panel">
       <div className="h-full overflow-y-auto overscroll-contain">
         <div key={selectedPost._id} className="animate-in fade-in slide-in-from-top-2 duration-200">
           <DetailPanelContent post={selectedPost} onClose={closeDetail} />
         </div>
       </div>
-    </aside>
+    </DetailRail>
   );
 }
 
+const postTypeLabel: Record<PostType, string> = {
+  insight: "Insight",
+  quote: "Quote",
+  summary: "Summary",
+  connection: "Connection",
+  quiz: "Quiz",
+};
+
+const postTypeText: Record<PostType, string> = {
+  insight: "text-primary",
+  quote: "text-amber-600 dark:text-amber-400",
+  summary: "text-blue-600 dark:text-blue-400",
+  connection: "text-violet-600 dark:text-violet-400",
+  quiz: "text-emerald-600 dark:text-emerald-400",
+};
+
 function DetailPanelContent({ post, onClose }: { post: PostView; onClose: () => void }) {
+  const hasQuizContent = post.typeData.type === "quiz";
+  const hasMarkdownBody = !hasQuizContent && post.content.trim().length > 0;
+
   return (
-    <div className="flex min-w-0 flex-col gap-4 px-6 py-5">
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-medium text-muted-foreground uppercase">{post.postType}</span>
-        <Button variant="ghost" size="icon" onClick={onClose}>
-          <X className="size-4" />
+    <div className="flex h-full min-w-0 flex-col">
+      <div className="flex items-center justify-between border-b border-dashed border-border px-6 py-4 md:px-7">
+        <div className="flex min-w-0 items-center gap-2 font-mono text-[10.5px] uppercase tracking-[0.16em] text-muted-foreground">
+          <span>Entry</span>
+          <span className="text-foreground/30">&middot;</span>
+          <span className={cn("font-medium", postTypeText[post.postType])}>
+            {postTypeLabel[post.postType]}
+          </span>
+          <span className="text-foreground/30">&middot;</span>
+          <span className="truncate">{format(post.createdAt, "MMM d, yyyy").toUpperCase()}</span>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8 shrink-0 rounded-none"
+          onClick={onClose}
+        >
+          <X className="size-3.5" />
           <span className="sr-only">Close</span>
         </Button>
       </div>
-      <div className="-mx-6 min-w-0 [&_article]:border-0 [&_article]:border-l-0 [&_article]:bg-transparent [&_article]:hover:bg-transparent">
-        <Post post={post} />
+
+      <div
+        className="flex flex-1 flex-col gap-8 overflow-y-auto px-6 py-7 md:px-8"
+        style={DETAIL_RULED_BG_STYLE}
+      >
+        {hasQuizContent ? (
+          <div className="-mx-6 md:-mx-8 [&_article]:border-b-0">
+            <Post post={post} />
+          </div>
+        ) : hasMarkdownBody ? (
+          <div className="prose prose-sm prose-neutral max-w-none font-logo text-[17px] leading-[1.65] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 dark:prose-invert">
+            <Markdown>{post.content}</Markdown>
+          </div>
+        ) : null}
+
+        <SourceMarker post={post} />
       </div>
-      <p className="mb-3 text-xs font-medium tracking-wide text-muted-foreground uppercase">
-        Source
-      </p>
-      <SourceDetailsContent postId={post._id} documentId={post.primarySourceDocumentId} />
     </div>
+  );
+}
+
+function SourceMarker({ post }: { post: PostView }) {
+  const posthog = usePostHog();
+  const { data: details, isPending } = useQuery(
+    convexQuery(api.feed.posts.getSourceDetails, { postId: post._id }),
+  );
+
+  return (
+    <>
+      <RailMarker marker="A">
+        <div className="flex items-start gap-4">
+          <DocumentThumb
+            documentId={post.primarySourceDocumentId as unknown as string}
+            title={post.primarySourceDocumentTitle ?? "Untitled"}
+            fileType={post.fileType}
+            variant="card"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="font-logo text-[16px] font-medium leading-tight tracking-tight">
+              {post.primarySourceDocumentTitle ?? "Untitled"}
+            </div>
+            <div className="mt-1 flex items-center gap-1.5 font-mono text-[11px] tracking-wide text-muted-foreground">
+              <FileTypeIcon fileType={post.fileType} className="size-3 text-muted-foreground/70" />
+              {post.sectionTitle && <span className="truncate">{post.sectionTitle}</span>}
+              {post.pageStart != null && (
+                <>
+                  {post.sectionTitle && <span className="text-foreground/30">&middot;</span>}
+                  <span>
+                    p. {post.pageStart}
+                    {post.pageEnd && post.pageEnd !== post.pageStart ? `-${post.pageEnd}` : ""}
+                  </span>
+                </>
+              )}
+            </div>
+            <div className="mt-3 flex items-center gap-4">
+              <Link
+                to="/app/library/$documentId"
+                params={{ documentId: post.primarySourceDocumentId }}
+                className="inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-primary transition-colors hover:text-primary/80"
+                onClick={() => posthog.capture("source.library_navigated", { postId: post._id })}
+              >
+                <BookOpen className="size-3" />
+                Library
+              </Link>
+              {details?.sourceUrl && (
+                <a
+                  href={details.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-primary transition-colors hover:text-primary/80"
+                  onClick={() => posthog.capture("source.original_opened", { postId: post._id })}
+                >
+                  <ExternalLink className="size-3" />
+                  Original
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
+      </RailMarker>
+
+      {(isPending || details?.sectionSummary) && (
+        <RailMarker marker="B">
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+            Section context
+          </div>
+          {isPending ? (
+            <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin" />
+              Loading context…
+            </div>
+          ) : (
+            <blockquote className="border-l-2 border-amber-500/50 pl-4 font-logo text-[15px] leading-[1.6] text-foreground/90 italic">
+              {details?.sectionSummary}
+            </blockquote>
+          )}
+        </RailMarker>
+      )}
+
+      {details && details.tags.length > 0 && (
+        <RailMarker marker="C">
+          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+            Tags
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {details.tags.map((t) => (
+              <span
+                key={t._id}
+                className="border border-border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-muted-foreground"
+              >
+                #{t.name}
+              </span>
+            ))}
+          </div>
+        </RailMarker>
+      )}
+
+      {details?.learningGoal && (
+        <RailMarker marker="D">
+          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+            Learning goal applied
+          </div>
+          <p className="font-logo text-[14.5px] leading-[1.6] text-foreground/85">
+            {details.learningGoal}
+          </p>
+        </RailMarker>
+      )}
+    </>
   );
 }

--- a/apps/web/src/components/detail-rail.tsx
+++ b/apps/web/src/components/detail-rail.tsx
@@ -1,0 +1,67 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type DetailRailProps = {
+  children: ReactNode;
+  testId: string;
+};
+
+export function DetailRail({ children, testId }: DetailRailProps) {
+  return (
+    <aside
+      data-testid={testId}
+      className="hidden min-w-0 overflow-hidden border-l border-border bg-background lg:fixed lg:right-0 lg:top-14 lg:bottom-0 lg:z-20 lg:block lg:w-[calc((100vw-var(--sidebar-width))*0.4)]"
+    >
+      {children}
+    </aside>
+  );
+}
+
+type DetailRailPlaceholderProps = {
+  description: string;
+  icon: LucideIcon;
+  title: string;
+};
+
+export function DetailRailPlaceholder({
+  description,
+  icon: Icon,
+  title,
+}: DetailRailPlaceholderProps) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center px-6 text-center">
+      <div className="flex size-12 items-center justify-center border border-border">
+        <Icon className="size-5 text-muted-foreground" />
+      </div>
+      <p className="mt-4 text-sm font-medium text-foreground">{title}</p>
+      <p className="mt-1 max-w-[220px] text-xs text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+export const DETAIL_RULED_BG_STYLE: React.CSSProperties = {
+  backgroundImage:
+    "repeating-linear-gradient(0deg, transparent 0, transparent 27px, rgba(125,138,144,0.05) 27px, rgba(125,138,144,0.05) 28px)",
+};
+
+type RailMarkerProps = {
+  marker: string;
+  children: ReactNode;
+  className?: string;
+};
+
+export function RailMarker({ marker, children, className }: RailMarkerProps) {
+  return (
+    <section className={cn("relative pl-6", className)}>
+      <span
+        aria-hidden
+        className="absolute top-0 left-0 font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground/50"
+      >
+        {marker}
+      </span>
+      {children}
+    </section>
+  );
+}

--- a/apps/web/src/components/documents/document-thumb.tsx
+++ b/apps/web/src/components/documents/document-thumb.tsx
@@ -1,0 +1,194 @@
+import { FileCode, FileText, Globe, Video } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type DocumentThumbVariant = "spine" | "card" | "mini" | "hero";
+
+interface DocumentThumbProps {
+  documentId: string;
+  title: string;
+  fileType?: string;
+  variant?: DocumentThumbVariant;
+  className?: string;
+}
+
+export function DocumentThumb({
+  documentId,
+  title,
+  fileType,
+  variant = "spine",
+  className,
+}: DocumentThumbProps) {
+  const hue = hashHue(documentId);
+  const initials = getInitials(title);
+
+  const style: React.CSSProperties = {
+    backgroundImage: `linear-gradient(170deg, hsl(${hue} 40% 22%) 0%, hsl(${hue} 55% 14%) 55%, hsl(${hue} 60% 10%) 100%)`,
+    borderColor: `hsl(${hue} 35% 28%)`,
+    color: `hsl(${hue} 60% 88%)`,
+  };
+
+  const pattern: React.CSSProperties = {
+    backgroundImage: `repeating-linear-gradient(180deg, transparent 0, transparent 5px, hsl(${hue} 20% 70% / 0.14) 5px, hsl(${hue} 20% 70% / 0.14) 6px)`,
+  };
+
+  if (variant === "mini") {
+    return (
+      <span
+        aria-hidden
+        className={cn(
+          "inline-flex h-5 w-4 shrink-0 items-center justify-center border font-logo text-[9px] font-medium leading-none",
+          className,
+        )}
+        style={style}
+      >
+        {initials[0]}
+      </span>
+    );
+  }
+
+  if (variant === "hero") {
+    return (
+      <div
+        className={cn(
+          "relative flex size-full items-center justify-center overflow-hidden border",
+          className,
+        )}
+        style={style}
+        aria-hidden
+      >
+        <div className="absolute inset-0 opacity-40" style={pattern} />
+        <div className="absolute inset-x-6 top-5 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.22em] opacity-70">
+          <span>{fileTypeShort(fileType)}</span>
+          <span>Vol.</span>
+        </div>
+        <span className="relative z-10 font-logo text-[72px] font-semibold leading-none tracking-tight">
+          {initials}
+        </span>
+        <div className="absolute inset-x-6 bottom-5 h-px bg-current opacity-25" />
+      </div>
+    );
+  }
+
+  if (variant === "card") {
+    return (
+      <div
+        className={cn(
+          "relative flex h-20 w-14 shrink-0 flex-col items-center justify-between overflow-hidden border px-1 py-1.5",
+          className,
+        )}
+        style={style}
+        aria-hidden
+      >
+        <span className="font-mono text-[8px] uppercase tracking-[0.14em] opacity-70">
+          {fileTypeShort(fileType)}
+        </span>
+        <span className="font-logo text-[20px] font-semibold leading-none">{initials}</span>
+        <div className="h-[14px] w-full" style={pattern} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "relative flex h-16 w-[18px] shrink-0 flex-col items-center justify-between overflow-hidden border px-[3px] py-1",
+        className,
+      )}
+      style={style}
+      aria-hidden
+      title={title}
+    >
+      <span className="font-logo text-[11px] font-semibold leading-none tracking-tight">
+        {initials[0]}
+      </span>
+      <div className="h-full w-full" style={pattern} />
+      <span className="font-mono text-[7px] uppercase leading-none opacity-70">
+        {fileTypeShort(fileType)}
+      </span>
+    </div>
+  );
+}
+
+export function ReadingProgress({
+  pageStart,
+  totalPages,
+  className,
+}: {
+  pageStart: number | null | undefined;
+  totalPages?: number | null;
+  className?: string;
+}) {
+  if (pageStart == null) return null;
+
+  if (totalPages == null) {
+    return (
+      <span
+        className={cn("font-mono text-[9.5px] tracking-wide text-muted-foreground/70", className)}
+      >
+        p. {pageStart}
+      </span>
+    );
+  }
+
+  const pct = Math.min(100, Math.max(1, Math.round((pageStart / totalPages) * 100)));
+  return (
+    <div
+      className={cn("flex w-24 flex-col gap-1", className)}
+      aria-label={`Page ${pageStart} of ${totalPages}`}
+    >
+      <div className="h-[2px] w-full bg-border">
+        <div className="h-[2px] bg-primary/70" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="flex justify-between font-mono text-[9.5px] tracking-wide text-muted-foreground/70">
+        <span>p. {pageStart}</span>
+        <span>/ {totalPages}</span>
+      </div>
+    </div>
+  );
+}
+
+export function FileTypeIcon({ fileType, className }: { fileType?: string; className?: string }) {
+  const cls = cn("size-3.5 shrink-0", className);
+  switch ((fileType ?? "").toLowerCase()) {
+    case "url":
+    case "article":
+      return <Globe className={cls} />;
+    case "youtube":
+      return <Video className={cls} />;
+    case "markdown":
+    case "md":
+      return <FileCode className={cls} />;
+    default:
+      return <FileText className={cls} />;
+  }
+}
+
+function hashHue(id: string): number {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash) % 360;
+}
+
+function getInitials(title: string): string {
+  const words = title
+    .replace(/[^a-zA-Z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((w) => !/^(the|a|an|of|and|in|on|for)$/i.test(w));
+  if (words.length === 0) return "??";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return (words[0][0] + words[1][0]).toUpperCase();
+}
+
+function fileTypeShort(ft?: string): string {
+  const f = (ft ?? "").toLowerCase();
+  if (f === "youtube") return "YT";
+  if (f === "markdown" || f === "md") return "MD";
+  if (f === "article" || f === "url") return "WEB";
+  if (f === "epub") return "EPB";
+  if (f === "text" || f === "txt") return "TXT";
+  return f.slice(0, 3).toUpperCase();
+}

--- a/apps/web/src/components/feed/unread-posts-banner.tsx
+++ b/apps/web/src/components/feed/unread-posts-banner.tsx
@@ -1,0 +1,53 @@
+import { ArrowDown, Sparkles, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface UnreadPostsBannerProps {
+  count: number;
+  scopeLabel: string;
+  onJump: () => void;
+  onDismiss: () => void;
+}
+
+export function UnreadPostsBanner({
+  count,
+  scopeLabel,
+  onJump,
+  onDismiss,
+}: UnreadPostsBannerProps) {
+  if (count === 0) return null;
+
+  const postLabel = count === 1 ? "post" : "posts";
+
+  return (
+    <div
+      data-testid="feed-new-posts-banner"
+      className="sticky top-0 z-30 border-b border-border bg-background/95 px-4 py-3 backdrop-blur md:px-6"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="flex size-9 shrink-0 items-center justify-center border border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400">
+            <Sparkles className="size-4" />
+          </span>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-foreground">
+              {count} new {postLabel}
+            </p>
+            <p className="truncate text-xs text-muted-foreground">Ready in {scopeLabel}</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button size="sm" onClick={onJump} data-testid="feed-jump-to-new-posts">
+            <ArrowDown className="size-3.5" data-icon="inline-start" />
+            Jump to new posts
+          </Button>
+          <Button variant="ghost" size="sm" onClick={onDismiss} data-testid="feed-stay-here">
+            <X className="size-3.5" data-icon="inline-start" />
+            Stay here
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/bottom-cta-section.tsx
+++ b/apps/web/src/components/landing/bottom-cta-section.tsx
@@ -28,29 +28,35 @@ export function BottomCtaSection() {
       )}
     >
       <div className="mx-auto max-w-5xl">
-        <div className="border border-border bg-card px-6 py-12 text-center md:px-12 md:py-16">
+        <div className="border border-border bg-card px-6 py-14 text-center md:px-12 md:py-20">
+          <div className="mb-6 inline-flex items-center gap-2.5 text-muted-foreground">
+            <span aria-hidden className="inline-block size-1.5 rounded-full bg-primary" />
+            <span className="font-mono text-[10px] font-medium uppercase tracking-[0.32em]">
+              Start today
+            </span>
+          </div>
           <h2
             id="cta-heading"
-            className="text-3xl font-bold tracking-[-0.02em] text-pretty sm:text-4xl"
+            className="font-logo text-4xl font-semibold leading-[1.05] tracking-[-0.015em] text-pretty sm:text-5xl md:text-[3.5rem]"
           >
             Your highlights are fading.
             <br />
-            Start remembering.
+            <em className="not-italic text-primary">Start remembering.</em>
           </h2>
-          <p className="mx-auto mt-4 max-w-md text-muted-foreground">
+          <p className="mx-auto mt-5 max-w-md text-base leading-relaxed text-muted-foreground text-pretty md:text-lg">
             Upload your first document in 30 seconds.
           </p>
           <Button
             size="lg"
             render={<Link to="/signin" />}
-            className="mt-8 border border-primary bg-primary px-8 text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.97]"
+            className="mt-9 border border-primary bg-primary px-8 text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.97]"
             onClick={() => posthog?.capture("landing_cta_clicked", { location: "bottom_cta" })}
           >
             Try Scrollect Free
           </Button>
 
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-            <span className="text-xs text-muted-foreground/60 uppercase tracking-wider">
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-x-3 gap-y-2">
+            <span className="font-mono text-[10px] font-medium uppercase tracking-[0.28em] text-muted-foreground/70">
               Supports
             </span>
             {contentTypes.map(({ icon: Icon, label }) => (

--- a/apps/web/src/components/landing/hero-section.tsx
+++ b/apps/web/src/components/landing/hero-section.tsx
@@ -18,21 +18,25 @@ export function HeroSection() {
     >
       <div className="mx-auto flex w-full max-w-5xl flex-col items-center gap-10 pt-12 md:flex-row md:items-center md:gap-16 md:pt-0">
         <div className="animate-hero-in flex flex-1 flex-col items-center text-center md:items-start md:text-left">
-          <div className="max-w-lg">
-            <div className="mb-4 inline-flex items-center border border-border px-3 py-1 text-xs tracking-widest text-muted-foreground uppercase">
-              AI-powered learning feed
+          <div className="max-w-xl">
+            <div className="mb-5 inline-flex items-center gap-2.5 text-muted-foreground">
+              <span aria-hidden className="inline-block size-1.5 rounded-full bg-primary" />
+              <span className="font-mono text-[10px] font-medium uppercase tracking-[0.32em]">
+                AI Learning Feed
+              </span>
             </div>
             <h1
               id="hero-heading"
-              className="text-5xl font-bold tracking-[-0.03em] text-balance sm:text-6xl md:text-7xl"
+              className="font-logo text-[3.25rem] font-semibold leading-[1] tracking-[-0.02em] text-balance sm:text-6xl md:text-[5.25rem]"
             >
-              Remember <span className="text-primary">everything</span> you read.
+              Remember <em className="not-italic text-primary">everything</em> you read.
             </h1>
-            <p className="mt-5 text-lg leading-relaxed text-muted-foreground text-pretty md:text-xl">
-              AI turns your saved content into a curated learning feed.
+            <p className="mt-6 text-lg leading-relaxed text-muted-foreground text-pretty md:text-xl md:leading-[1.55]">
+              AI turns your saved content into a curated learning feed - bite-sized posts
+              you&apos;ll actually remember.
             </p>
           </div>
-          <div className="mt-8 flex flex-col items-center gap-4 md:items-start">
+          <div className="mt-10 flex flex-col items-center gap-4 md:items-start">
             <Button
               size="lg"
               render={<Link to="/signin" />}
@@ -41,8 +45,8 @@ export function HeroSection() {
             >
               Get Started
             </Button>
-            <span className="text-sm text-muted-foreground">
-              Free during beta. No credit card required.
+            <span className="font-mono text-[11px] uppercase tracking-[0.22em] text-foreground">
+              Free during beta · No credit card
             </span>
             <span className="text-sm text-muted-foreground">
               Already have an account?{" "}

--- a/apps/web/src/components/landing/how-it-works-section.tsx
+++ b/apps/web/src/components/landing/how-it-works-section.tsx
@@ -44,17 +44,20 @@ export function HowItWorksSection() {
       )}
     >
       <div className="mx-auto max-w-5xl">
-        <div className="mb-10 md:mb-12">
-          <span className="mb-3 inline-flex items-center border border-border px-3 py-1 text-xs tracking-widest text-muted-foreground uppercase">
-            How it works
-          </span>
+        <div className="mb-10 md:mb-14">
+          <div className="mb-4 inline-flex items-center gap-2.5 text-muted-foreground">
+            <span aria-hidden className="inline-block size-1.5 rounded-full bg-primary" />
+            <span className="font-mono text-[10px] font-medium uppercase tracking-[0.32em]">
+              How it works
+            </span>
+          </div>
           <h2
             id="how-it-works-heading"
-            className="text-2xl font-bold tracking-[-0.02em] text-pretty sm:text-3xl"
+            className="font-logo text-3xl font-semibold leading-[1.05] tracking-[-0.015em] text-pretty sm:text-4xl md:text-[2.75rem]"
           >
             Three steps from content to retention
           </h2>
-          <p className="mt-2 max-w-lg text-muted-foreground">
+          <p className="mt-4 max-w-lg text-base leading-relaxed text-muted-foreground text-pretty md:text-lg">
             From raw content to lasting knowledge in under a minute - no manual note-taking
             required.
           </p>
@@ -77,8 +80,10 @@ export function HowItWorksSection() {
                   {String(step.number).padStart(2, "0")}
                 </span>
               </div>
-              <h3 className="text-base font-semibold">{step.title}</h3>
-              <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+              <h3 className="font-logo text-xl font-semibold leading-tight tracking-tight">
+                {step.title}
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground text-pretty">
                 {step.description}
               </p>
             </div>

--- a/apps/web/src/components/landing/post-types-section.tsx
+++ b/apps/web/src/components/landing/post-types-section.tsx
@@ -94,17 +94,20 @@ export function PostTypesSection() {
       )}
     >
       <div className="mx-auto max-w-5xl">
-        <div className="mb-10 md:mb-12">
-          <span className="mb-3 inline-flex items-center border border-border px-3 py-1 text-xs tracking-widest text-muted-foreground uppercase">
-            Post types
-          </span>
+        <div className="mb-10 md:mb-14">
+          <div className="mb-4 inline-flex items-center gap-2.5 text-muted-foreground">
+            <span aria-hidden className="inline-block size-1.5 rounded-full bg-primary" />
+            <span className="font-mono text-[10px] font-medium uppercase tracking-[0.32em]">
+              Post types
+            </span>
+          </div>
           <h2
             id="post-types-heading"
-            className="text-2xl font-bold tracking-[-0.02em] text-pretty sm:text-3xl"
+            className="font-logo text-3xl font-semibold leading-[1.05] tracking-[-0.015em] text-pretty sm:text-4xl md:text-[2.75rem]"
           >
             Five ways to learn from every document
           </h2>
-          <p className="mt-2 max-w-lg text-muted-foreground">
+          <p className="mt-4 max-w-lg text-base leading-relaxed text-muted-foreground text-pretty md:text-lg">
             Each post type reinforces knowledge differently - from active recall quizzes to
             cross-document connections.
           </p>
@@ -152,7 +155,7 @@ export function PostTypesSection() {
                   <div className="min-w-0">
                     <span
                       className={cn(
-                        "text-sm font-semibold transition-colors duration-150",
+                        "font-logo text-lg font-semibold leading-tight tracking-tight transition-colors duration-150",
                         isActive ? "text-foreground" : "text-foreground/80",
                       )}
                     >
@@ -160,7 +163,7 @@ export function PostTypesSection() {
                     </span>
                     <p
                       className={cn(
-                        "mt-0.5 text-sm transition-colors duration-150",
+                        "mt-1 text-sm leading-relaxed transition-colors duration-150 text-pretty",
                         isActive ? "text-muted-foreground" : "text-muted-foreground/60",
                       )}
                     >

--- a/apps/web/src/components/landing/preview-posts.tsx
+++ b/apps/web/src/components/landing/preview-posts.tsx
@@ -1,56 +1,90 @@
-import { Bookmark, Check, FileText, ThumbsUp, X } from "lucide-react";
+import { ArrowLeftRight, Bookmark, Check, ThumbsUp, X } from "lucide-react";
 import { useState } from "react";
 
-import { Badge } from "@/components/ui/badge";
+import { DocumentThumb, FileTypeIcon } from "@/components/documents/document-thumb";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-function PreviewPostActions() {
-  const [saved, setSaved] = useState(false);
-  const [liked, setLiked] = useState(false);
+type PreviewAccent = "primary" | "amber" | "blue" | "violet" | "emerald";
 
-  return (
-    <div className="flex items-center gap-0.5">
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        title={saved ? "Unsave" : "Save for later"}
-        className={cn("transition-colors", saved && "text-primary")}
-        onClick={() => setSaved((s) => !s)}
-      >
-        <Bookmark className={cn("size-3.5", saved && "fill-current")} />
-      </Button>
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        title={liked ? "Remove like" : "Like this post"}
-        className={cn("transition-colors", liked && "text-primary")}
-        onClick={() => setLiked((l) => !l)}
-      >
-        <ThumbsUp className={cn("size-3.5", liked && "fill-current")} />
-      </Button>
-    </div>
-  );
-}
+const accentRail: Record<PreviewAccent, string> = {
+  primary: "bg-primary/60",
+  amber: "bg-amber-500/60",
+  blue: "bg-blue-500/60",
+  violet: "bg-violet-500/60",
+  emerald: "bg-emerald-500/60",
+};
+
+const accentText: Record<PreviewAccent, string> = {
+  primary: "text-primary",
+  amber: "text-amber-600 dark:text-amber-400",
+  blue: "text-blue-600 dark:text-blue-400",
+  violet: "text-violet-600 dark:text-violet-400",
+  emerald: "text-emerald-600 dark:text-emerald-400",
+};
 
 function PreviewPostShell({
-  accentClassName,
+  accent,
+  kindLabel,
+  kindSuffix,
+  pageStart,
+  documentId,
+  documentTitle,
+  fileType,
   children,
 }: {
-  accentClassName?: string;
+  accent: PreviewAccent;
+  kindLabel: string;
+  kindSuffix?: string;
+  pageStart?: number;
+  documentId: string;
+  documentTitle: string;
+  fileType: string;
   children: React.ReactNode;
 }) {
   return (
-    <article
-      className={cn(
-        "group/card relative border border-border border-l-[2px] bg-card text-card-foreground transition-colors hover:bg-accent/30",
-        accentClassName,
-      )}
-    >
-      <div className="px-6 pt-6 pb-5">
+    <article className="@container relative grid min-w-0 grid-cols-[24px_1fr] gap-2.5 border border-border bg-card px-2.5 pt-3 pb-2.5 text-card-foreground @[360px]:grid-cols-[32px_1fr] @[360px]:gap-4 @[360px]:px-4 @[360px]:pt-5 @[360px]:pb-4">
+      <div aria-hidden className={cn("absolute inset-x-0 top-0 h-px", accentRail[accent])} />
+
+      <aside className="flex flex-col items-center gap-1.5 pt-[2px] @[360px]:gap-2">
+        <DocumentThumb
+          documentId={documentId}
+          title={documentTitle}
+          fileType={fileType}
+          variant="spine"
+          className="h-10 w-[14px] @[360px]:h-14 @[360px]:w-[18px]"
+        />
+        <div className="h-full w-px bg-border" />
+      </aside>
+
+      <div className="min-w-0">
+        <div className="mb-2.5 flex items-center justify-between gap-2 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground @[360px]:mb-3.5 @[360px]:text-[10.5px]">
+          <div className="flex min-w-0 items-center gap-1.5 @[360px]:gap-2.5">
+            <span className={cn("truncate font-medium", accentText[accent])}>{kindLabel}</span>
+            {kindSuffix && (
+              <>
+                <span className="text-foreground/30">&middot;</span>
+                <span className="truncate">{kindSuffix}</span>
+              </>
+            )}
+          </div>
+          {pageStart != null && (
+            <span className="shrink-0 tracking-wide text-muted-foreground/70">p. {pageStart}</span>
+          )}
+        </div>
+
         {children}
-        <div className="mt-4 flex items-center justify-between border-t border-border pt-3">
-          <span className="text-xs tracking-wide text-muted-foreground/70">2 hours ago</span>
+
+        <div className="mt-3 flex items-center justify-between gap-2 border-t border-border pt-2 @[360px]:mt-4 @[360px]:pt-2.5">
+          <div className="flex min-w-0 items-center gap-1.5 text-muted-foreground @[360px]:gap-2">
+            <FileTypeIcon
+              fileType={fileType}
+              className="size-3 text-muted-foreground/70 @[360px]:size-3.5"
+            />
+            <span className="min-w-0 truncate font-logo text-[11.5px] font-medium text-foreground/85 @[360px]:text-[13px]">
+              {documentTitle}
+            </span>
+          </div>
           <PreviewPostActions />
         </div>
       </div>
@@ -58,45 +92,84 @@ function PreviewPostShell({
   );
 }
 
-function PreviewSourceBadge({ label }: { label: string }) {
+function PreviewPostActions() {
+  const [saved, setSaved] = useState(false);
+  const [liked, setLiked] = useState(false);
+
   return (
-    <div className="mb-3">
-      <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground/70">
-        <FileText className="size-3 shrink-0" />
-        <span className="max-w-64 truncate">{label}</span>
-      </span>
+    <div className="flex shrink-0 items-center">
+      <Button
+        variant="ghost"
+        size="icon"
+        title={saved ? "Unsave" : "Save for later"}
+        className={cn(
+          "size-6 rounded-none @[360px]:size-8",
+          saved
+            ? "bg-primary/10 text-primary hover:bg-primary/15"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground",
+        )}
+        onClick={() => setSaved((s) => !s)}
+      >
+        <Bookmark className={cn("size-3 @[360px]:size-[15px]", saved && "fill-current")} />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        title={liked ? "Remove like" : "Like this post"}
+        className={cn(
+          "size-6 rounded-none @[360px]:size-8",
+          liked
+            ? "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/15 dark:text-emerald-400"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground",
+        )}
+        onClick={() => setLiked((l) => !l)}
+      >
+        <ThumbsUp className={cn("size-3 @[360px]:size-[15px]", liked && "fill-current")} />
+      </Button>
     </div>
   );
 }
 
 export function PreviewInsightPost() {
   return (
-    <PreviewPostShell accentClassName="border-l-primary/50">
-      <PreviewSourceBadge label="Clean Code - Chapter 3" />
-      <div className="prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-        <p>
-          Functions should do one thing, do it well, and do it only. A function that handles both
-          validation and persistence is doing two things - split it.
-        </p>
-      </div>
+    <PreviewPostShell
+      accent="primary"
+      kindLabel="Insight"
+      pageStart={34}
+      documentId="preview-clean-code"
+      documentTitle="Clean Code"
+      fileType="pdf"
+    >
+      <p className="text-[12.5px] leading-[1.55] text-foreground/90 @[360px]:text-[15.5px] @[360px]:leading-[1.6]">
+        Functions should do one thing. A function that handles both validation and persistence is
+        doing two - split it.
+      </p>
     </PreviewPostShell>
   );
 }
 
 export function PreviewQuotePost() {
   return (
-    <PreviewPostShell accentClassName="border-l-amber-500/50">
-      <PreviewSourceBadge label="Thinking, Fast and Slow - Part II" />
-      <div>
-        <blockquote className="text-base leading-relaxed text-foreground/90">
-          Nothing in life is as important as you think it is, while you are thinking about it.
-        </blockquote>
-        <p className="mt-2 text-sm text-muted-foreground/70">&mdash; Daniel Kahneman</p>
-        <p className="mt-1.5 line-clamp-2 text-xs not-italic text-muted-foreground/50">
-          Kahneman introduces the focusing illusion - we overweight whatever we're currently
-          attending to, distorting our judgment of its true importance.
-        </p>
-      </div>
+    <PreviewPostShell
+      accent="amber"
+      kindLabel="Quote"
+      pageStart={148}
+      documentId="preview-thinking-slow"
+      documentTitle="Thinking, Fast and Slow"
+      fileType="epub"
+    >
+      <blockquote className="relative pl-4 font-logo text-[14px] font-medium leading-[1.35] tracking-tight text-foreground @[360px]:pl-7 @[360px]:text-[22px] @[360px]:leading-[1.3]">
+        <span
+          aria-hidden
+          className="absolute -top-1 left-0 font-logo text-[28px] font-semibold leading-none text-amber-500/45 @[360px]:-top-2 @[360px]:text-[60px]"
+        >
+          &ldquo;
+        </span>
+        Nothing in life is as important as you think it is, while you are thinking about it.
+      </blockquote>
+      <p className="mt-1.5 pl-4 font-mono text-[9px] uppercase tracking-[0.16em] text-amber-600/90 dark:text-amber-400/90 @[360px]:mt-3 @[360px]:pl-7 @[360px]:text-[11px]">
+        &mdash; Daniel Kahneman
+      </p>
     </PreviewPostShell>
   );
 }
@@ -115,113 +188,147 @@ export function PreviewQuizPost({ interactive = false }: { interactive?: boolean
   const answered = selected !== null;
 
   return (
-    <PreviewPostShell accentClassName="border-l-emerald-500/50">
-      <PreviewSourceBadge label="Designing Data-Intensive Applications" />
-      <div className="mb-3 text-sm font-medium text-foreground">
-        What is the primary advantage of an append-only log over in-place updates in a database
-        storage engine?
-      </div>
-      <div className="flex flex-col gap-2">
+    <PreviewPostShell
+      accent="emerald"
+      kindLabel="Quiz"
+      kindSuffix="MC"
+      pageStart={75}
+      documentId="preview-ddia"
+      documentTitle="Designing Data-Intensive Applications"
+      fileType="pdf"
+    >
+      <p className="mb-2 font-logo text-[13px] font-medium leading-tight tracking-tight text-foreground @[360px]:mb-4 @[360px]:text-[18px]">
+        What is the primary advantage of an append-only log over in-place updates?
+      </p>
+      <div className="flex flex-col gap-1 @[360px]:gap-1.5">
         {QUIZ_OPTIONS.map((option, i) => {
           const isCorrect = i === CORRECT_INDEX;
-          const isSelected = i === selected;
-
-          let optionStyle = "";
-          if (answered) {
-            if (isCorrect) {
-              optionStyle =
-                "border-emerald-500/50 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400";
-            } else if (isSelected) {
-              optionStyle = "border-red-500/50 bg-red-500/10 text-red-700 dark:text-red-400";
-            } else {
-              optionStyle = "opacity-50";
-            }
-          }
-
+          const isPicked = i === selected;
           return (
-            <Button
+            <button
               key={option}
-              variant="outline"
-              className={cn(
-                "h-auto w-full justify-start whitespace-normal px-3 py-2.5 text-left text-sm transition-[color,background-color,border-color,opacity]",
-                interactive &&
-                  !answered &&
-                  "cursor-pointer hover:border-emerald-500/30 hover:bg-emerald-500/5",
-                !interactive && "cursor-default",
-                optionStyle,
-              )}
-              tabIndex={interactive && !answered ? 0 : -1}
+              type="button"
               aria-disabled={!interactive || answered}
+              tabIndex={interactive && !answered ? 0 : -1}
+              disabled={!interactive || answered}
               onClick={() => {
                 if (interactive && !answered) setSelected(i);
               }}
-            >
-              <span className="flex-1">{option}</span>
-              {answered && isCorrect && <Check className="ml-2 size-4 shrink-0 text-emerald-500" />}
-              {answered && isSelected && !isCorrect && (
-                <X className="ml-2 size-4 shrink-0 text-red-500" />
+              className={cn(
+                "grid grid-cols-[16px_1fr_14px] items-center gap-1.5 border border-border bg-transparent px-2 py-1 text-left text-[11.5px] leading-tight transition-colors @[360px]:grid-cols-[24px_1fr_18px] @[360px]:gap-2.5 @[360px]:px-3 @[360px]:py-2 @[360px]:text-[14px]",
+                interactive &&
+                  !answered &&
+                  "cursor-pointer hover:border-emerald-500/40 hover:bg-emerald-500/[0.05]",
+                !interactive && "cursor-default",
+                answered && isCorrect && "border-emerald-500/45 bg-emerald-500/[0.06]",
+                answered &&
+                  isPicked &&
+                  !isCorrect &&
+                  "border-red-500/45 bg-red-500/[0.06] text-red-500",
+                answered && !isPicked && !isCorrect && "opacity-45",
               )}
-            </Button>
+            >
+              <span
+                className={cn(
+                  "font-mono text-[9px] tracking-wider @[360px]:text-[11px]",
+                  answered && isCorrect
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : answered && isPicked
+                      ? "text-red-500"
+                      : "text-foreground/35",
+                )}
+              >
+                {String.fromCharCode(65 + i)}
+              </span>
+              <span className="truncate">{option}</span>
+              {answered && isCorrect && (
+                <Check className="size-3 text-emerald-500 @[360px]:size-4" />
+              )}
+              {answered && isPicked && !isCorrect && (
+                <X className="size-3 text-red-500 @[360px]:size-4" />
+              )}
+            </button>
           );
         })}
       </div>
-      {answered && (
-        <div className="mt-3 rounded-lg bg-emerald-500/10 px-3 py-2.5 text-sm text-emerald-700 dark:text-emerald-400">
-          Append-only logs simplify concurrency control (no in-place overwrites to coordinate) and
-          crash recovery (replay the log from the last checkpoint).
-        </div>
-      )}
     </PreviewPostShell>
   );
 }
 
 export function PreviewSummaryPost() {
+  const bullets = [
+    "Consistent hashing minimizes key redistribution when nodes join or leave the ring.",
+    "Virtual nodes improve load balance across physical servers.",
+    "The hash ring maps both keys and servers to positions on a fixed circle.",
+  ];
   return (
-    <PreviewPostShell accentClassName="border-l-blue-500/50">
-      <PreviewSourceBadge label="System Design Interview - Ch. 5" />
-      <ul className="flex flex-col gap-2 text-sm leading-relaxed text-foreground/90">
-        {[
-          "Consistent hashing minimizes key redistribution when nodes join or leave",
-          "Virtual nodes improve balance across physical servers",
-          "The hash ring maps both keys and servers to positions on a fixed circle",
-        ].map((point) => (
-          <li key={point} className="flex gap-2.5">
-            <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-blue-500/60" />
-            <span>{point}</span>
+    <PreviewPostShell
+      accent="blue"
+      kindLabel="Summary"
+      pageStart={12}
+      documentId="preview-sys-design"
+      documentTitle="System Design Interview - Ch. 5"
+      fileType="pdf"
+    >
+      <p className="mb-2 font-logo text-[14px] font-medium tracking-tight text-foreground @[360px]:mb-3 @[360px]:text-[18px]">
+        Consistent hashing
+      </p>
+      <ol className="m-0 list-none p-0">
+        {bullets.map((pt, i) => (
+          <li
+            key={i}
+            className={cn(
+              "grid grid-cols-[22px_1fr] gap-1 py-1 @[360px]:grid-cols-[30px_1fr] @[360px]:py-2",
+              i > 0 && "border-t border-dashed border-border",
+            )}
+          >
+            <span className="pt-0.5 font-mono text-[9.5px] tracking-wide text-blue-500 @[360px]:text-[11px]">
+              {String(i + 1).padStart(2, "0")}
+            </span>
+            <span className="text-[11.5px] leading-[1.5] text-foreground/90 @[360px]:text-[14px] @[360px]:leading-[1.55]">
+              {pt}
+            </span>
           </li>
         ))}
-      </ul>
+      </ol>
     </PreviewPostShell>
   );
 }
 
 export function PreviewConnectionPost() {
   return (
-    <PreviewPostShell accentClassName="border-l-violet-500/50">
-      <div className="mb-3 flex items-center gap-2">
-        <Badge
-          variant="outline"
-          className="gap-1.5 border-violet-500/15 bg-violet-500/[0.03] font-normal text-muted-foreground"
-        >
-          Cross-source
-        </Badge>
+    <PreviewPostShell
+      accent="violet"
+      kindLabel="Connection"
+      kindSuffix="Cross-source"
+      documentId="preview-clean-code"
+      documentTitle="Clean Code &amp; DDIA"
+      fileType="pdf"
+    >
+      <div className="mb-2 grid grid-cols-[1fr_16px_1fr] items-stretch gap-1.5 @[360px]:mb-4 @[360px]:grid-cols-[1fr_28px_1fr] @[360px]:gap-3">
+        <div className="border border-border bg-violet-500/[0.03] px-1.5 py-1.5 @[360px]:px-3 @[360px]:py-2.5">
+          <div className="mb-0.5 font-mono text-[8px] uppercase tracking-[0.14em] text-violet-500 @[360px]:mb-1 @[360px]:text-[10px]">
+            Source A
+          </div>
+          <div className="truncate text-[10px] text-muted-foreground/90 @[360px]:text-[12px]">
+            Clean Code
+          </div>
+        </div>
+        <div className="flex items-center justify-center text-violet-500">
+          <ArrowLeftRight className="size-3 @[360px]:size-4" />
+        </div>
+        <div className="border border-border bg-violet-500/[0.03] px-1.5 py-1.5 @[360px]:px-3 @[360px]:py-2.5">
+          <div className="mb-0.5 font-mono text-[8px] uppercase tracking-[0.14em] text-violet-500 @[360px]:mb-1 @[360px]:text-[10px]">
+            Source B
+          </div>
+          <div className="truncate text-[10px] text-muted-foreground/90 @[360px]:text-[12px]">
+            DDIA
+          </div>
+        </div>
       </div>
-      <div className="space-y-2 text-sm leading-relaxed text-foreground/90">
-        <p>
-          Both <span className="font-medium text-violet-600 dark:text-violet-400">Clean Code</span>{" "}
-          and <span className="font-medium text-violet-600 dark:text-violet-400">DDIA</span> argue
-          that the hardest part of software design is managing complexity at the boundaries between
-          components.
-        </p>
-      </div>
-      <div className="mt-3 flex flex-wrap gap-2">
-        <span className="inline-flex items-center gap-1 rounded-md bg-violet-500/10 px-2 py-0.5 text-xs text-violet-600 dark:text-violet-400">
-          <FileText className="size-2.5" /> Clean Code
-        </span>
-        <span className="inline-flex items-center gap-1 rounded-md bg-violet-500/10 px-2 py-0.5 text-xs text-violet-600 dark:text-violet-400">
-          <FileText className="size-2.5" /> DDIA - Ch. 1
-        </span>
-      </div>
+      <p className="font-logo text-[13px] font-normal leading-[1.4] tracking-tight text-foreground @[360px]:text-[17px] @[360px]:leading-[1.45]">
+        The hardest part of software design is managing complexity at boundaries between components.
+      </p>
     </PreviewPostShell>
   );
 }

--- a/apps/web/src/components/landing/pricing-section.tsx
+++ b/apps/web/src/components/landing/pricing-section.tsx
@@ -76,17 +76,20 @@ export function PricingSection() {
       )}
     >
       <div className="mx-auto max-w-5xl">
-        <div className="mb-10 md:mb-12">
-          <span className="mb-3 inline-flex items-center border border-border px-3 py-1 text-xs tracking-widest text-muted-foreground uppercase">
-            Pricing
-          </span>
+        <div className="mb-10 md:mb-14">
+          <div className="mb-4 inline-flex items-center gap-2.5 text-muted-foreground">
+            <span aria-hidden className="inline-block size-1.5 rounded-full bg-primary" />
+            <span className="font-mono text-[10px] font-medium uppercase tracking-[0.32em]">
+              Pricing
+            </span>
+          </div>
           <h2
             id="pricing-heading"
-            className="text-2xl font-bold tracking-[-0.02em] text-pretty sm:text-3xl"
+            className="font-logo text-3xl font-semibold leading-[1.05] tracking-[-0.015em] text-pretty sm:text-4xl md:text-[2.75rem]"
           >
             One tier to try it, one tier to live in it
           </h2>
-          <p className="mt-2 max-w-lg text-muted-foreground">
+          <p className="mt-4 max-w-lg text-base leading-relaxed text-muted-foreground text-pretty md:text-lg">
             No seats, no add-ons, no surprise usage bills. Free is enough to decide if Scrollect
             fits; Pro is enough to make it a habit.
           </p>
@@ -103,24 +106,26 @@ export function PricingSection() {
               )}
             >
               {tier.highlight && (
-                <span className="absolute top-4 right-4 inline-flex items-center border border-primary px-2 py-0.5 text-[10px] tracking-[0.15em] text-primary uppercase">
+                <span className="absolute top-4 right-4 inline-flex items-center border border-primary px-2 py-0.5 font-mono text-[10px] font-medium tracking-[0.22em] text-primary uppercase">
                   Recommended
                 </span>
               )}
 
-              <span className="text-xs tracking-widest text-muted-foreground uppercase">
+              <span className="font-mono text-[10px] font-medium tracking-[0.28em] text-muted-foreground uppercase">
                 {tier.eyebrow}
               </span>
-              <h3 className="mt-3 text-2xl font-bold tracking-tight">{tier.name}</h3>
+              <h3 className="mt-3 font-logo text-3xl font-semibold tracking-tight">{tier.name}</h3>
 
               <div className="mt-4 flex items-baseline gap-2">
-                <span className="font-mono text-4xl font-bold tracking-tight text-foreground">
+                <span className="font-mono text-[2.75rem] font-semibold tabular-nums tracking-tight text-foreground">
                   {tier.price}
                 </span>
                 <span className="text-sm text-muted-foreground">/ {tier.priceUnit}</span>
               </div>
 
-              <p className="mt-4 text-sm text-muted-foreground text-pretty">{tier.blurb}</p>
+              <p className="mt-4 text-sm leading-relaxed text-muted-foreground text-pretty">
+                {tier.blurb}
+              </p>
 
               <ul className="mt-6 flex-1 space-y-2.5">
                 {tier.features.map((feature) => (

--- a/apps/web/src/components/library-detail-panel.tsx
+++ b/apps/web/src/components/library-detail-panel.tsx
@@ -4,15 +4,16 @@ import type { Id } from "@scrollect/backend/convex/_generated/dataModel";
 import { Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { formatDistanceToNow } from "date-fns";
-import { FileText, Globe, Loader2, MousePointerClick, Rss, Trash2, X } from "lucide-react";
+import { format, formatDistanceToNow } from "date-fns";
+import { ExternalLink, Loader2, MousePointerClick, Rss, Trash2, X } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { createContext, useCallback, useContext, useState } from "react";
 import { toast } from "sonner";
 
-import { fileTypeIcons, StatusBadge } from "@/components/document-status";
-import { Badge } from "@/components/ui/badge";
+import { StatusBadge, statusConfig } from "@/components/document-status";
+import { DetailRail, DetailRailPlaceholder, DETAIL_RULED_BG_STYLE } from "@/components/detail-rail";
 import { BookmarkedPostsSection } from "@/components/documents/bookmarked-posts-section";
+import { DocumentThumb, FileTypeIcon } from "@/components/documents/document-thumb";
 import { HighlightsSection } from "@/components/documents/highlights-section";
 import { ImportHighlightsDialog } from "@/components/documents/import-highlights-dialog";
 import { LearningGoalSection } from "@/components/documents/learning-goal-section";
@@ -34,6 +35,7 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
 
 type LibraryDetailContextValue = {
   selectedDocumentId: Id<"documents"> | null;
@@ -75,17 +77,13 @@ export function LibraryDetailPanel() {
     if (isMobile) return null;
 
     return (
-      <aside className="-ml-px hidden h-full min-h-0 min-w-0 overflow-hidden border-l border-border lg:block">
-        <div className="flex h-full flex-col items-center justify-center px-6 text-center">
-          <div className="flex size-12 items-center justify-center border border-border">
-            <MousePointerClick className="size-5 text-muted-foreground" />
-          </div>
-          <p className="mt-4 text-sm font-medium text-foreground">Select a document</p>
-          <p className="mt-1 max-w-[200px] text-xs text-muted-foreground">
-            Click any document in your library to see its details here.
-          </p>
-        </div>
-      </aside>
+      <DetailRail testId="library-detail-panel">
+        <DetailRailPlaceholder
+          icon={MousePointerClick}
+          title="Select a document"
+          description="Click any document in your archive to open its file card here."
+        />
+      </DetailRail>
     );
   }
 
@@ -109,7 +107,7 @@ export function LibraryDetailPanel() {
   }
 
   return (
-    <aside className="-ml-px hidden h-full min-h-0 min-w-0 overflow-hidden border-l border-border lg:block">
+    <DetailRail testId="library-detail-panel">
       <div className="h-full overflow-y-auto overscroll-contain">
         <div
           key={selectedDocumentId}
@@ -118,8 +116,25 @@ export function LibraryDetailPanel() {
           <DocumentDetailContent documentId={selectedDocumentId} onClose={closeDetail} />
         </div>
       </div>
-    </aside>
+    </DetailRail>
   );
+}
+
+const KIND_LABELS: Record<string, string> = {
+  pdf: "PDF",
+  epub: "Book",
+  md: "Markdown",
+  markdown: "Markdown",
+  txt: "Note",
+  text: "Note",
+  html: "Article",
+  article: "Article",
+  url: "Article",
+  youtube: "Video",
+};
+
+function kindLabel(fileType: string): string {
+  return KIND_LABELS[fileType.toLowerCase()] ?? fileType.toUpperCase();
 }
 
 function DocumentDetailContent({
@@ -153,10 +168,16 @@ function DocumentDetailContent({
 
   if (document === undefined) {
     return (
-      <div className="px-6 py-5">
-        <Skeleton className="h-6 w-2/3" />
-        <Skeleton className="mt-3 h-4 w-1/3" />
-        <Skeleton className="mt-6 h-32 w-full" />
+      <div className="flex h-full min-w-0 flex-col">
+        <div className="flex items-center justify-between border-b border-dashed border-border px-6 py-4 md:px-7">
+          <Skeleton className="h-3 w-40" />
+          <Skeleton className="size-8" />
+        </div>
+        <div className="px-6 py-7 md:px-8">
+          <Skeleton className="aspect-[16/9] w-full" />
+          <Skeleton className="mt-6 h-7 w-3/4" />
+          <Skeleton className="mt-3 h-3 w-1/2" />
+        </div>
       </div>
     );
   }
@@ -172,130 +193,218 @@ function DocumentDetailContent({
     );
   }
 
+  const statusAccent = statusConfig[document.status].dotClassName;
+  const hostname = document.sourceUrl ? safeHostname(document.sourceUrl) : null;
+
   return (
-    <div className="min-w-0 px-6 py-5">
-      <div className="flex items-start justify-between gap-3">
-        <h2 className="flex min-w-0 items-start gap-2.5 text-lg font-bold tracking-tight">
-          <span className="mt-0.5 shrink-0 text-muted-foreground">
-            {fileTypeIcons[document.fileType] ?? <FileText className="size-4" />}
+    <div className="flex h-full min-w-0 flex-col">
+      <div className="flex items-center justify-between border-b border-dashed border-border px-6 py-4 md:px-7">
+        <div className="flex min-w-0 items-center gap-2 font-mono text-[10.5px] uppercase tracking-[0.16em] text-muted-foreground">
+          <span>Volume</span>
+          <span className="text-foreground/30">&middot;</span>
+          <span className="font-medium text-foreground">{kindLabel(document.fileType)}</span>
+          <span className="text-foreground/30">&middot;</span>
+          <span className="truncate">
+            {format(document.createdAt, "MMM d, yyyy").toUpperCase()}
           </span>
-          <span className="min-w-0 break-all">{document.title}</span>
-        </h2>
-        <Button variant="ghost" size="icon" onClick={onClose} className="shrink-0">
-          <X className="size-4" />
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8 shrink-0 rounded-none"
+          onClick={onClose}
+        >
+          <X className="size-3.5" />
           <span className="sr-only">Close</span>
         </Button>
       </div>
 
-      <div className="mt-3 flex flex-wrap items-center gap-3">
-        <StatusBadge status={document.status} />
-        <Badge
-          variant="outline"
-          className="rounded-none border-border bg-transparent font-normal text-muted-foreground"
-        >
-          {document.fileType.toUpperCase()}
-        </Badge>
-        {document.sourceUrl && (
-          <a
-            href={document.sourceUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex min-w-0 items-center gap-1 text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+      <div
+        className="flex min-w-0 flex-1 flex-col gap-6 overflow-y-auto px-6 py-7 md:px-8"
+        style={DETAIL_RULED_BG_STYLE}
+      >
+        <div className="flex min-w-0 flex-col gap-5">
+          <figure
+            className={cn(
+              "relative aspect-[16/9] w-full overflow-hidden border border-border",
+              "bg-muted/30 shadow-[0_1px_0_0_rgba(0,0,0,0.04)]",
+            )}
           >
-            <Globe className="size-3 shrink-0" />
-            <span className="min-w-0 break-all">{new URL(document.sourceUrl).hostname}</span>
-          </a>
-        )}
-        <span className="text-xs text-muted-foreground">
-          {formatDistanceToNow(document.createdAt, { addSuffix: true })}
-        </span>
-        {document.status === "ready" && (
-          <span className="text-xs text-muted-foreground">
-            {document.chunkCount} chunk{document.chunkCount !== 1 ? "s" : ""}
-          </span>
-        )}
-      </div>
+            {document.thumbnailUrl ? (
+              <img
+                src={document.thumbnailUrl}
+                alt=""
+                loading="lazy"
+                className="absolute inset-0 size-full object-cover"
+              />
+            ) : (
+              <DocumentThumb
+                documentId={document._id}
+                title={document.title}
+                fileType={document.fileType}
+                variant="hero"
+                className="absolute inset-0"
+              />
+            )}
+            <div aria-hidden className={cn("absolute inset-x-0 bottom-0 h-[3px]", statusAccent)} />
+            <div className="absolute left-4 top-4">
+              <span className="inline-flex items-center gap-1.5 border border-border/80 bg-background/80 px-2 py-[3px] font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground backdrop-blur">
+                <FileTypeIcon fileType={document.fileType} className="size-3" />
+                {kindLabel(document.fileType)}
+              </span>
+            </div>
+          </figure>
 
-      <div className="mt-4 flex flex-wrap justify-end gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          render={<Link to="/app/feed" search={{ documentId: document._id }} />}
-        >
-          <Rss data-icon="inline-start" />
-          Open feed for this document
-        </Button>
-        {document.status === "ready" && <ImportHighlightsDialog documentId={document._id} />}
-        <AlertDialog
-          open={deleteDialogOpen}
-          onOpenChange={(open) => {
-            if (!isDeleting) setDeleteDialogOpen(open);
-          }}
-        >
-          <AlertDialogTrigger
-            render={<Button variant="destructive" size="sm" data-testid="delete-document-button" />}
-          >
-            <Trash2 data-icon="inline-start" />
-            Delete
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Delete document</AlertDialogTitle>
-              <AlertDialogDescription>
-                Delete &ldquo;{document.title}&rdquo;? This will remove the document and all
-                generated posts. This cannot be undone.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel disabled={isDeleting} data-testid="cancel-delete-button">
-                Cancel
-              </AlertDialogCancel>
-              <AlertDialogAction
-                variant="destructive"
-                disabled={isDeleting}
-                onClick={handleDelete}
-                data-testid="confirm-delete-button"
+          <div className="flex items-center justify-between gap-3">
+            <StatusBadge status={document.status} />
+            {hostname && (
+              <a
+                href={document.sourceUrl!}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex min-w-0 items-center gap-1 font-mono text-[10.5px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
               >
-                {isDeleting && <Loader2 className="animate-spin" data-icon="inline-start" />}
-                Delete
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-      </div>
-
-      {(document.status === "ready" || document.learningGoalOnboardingStatus === "pending") && (
-        <>
-          {document.status === "ready" && <DocumentTagSection documentId={document._id} />}
-          <LearningGoalSection
-            documentId={document._id}
-            initialGoal={document.learningGoal}
-            onboardingStatus={document.learningGoalOnboardingStatus}
-            sourceType={document.fileType}
-          />
-          {document.status === "ready" && <HighlightsSection documentId={document._id} />}
-          {document.status === "ready" && <BookmarkedPostsSection documentId={document._id} />}
-        </>
-      )}
-
-      {document.status === "error" && (
-        <PipelineError
-          documentId={document._id}
-          errorMessage={document.errorMessage}
-          failedAt={document.failedAt}
-        />
-      )}
-
-      {isProcessingStatus(document.status) && <ProcessingProgress status={document.status} />}
-
-      {document.status === "deleting" && (
-        <div className="mt-10 flex flex-col items-center gap-4 text-center" role="status">
-          <div className="flex size-12 items-center justify-center border border-destructive/30 bg-transparent">
-            <Loader2 className="size-5 animate-spin text-destructive" aria-hidden="true" />
+                <ExternalLink className="size-3 shrink-0" />
+                <span className="truncate normal-case tracking-normal text-[12px]">{hostname}</span>
+              </a>
+            )}
           </div>
-          <p className="text-sm text-muted-foreground">Deleting document...</p>
+
+          <h2
+            data-testid="library-detail-title"
+            className="font-logo text-[1.65rem] font-semibold leading-[1.15] tracking-tight text-foreground md:text-[1.85rem]"
+          >
+            {document.title}
+          </h2>
+
+          <dl className="flex flex-wrap items-center gap-x-3 gap-y-1.5 font-mono text-[10.5px] uppercase tracking-[0.16em] text-muted-foreground">
+            {document.status === "ready" && (
+              <>
+                <div className="flex items-center gap-1.5">
+                  <dt className="sr-only">Chunks</dt>
+                  <dd className="tabular-nums text-foreground/70">
+                    {document.chunkCount.toLocaleString()}
+                  </dd>
+                  <span>Chunk{document.chunkCount !== 1 ? "s" : ""}</span>
+                </div>
+                <span aria-hidden className="text-foreground/20">
+                  &middot;
+                </span>
+              </>
+            )}
+            <div className="flex items-center gap-1.5">
+              <dt className="sr-only">Added</dt>
+              <span>Added</span>
+              <dd className="normal-case tracking-normal text-foreground/70">
+                {formatDistanceToNow(document.createdAt, { addSuffix: true })}
+              </dd>
+            </div>
+          </dl>
         </div>
-      )}
+
+        <div className="flex flex-wrap items-center gap-1 border-y border-dashed border-border py-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="rounded-none"
+            render={<Link to="/app/feed" search={{ documentId: document._id }} />}
+          >
+            <Rss data-icon="inline-start" />
+            Open in feed
+          </Button>
+          {document.status === "ready" && (
+            <>
+              <span aria-hidden className="mx-1 h-4 w-px bg-border" />
+              <ImportHighlightsDialog documentId={document._id} />
+            </>
+          )}
+          <span className="ml-auto" />
+          <AlertDialog
+            open={deleteDialogOpen}
+            onOpenChange={(open) => {
+              if (!isDeleting) setDeleteDialogOpen(open);
+            }}
+          >
+            <AlertDialogTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="rounded-none text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                  data-testid="delete-document-button"
+                />
+              }
+            >
+              <Trash2 data-icon="inline-start" />
+              Delete
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete document</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Delete &ldquo;{document.title}&rdquo;? This will remove the document and all
+                  generated posts. This cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={isDeleting} data-testid="cancel-delete-button">
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  disabled={isDeleting}
+                  onClick={handleDelete}
+                  data-testid="confirm-delete-button"
+                >
+                  {isDeleting && <Loader2 className="animate-spin" data-icon="inline-start" />}
+                  Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+
+        {(document.status === "ready" || document.learningGoalOnboardingStatus === "pending") && (
+          <div className="flex flex-col">
+            {document.status === "ready" && <DocumentTagSection documentId={document._id} />}
+            <LearningGoalSection
+              documentId={document._id}
+              initialGoal={document.learningGoal}
+              onboardingStatus={document.learningGoalOnboardingStatus}
+              sourceType={document.fileType}
+            />
+            {document.status === "ready" && <HighlightsSection documentId={document._id} />}
+            {document.status === "ready" && <BookmarkedPostsSection documentId={document._id} />}
+          </div>
+        )}
+
+        {document.status === "error" && (
+          <PipelineError
+            documentId={document._id}
+            errorMessage={document.errorMessage}
+            failedAt={document.failedAt}
+          />
+        )}
+
+        {isProcessingStatus(document.status) && <ProcessingProgress status={document.status} />}
+
+        {document.status === "deleting" && (
+          <div className="mt-4 flex flex-col items-center gap-4 text-center" role="status">
+            <div className="flex size-12 items-center justify-center border border-destructive/30 bg-transparent">
+              <Loader2 className="size-5 animate-spin text-destructive" aria-hidden="true" />
+            </div>
+            <p className="text-sm text-muted-foreground">Deleting document...</p>
+          </div>
+        )}
+      </div>
     </div>
   );
+}
+
+function safeHostname(url: string): string | null {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return null;
+  }
 }

--- a/apps/web/src/components/onboarding/onboarding-wizard.tsx
+++ b/apps/web/src/components/onboarding/onboarding-wizard.tsx
@@ -4,9 +4,10 @@ import type { Doc } from "@scrollect/backend/convex/_generated/dataModel";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useMutation, usePaginatedQuery } from "convex/react";
-import { ArrowRight, CheckCircle2, FileText, Globe, Loader2, Sparkles, Upload } from "lucide-react";
+import { ArrowRight, Check, FileText, Globe, Loader2, Sparkles, Upload } from "lucide-react";
 import { useEffect, useRef } from "react";
 
+import { DETAIL_RULED_BG_STYLE } from "@/components/detail-rail";
 import {
   ProcessingProgressBar,
   isProcessingStatus,
@@ -30,9 +31,9 @@ function resolveStage({
   return "welcome";
 }
 
-const steps: ReadonlyArray<{ key: OnboardingStage; label: string }> = [
+const STEPS: ReadonlyArray<{ key: OnboardingStage; label: string }> = [
   { key: "welcome", label: "Add content" },
-  { key: "processing", label: "AI generates posts" },
+  { key: "processing", label: "AI extracts posts" },
   { key: "ready", label: "Scroll your feed" },
 ];
 
@@ -43,6 +44,7 @@ export function OnboardingWizard({ documents }: { documents: OnboardingDocument[
   const firstPostQuery = usePaginatedQuery(api.feed.queries.list, {}, { initialNumItems: 1 });
   const hasFirstPost = firstPostQuery.results.length > 0;
   const stage = resolveStage({ documents, hasFirstPost });
+  const stageIndex = STEPS.findIndex((s) => s.key === stage);
 
   const markedRef = useRef(false);
   useEffect(() => {
@@ -55,62 +57,81 @@ export function OnboardingWizard({ documents }: { documents: OnboardingDocument[
 
   if (!profile || profile.onboardingCompleted) return null;
 
+  const progress = ((stageIndex + 1) / STEPS.length) * 100;
+  const currentStep = STEPS[stageIndex];
+
   return (
-    <div className="mx-4 md:mx-6 mb-8 border border-border bg-card">
-      <div className="grid gap-0 border-b border-border md:grid-cols-3">
-        {steps.map((step, i) => {
-          const reached = steps.findIndex((s) => s.key === stage) >= i;
-          return (
-            <div
-              key={step.key}
-              className={cn(
-                "flex items-center gap-3 px-5 py-3 text-sm",
-                i > 0 && "border-t border-border md:border-t-0 md:border-l",
-                reached ? "text-foreground" : "text-muted-foreground/70",
-              )}
-            >
+    <section
+      data-testid="onboarding-wizard"
+      className="mx-4 mb-10 border border-border bg-card md:mx-6"
+    >
+      <div className="flex items-center gap-4 px-5 pt-4 pb-3 md:px-6">
+        <span className="shrink-0 font-mono text-[10.5px] uppercase tracking-[0.22em] text-muted-foreground">
+          <span className="text-foreground tabular-nums">
+            {String(stageIndex + 1).padStart(2, "0")}
+          </span>
+          <span className="text-muted-foreground/50"> / 0{STEPS.length}</span>
+          <span className="mx-2 text-muted-foreground/30">·</span>
+          <span className="text-foreground normal-case tracking-normal">{currentStep.label}</span>
+        </span>
+        <div
+          className="relative h-[2px] flex-1 overflow-hidden bg-border/60"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(progress)}
+        >
+          <div
+            className={cn(
+              "absolute inset-y-0 left-0 transition-[width] duration-500 ease-out",
+              stage === "ready" ? "bg-emerald-500" : "bg-primary",
+            )}
+            style={{ width: `${progress}%` }}
+          />
+          {STEPS.map((_, i) => {
+            if (i === 0) return null;
+            const pct = (i / STEPS.length) * 100;
+            return (
               <span
-                className={cn(
-                  "flex size-6 items-center justify-center border font-mono text-xs",
-                  reached
-                    ? "border-primary/40 bg-primary/10 text-primary"
-                    : "border-border text-muted-foreground",
-                )}
-              >
-                {i + 1}
-              </span>
-              <span className={cn(reached ? "font-medium" : "")}>{step.label}</span>
-            </div>
-          );
-        })}
+                key={i}
+                aria-hidden
+                className="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-card ring-1 ring-border"
+                style={{ left: `${pct}%` }}
+              />
+            );
+          })}
+        </div>
       </div>
 
-      <div className="px-6 py-8 md:px-10 md:py-10">
+      <div
+        className="border-t border-border px-6 py-10 md:px-10 md:py-12"
+        style={DETAIL_RULED_BG_STYLE}
+      >
         {stage === "welcome" && <WelcomeStage />}
         {stage === "processing" && <ProcessingStage documents={documents} />}
         {stage === "ready" && <ReadyStage />}
       </div>
-    </div>
+    </section>
   );
 }
 
 function WelcomeStage() {
   return (
     <div className="flex flex-col items-start gap-6">
-      <div className="inline-flex items-center gap-2 border border-primary/40 bg-primary/5 px-3 py-1 text-[10px] font-medium tracking-[0.15em] text-primary uppercase">
+      <span className="inline-flex items-center gap-2 border border-primary/40 bg-primary/5 px-3 py-1 font-mono text-[10px] font-medium tracking-[0.22em] text-primary uppercase">
         <Sparkles className="size-3" />
         Welcome to Scrollect
-      </div>
-      <div>
-        <h2 className="text-2xl font-bold tracking-tight text-balance sm:text-3xl">
-          Let's turn something you've read into posts you'll remember.
-        </h2>
-        <p className="mt-3 max-w-xl text-muted-foreground">
-          Add any PDF, article, YouTube video, or note. In about a minute you'll have a personal
-          feed of insights, quotes, and quizzes drawn from it.
-        </p>
-      </div>
-      <div className="flex flex-wrap gap-3">
+      </span>
+      <h2 className="font-logo text-[2rem] font-semibold leading-[1.05] tracking-tight text-balance md:text-[2.6rem]">
+        Let&rsquo;s turn something you&rsquo;ve read
+        <br className="hidden sm:block" />
+        into posts you&rsquo;ll remember.
+      </h2>
+      <p className="max-w-xl text-[15px] leading-relaxed text-muted-foreground">
+        Add any PDF, article, YouTube video, or note. In about a minute you&rsquo;ll have a personal
+        feed of insights, quotes, and quizzes drawn from it.
+      </p>
+      <div className="flex flex-wrap gap-2 pt-1">
         <Button size="lg" render={<Link to="/app/upload" />}>
           <Upload className="size-4" />
           Upload a file
@@ -119,7 +140,7 @@ function WelcomeStage() {
           <Globe className="size-4" />
           Paste a URL
         </Button>
-        <Button size="lg" variant="outline" render={<Link to="/app/upload" />}>
+        <Button size="lg" variant="ghost" render={<Link to="/app/upload" />}>
           <FileText className="size-4" />
           Paste text
         </Button>
@@ -134,27 +155,45 @@ function ProcessingStage({ documents }: { documents: OnboardingDocument[] }) {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-start gap-4">
-        <div className="flex size-10 shrink-0 items-center justify-center border border-primary/40 bg-primary/5 text-primary">
-          <Loader2 className="size-5 animate-spin" />
-        </div>
-        <div className="min-w-0">
-          <h2 className="text-xl font-bold tracking-tight">Generating your first posts</h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            This typically takes 1-3 minutes. You can stay here or come back later - we'll keep
-            working in the background.
-          </p>
-        </div>
+      <span className="inline-flex items-center gap-2 border border-primary/40 bg-primary/5 px-3 py-1 font-mono text-[10px] font-medium tracking-[0.22em] text-primary uppercase">
+        <Loader2 className="size-3 animate-spin" />
+        Working on it
+      </span>
+
+      <div className="max-w-xl">
+        <h2 className="font-logo text-[1.85rem] font-semibold leading-[1.08] tracking-tight text-balance md:text-[2.2rem]">
+          Generating your first posts.
+        </h2>
+        <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+          This usually takes a minute or three. Stay here to watch, or come back later - we&rsquo;ll
+          keep working while you&rsquo;re away.
+        </p>
       </div>
 
       {active && (
-        <div className="border border-border border-l-[2px] border-l-primary bg-background px-5 py-4">
-          <p className="line-clamp-1 text-sm font-semibold">{active.title}</p>
-          <div className="mt-2 flex items-center gap-3">
+        <div className="relative border border-border bg-background/80 px-5 py-4 backdrop-blur">
+          <span
+            aria-hidden
+            className={cn(
+              "absolute inset-y-0 left-0 w-[2px]",
+              isProcessingStatus(active.status) ? "bg-primary" : "bg-muted-foreground/40",
+            )}
+          />
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                Now processing
+              </p>
+              <p className="mt-1.5 line-clamp-1 font-logo text-[17px] font-medium leading-tight">
+                {active.title}
+              </p>
+            </div>
             {isProcessingStatus(active.status) ? (
               <ProcessingProgressBar status={active.status} />
             ) : (
-              <span className="text-xs text-muted-foreground">{active.status}</span>
+              <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+                {active.status}
+              </span>
             )}
           </div>
         </div>
@@ -166,19 +205,18 @@ function ProcessingStage({ documents }: { documents: OnboardingDocument[] }) {
 function ReadyStage() {
   return (
     <div className="flex flex-col items-start gap-5">
-      <div className="inline-flex items-center gap-2 border border-emerald-500/40 bg-emerald-500/5 px-3 py-1 text-[10px] font-medium tracking-[0.15em] text-emerald-600 uppercase dark:text-emerald-400">
-        <CheckCircle2 className="size-3" />
-        Your first posts are ready
-      </div>
-      <div>
-        <h2 className="text-2xl font-bold tracking-tight text-balance sm:text-3xl">
-          The good part. Scroll your first feed.
-        </h2>
-        <p className="mt-3 max-w-xl text-muted-foreground">
-          Your posts are waiting in the feed. React to shape what you see next - Scrollect learns as
-          you go.
-        </p>
-      </div>
+      <span className="inline-flex items-center gap-2 border border-emerald-500/40 bg-emerald-500/5 px-3 py-1 font-mono text-[10px] font-medium tracking-[0.22em] text-emerald-600 uppercase dark:text-emerald-400">
+        <Check className="size-3" strokeWidth={3} />
+        First posts ready
+      </span>
+      <h2 className="font-logo text-[2rem] font-semibold leading-[1.05] tracking-tight text-balance md:text-[2.6rem]">
+        The good part.
+        <br className="hidden sm:block" />
+        Scroll your first feed.
+      </h2>
+      <p className="max-w-xl text-[15px] leading-relaxed text-muted-foreground">
+        Your posts are waiting. React to shape what comes next - Scrollect learns from every tap.
+      </p>
       <Button size="lg" render={<Link to="/app/feed" />}>
         Open the feed
         <ArrowRight className="size-4" />

--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type PageHeaderProps = {
+  eyebrow: string;
+  title: string;
+  description?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+};
+
+export function PageHeader({ eyebrow, title, description, actions, className }: PageHeaderProps) {
+  return (
+    <header
+      className={cn("border-b border-border px-4 pb-7 pt-8 md:px-8 md:pb-8 md:pt-10", className)}
+    >
+      <div className="flex items-center gap-3">
+        <span aria-hidden className="inline-block size-1.5 rounded-full bg-primary" />
+        <span className="font-mono text-[10px] font-medium uppercase tracking-[0.32em] text-muted-foreground">
+          {eyebrow}
+        </span>
+        <div className="h-px flex-1 bg-border" />
+      </div>
+      <div className="mt-5 flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+        <div className="max-w-md">
+          <h1 className="font-logo text-[2.5rem] font-semibold leading-[1.02] tracking-tight md:text-5xl">
+            {title}
+          </h1>
+          {description && (
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{description}</p>
+          )}
+        </div>
+        {actions && <div className="flex flex-col items-start gap-3 md:items-end">{actions}</div>}
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/components/posts/connection-post.tsx
+++ b/apps/web/src/components/posts/connection-post.tsx
@@ -1,126 +1,66 @@
-import { Link } from "@tanstack/react-router";
-import type { Id } from "@scrollect/backend/convex/_generated/dataModel";
-import { ArrowLeftRight, FileText } from "lucide-react";
-import Markdown from "react-markdown";
-
-import { Badge } from "@/components/ui/badge";
+import { ArrowLeftRight } from "lucide-react";
 
 import { PostShell } from "./post-shell";
 import type { ConnectionTypeData, PostView } from "./types";
 
 interface ConnectionPostProps {
   post: PostView & { typeData: ConnectionTypeData };
+  onViewed?: (postId: string) => void;
 }
 
-export function ConnectionPost({ post }: ConnectionPostProps) {
-  const { sourceATitleHint, sourceBTitleHint, connectionType, sourceAKeyIdea, sourceBKeyIdea } =
-    post.typeData;
-
-  const isWithinDocument = connectionType === "within_document";
+export function ConnectionPost({ post, onViewed }: ConnectionPostProps) {
+  const { sourceATitleHint, sourceBTitleHint, sourceAKeyIdea, sourceBKeyIdea } = post.typeData;
 
   return (
-    <PostShell post={post}>
-      <div className="mb-3 flex items-center gap-2" data-testid="connection-header">
-        <Badge
-          variant="outline"
-          className="gap-1.5 rounded-none border-violet-500/30 bg-transparent font-normal text-muted-foreground"
-        >
-          <ArrowLeftRight className="size-3 shrink-0 text-violet-500/60" />
-          {isWithinDocument ? "Cross-section" : "Cross-source"}
-        </Badge>
-      </div>
-
-      <ConnectionProvenance
-        sourceATitleHint={sourceATitleHint}
-        sourceBTitleHint={sourceBTitleHint}
-        primaryDocumentId={post.primarySourceDocumentId}
-        isWithinDocument={isWithinDocument}
-      />
-
-      {(sourceAKeyIdea || sourceBKeyIdea) && (
-        <div className="mb-3 flex flex-col gap-1.5">
-          {sourceAKeyIdea && (
-            <p
-              data-testid="connection-key-idea-a"
-              className="text-xs italic leading-relaxed text-muted-foreground"
+    <PostShell post={post} onViewed={onViewed}>
+      <div data-testid="connection-content">
+        <div className="mb-4 grid grid-cols-[1fr_28px_1fr] items-stretch gap-3">
+          <div className="border border-border bg-violet-500/[0.03] px-3.5 py-3">
+            <div className="mb-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-violet-500">
+              Source A
+            </div>
+            <div
+              data-testid="connection-source-a"
+              className="truncate text-[12px] text-muted-foreground/90"
             >
-              {sourceAKeyIdea}
-            </p>
-          )}
-          {sourceBKeyIdea && (
-            <p
-              data-testid="connection-key-idea-b"
-              className="text-xs italic leading-relaxed text-muted-foreground"
+              {sourceATitleHint}
+            </div>
+            {sourceAKeyIdea && (
+              <p
+                data-testid="connection-key-idea-a"
+                className="mt-2 text-[13px] italic leading-[1.5] text-foreground/85"
+              >
+                &ldquo;{sourceAKeyIdea}&rdquo;
+              </p>
+            )}
+          </div>
+          <div className="flex items-center justify-center text-violet-500">
+            <ArrowLeftRight className="size-4" />
+          </div>
+          <div className="border border-border bg-violet-500/[0.03] px-3.5 py-3">
+            <div className="mb-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-violet-500">
+              Source B
+            </div>
+            <div
+              data-testid="connection-source-b"
+              className="truncate text-[12px] text-muted-foreground/90"
             >
-              {sourceBKeyIdea}
-            </p>
-          )}
+              {sourceBTitleHint}
+            </div>
+            {sourceBKeyIdea && (
+              <p
+                data-testid="connection-key-idea-b"
+                className="mt-2 text-[13px] italic leading-[1.5] text-foreground/85"
+              >
+                &ldquo;{sourceBKeyIdea}&rdquo;
+              </p>
+            )}
+          </div>
         </div>
-      )}
-
-      <div
-        data-testid="connection-content"
-        className="prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
-      >
-        <Markdown>{post.content}</Markdown>
+        <p className="font-logo text-[18.5px] font-normal leading-[1.45] tracking-tight text-foreground">
+          {post.content}
+        </p>
       </div>
     </PostShell>
-  );
-}
-
-interface ConnectionProvenanceProps {
-  sourceATitleHint: string;
-  sourceBTitleHint: string;
-  primaryDocumentId: Id<"documents">;
-  isWithinDocument: boolean;
-}
-
-function ConnectionProvenance({
-  sourceATitleHint,
-  sourceBTitleHint,
-  primaryDocumentId,
-  isWithinDocument,
-}: ConnectionProvenanceProps) {
-  if (isWithinDocument) {
-    return (
-      <div
-        data-testid="connection-provenance"
-        className="mb-3 flex items-center gap-1.5 text-xs text-muted-foreground/70"
-      >
-        <FileText className="size-3 shrink-0" />
-        <span className="truncate">
-          Sections in:{" "}
-          <Link
-            to="/app/library/$documentId"
-            params={{ documentId: primaryDocumentId }}
-            className="underline decoration-muted-foreground/30 underline-offset-2 transition-colors hover:text-foreground/80 hover:decoration-muted-foreground/60"
-          >
-            {sourceATitleHint}
-          </Link>
-        </span>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      data-testid="connection-provenance"
-      className="mb-3 flex items-center gap-1.5 text-xs text-muted-foreground/70"
-    >
-      <FileText className="size-3 shrink-0" />
-      <span className="truncate">
-        Connecting:{" "}
-        <Link
-          to="/app/library/$documentId"
-          params={{ documentId: primaryDocumentId }}
-          className="underline decoration-muted-foreground/30 underline-offset-2 transition-colors hover:text-foreground/80 hover:decoration-muted-foreground/60"
-          aria-label={`Source: ${sourceATitleHint}`}
-        >
-          {sourceATitleHint}
-        </Link>
-        {" + "}
-        <span>{sourceBTitleHint}</span>
-      </span>
-    </div>
   );
 }

--- a/apps/web/src/components/posts/insight-post.tsx
+++ b/apps/web/src/components/posts/insight-post.tsx
@@ -1,19 +1,19 @@
 import Markdown from "react-markdown";
 
-import { PostShell, SourceBadge } from "./post-shell";
+import { PostShell } from "./post-shell";
 import type { PostView } from "./types";
 
 interface InsightPostProps {
   post: PostView;
+  onViewed?: (postId: string) => void;
 }
 
-export function InsightPost({ post }: InsightPostProps) {
+export function InsightPost({ post, onViewed }: InsightPostProps) {
   return (
-    <PostShell post={post}>
-      <SourceBadge post={post} />
+    <PostShell post={post} onViewed={onViewed}>
       <div
         data-testid="insight-content"
-        className="prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+        className="prose prose-sm prose-neutral max-w-none text-[15.5px] leading-[1.62] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 dark:prose-invert"
       >
         <Markdown>{post.content}</Markdown>
       </div>

--- a/apps/web/src/components/posts/post-shell.tsx
+++ b/apps/web/src/components/posts/post-shell.tsx
@@ -8,8 +8,12 @@ import type { ReactNode } from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import {
+  DocumentThumb,
+  FileTypeIcon,
+  ReadingProgress,
+} from "@/components/documents/document-thumb";
 import { TagList } from "@/components/tags";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -17,15 +21,24 @@ import { usePostImpression } from "@/hooks/use-post-impression";
 import { useDetailPanel } from "@/components/detail-panel";
 
 import { DislikeReasonSheet } from "./dislike-reason-sheet";
-import { getFileTypeConfig } from "./file-type-config";
 import type { DislikeReason, PostType, PostView } from "./types";
 
-const postAccentColor: Record<PostType, string> = {
-  insight: "border-l-primary",
-  quote: "border-l-amber-500",
-  summary: "border-l-blue-500",
-  connection: "border-l-violet-500",
-  quiz: "border-l-emerald-500",
+type AccentTokens = { rail: string; text: string };
+
+const postAccent: Record<PostType, AccentTokens> = {
+  insight: { rail: "bg-primary/60", text: "text-primary" },
+  quote: { rail: "bg-amber-500/60", text: "text-amber-600 dark:text-amber-400" },
+  summary: { rail: "bg-blue-500/60", text: "text-blue-600 dark:text-blue-400" },
+  connection: { rail: "bg-violet-500/60", text: "text-violet-600 dark:text-violet-400" },
+  quiz: { rail: "bg-emerald-500/60", text: "text-emerald-600 dark:text-emerald-400" },
+};
+
+const postTypeLabel: Record<PostType, string> = {
+  insight: "Insight",
+  quote: "Quote",
+  summary: "Summary",
+  connection: "Connection",
+  quiz: "Quiz",
 };
 
 function updatePostInPaginatedPages(
@@ -58,30 +71,14 @@ function removePostFromPaginatedPages(localStore: OptimisticLocalStore, postId: 
   }
 }
 
-export function SourceBadge({ post, className }: { post: PostView; className?: string }) {
-  const { Icon } = getFileTypeConfig(post.fileType);
-
-  return (
-    <div
-      data-testid="source-badge"
-      className={cn(
-        "mb-3 flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground",
-        className,
-      )}
-    >
-      <Icon className="size-3.5 shrink-0" />
-      <span className="truncate">{post.primarySourceDocumentTitle ?? "Untitled"}</span>
-    </div>
-  );
-}
-
 interface PostShellProps {
   post: PostView;
   children: ReactNode;
   quizVariant?: "multiple_choice" | "true_false";
+  onViewed?: (postId: string) => void;
 }
 
-export function PostShell({ post, children, quizVariant }: PostShellProps) {
+export function PostShell({ post, children, quizVariant, onViewed }: PostShellProps) {
   const posthog = usePostHog();
   const detailPanel = useDetailPanel();
   const [sheetOpen, setSheetOpen] = useState(false);
@@ -96,9 +93,13 @@ export function PostShell({ post, children, quizVariant }: PostShellProps) {
     }),
     [post.postType, post.createdAt],
   );
-  const impressionRef = usePostImpression(post._id, impressionProperties);
+  const impressionRef = usePostImpression(post._id, impressionProperties, {
+    onViewed: () => onViewed?.(post._id),
+  });
 
   const tags = post.tags ?? [];
+  const accent = postAccent[post.postType];
+  const selected = detailPanel?.selectedPost?._id === post._id;
 
   const toggleBookmark = useMutation(api.content.bookmarks.toggle).withOptimisticUpdate(
     (localStore, args) => {
@@ -192,51 +193,92 @@ export function PostShell({ post, children, quizVariant }: PostShellProps) {
       <article
         ref={impressionRef}
         data-testid="post-card"
+        data-post-id={post._id}
         data-post-type={post.postType}
         data-quiz-variant={quizVariant}
         className={cn(
-          "group/card relative min-w-0 border-l-2 border-t border-border first:border-t-0 bg-card text-card-foreground transition-colors",
-          postAccentColor[post.postType],
-          !detailPanel && "border-r",
-          detailPanel && "cursor-pointer hover:bg-accent/30",
+          "group/card relative grid min-w-0 scroll-mt-24 grid-cols-[38px_1fr] gap-5 border-b border-border bg-card pt-6 pr-6 pb-5 pl-5 text-card-foreground transition-colors",
+          detailPanel && "cursor-pointer",
+          detailPanel && !selected && "hover:bg-accent/30",
+          selected && "bg-primary/[0.04]",
         )}
         onClick={() => detailPanel?.openDetail(post)}
       >
-        <div className="px-6 pt-6 pb-5">
-          {post.isNew && (
-            <Badge
-              data-testid="new-badge"
-              aria-label="New: from a recently added document"
-              className="mb-2 gap-1 rounded-none border-emerald-500/40 bg-transparent text-emerald-600 dark:text-emerald-400"
-              variant="freshness"
-            >
-              <span aria-hidden="true" className="size-1.5 shrink-0 rounded-full bg-emerald-500" />
-              New
-            </Badge>
-          )}
+        <div aria-hidden className={cn("absolute inset-x-0 top-0 h-px", accent.rail)} />
+
+        <aside className="flex flex-col items-center gap-2 pt-[2px]">
+          <DocumentThumb
+            documentId={post.primarySourceDocumentId as unknown as string}
+            title={post.primarySourceDocumentTitle ?? "Untitled"}
+            fileType={post.fileType}
+            variant="spine"
+          />
+          <div className="h-full w-px bg-border" />
+        </aside>
+
+        <div className="min-w-0">
+          <div className="mb-4 flex items-center justify-between gap-4 font-mono text-[10.5px] uppercase tracking-[0.14em] text-muted-foreground">
+            <div className="flex min-w-0 items-center gap-2.5">
+              <span className={cn("font-medium", accent.text)}>{postTypeLabel[post.postType]}</span>
+              {quizVariant && (
+                <>
+                  <span className="text-foreground/30">·</span>
+                  <span>{quizVariant === "multiple_choice" ? "MC" : "True/False"}</span>
+                </>
+              )}
+              {post.isNew && (
+                <>
+                  <span className="text-foreground/30">·</span>
+                  <span
+                    data-testid="new-badge"
+                    aria-label="New: from a recently added document"
+                    className="inline-flex items-center gap-1.5 border border-emerald-500/25 bg-emerald-500/10 px-1.5 py-0.5 text-emerald-600 dark:text-emerald-400"
+                  >
+                    <span aria-hidden className="size-1 rounded-full bg-emerald-500" />
+                    New
+                  </span>
+                </>
+              )}
+            </div>
+            <div className="flex items-center gap-3 whitespace-nowrap text-muted-foreground/80">
+              {post.sectionTitle && <span className="truncate">&sect; {post.sectionTitle}</span>}
+              <ReadingProgress pageStart={post.pageStart} />
+            </div>
+          </div>
+
           {children}
 
           {tags.length > 0 && (
-            <div className="mt-2">
+            <div className="mt-4">
               <TagList tags={tags} maxVisible={3} size="sm" />
             </div>
           )}
 
-          <div className="mt-4 flex items-center justify-between border-t border-border pt-3">
-            <time className="text-xs tracking-wide text-muted-foreground/70">
-              {formatDistanceToNow(post.createdAt, { addSuffix: true })}
-            </time>
+          <div className="mt-5 grid grid-cols-[1fr_auto] items-end gap-6 border-t border-border pt-3">
+            <div className="flex min-w-0 items-center gap-2 text-[12px] leading-snug text-muted-foreground">
+              <FileTypeIcon fileType={post.fileType} className="text-muted-foreground/70" />
+              <span data-testid="source-badge" className="min-w-0 truncate">
+                <span className="border-b border-border font-logo text-[13.5px] font-medium text-foreground/85">
+                  {post.primarySourceDocumentTitle ?? "Untitled"}
+                </span>
+              </span>
+              <span className="text-foreground/30">·</span>
+              <time className="font-mono text-[11px] tracking-wide text-muted-foreground/60">
+                {formatDistanceToNow(post.createdAt, { addSuffix: true })}
+              </time>
+            </div>
 
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-0" onClick={(e) => e.stopPropagation()}>
               <Button
                 variant="ghost"
                 size="icon"
                 className={cn(
-                  "transition-all duration-200 active:scale-95 [&_svg]:transition-all [&_svg]:duration-200",
-                  post.isBookmarked && "bg-primary/15 text-primary hover:bg-primary/20",
+                  "size-8 rounded-none transition-all duration-200 active:scale-95",
+                  post.isBookmarked
+                    ? "bg-primary/10 text-primary hover:bg-primary/15"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
                 )}
-                onClick={(e) => {
-                  e.stopPropagation();
+                onClick={() => {
                   posthog.capture("post.bookmarked", {
                     post_type: post.postType,
                     bookmarked: !post.isBookmarked,
@@ -248,47 +290,46 @@ export function PostShell({ post, children, quizVariant }: PostShellProps) {
                 title="Save"
               >
                 {post.isBookmarked ? (
-                  <BookmarkCheck className="size-4" />
+                  <BookmarkCheck className="size-[15px]" />
                 ) : (
-                  <Bookmark className="size-4" />
+                  <Bookmark className="size-[15px]" />
                 )}
               </Button>
               <Button
                 variant="ghost"
                 size="icon"
                 className={cn(
-                  "transition-all duration-200 active:scale-95 [&_svg]:transition-all [&_svg]:duration-200",
-                  post.reaction === "like" &&
-                    "bg-emerald-500/15 text-emerald-600 hover:bg-emerald-500/20",
+                  "size-8 rounded-none transition-all duration-200 active:scale-95",
+                  post.reaction === "like"
+                    ? "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/15 dark:text-emerald-400"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
                 )}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleLikeClick();
-                }}
+                onClick={handleLikeClick}
                 data-testid="like-button"
                 aria-pressed={post.reaction === "like"}
                 title="Like"
               >
-                <ThumbsUp className={cn("size-4", post.reaction === "like" && "fill-current")} />
+                <ThumbsUp
+                  className={cn("size-[15px]", post.reaction === "like" && "fill-current")}
+                />
               </Button>
               <Button
                 ref={dislikeButtonRef}
                 variant="ghost"
                 size="icon"
                 className={cn(
-                  "transition-all duration-200 active:scale-95 [&_svg]:transition-all [&_svg]:duration-200",
-                  post.reaction === "dislike" && "bg-red-500/15 text-red-500 hover:bg-red-500/20",
+                  "size-8 rounded-none transition-all duration-200 active:scale-95",
+                  post.reaction === "dislike"
+                    ? "bg-red-500/10 text-red-500 hover:bg-red-500/15"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
                 )}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleDislikeClick();
-                }}
+                onClick={handleDislikeClick}
                 data-testid="dislike-button"
                 aria-pressed={post.reaction === "dislike"}
                 title="Dislike"
               >
                 <ThumbsDown
-                  className={cn("size-4", post.reaction === "dislike" && "fill-current")}
+                  className={cn("size-[15px]", post.reaction === "dislike" && "fill-current")}
                 />
               </Button>
             </div>

--- a/apps/web/src/components/posts/post.tsx
+++ b/apps/web/src/components/posts/post.tsx
@@ -12,28 +12,28 @@ export type { PostView };
 
 interface PostProps {
   post: PostView;
+  onViewed?: (postId: string) => void;
 }
 
-export function Post({ post }: PostProps) {
+export function Post({ post, onViewed }: PostProps) {
   const { typeData } = post;
 
   switch (typeData.type) {
     case "insight":
-      return <InsightPost post={post} />;
+      return <InsightPost post={post} onViewed={onViewed} />;
     case "quiz":
       if (typeData.variant === "multiple_choice") {
-        return <QuizMcPost post={{ ...post, typeData }} />;
+        return <QuizMcPost post={{ ...post, typeData }} onViewed={onViewed} />;
       }
-      return <QuizRevealPost post={{ ...post, typeData }} />;
+      return <QuizRevealPost post={{ ...post, typeData }} onViewed={onViewed} />;
     case "quote":
-      return <QuotePost post={{ ...post, typeData }} />;
+      return <QuotePost post={{ ...post, typeData }} onViewed={onViewed} />;
     case "summary":
-      return <SummaryPost post={{ ...post, typeData }} />;
+      return <SummaryPost post={{ ...post, typeData }} onViewed={onViewed} />;
     case "connection":
-      return <ConnectionPost post={{ ...post, typeData }} />;
-    default: {
-      const _exhaustive: never = typeData;
+      return <ConnectionPost post={{ ...post, typeData }} onViewed={onViewed} />;
+    default:
+      typeData satisfies never;
       return null;
-    }
   }
 }

--- a/apps/web/src/components/posts/quiz-mc-post.tsx
+++ b/apps/web/src/components/posts/quiz-mc-post.tsx
@@ -1,91 +1,105 @@
 import { CheckCircle2, XCircle } from "lucide-react";
 import { useState } from "react";
 
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-import { PostShell, SourceBadge } from "./post-shell";
+import { PostShell } from "./post-shell";
 import type { PostView, QuizTypeData } from "./types";
 
 interface QuizMcPostProps {
   post: PostView & { typeData: QuizTypeData };
+  onViewed?: (postId: string) => void;
 }
 
-export function QuizMcPost({ post }: QuizMcPostProps) {
+export function QuizMcPost({ post, onViewed }: QuizMcPostProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const { question, options, correctIndex, explanation } = post.typeData;
   const answered = selectedIndex !== null;
 
-  function getOptionState(index: number): "correct" | "incorrect" | undefined {
+  function getOptionState(i: number): "correct" | "incorrect" | undefined {
     if (!answered) return undefined;
-    if (index === correctIndex) return "correct";
-    if (index === selectedIndex) return "incorrect";
+    if (i === correctIndex) return "correct";
+    if (i === selectedIndex) return "incorrect";
     return undefined;
   }
 
   return (
-    <PostShell post={post} quizVariant={post.typeData.variant}>
-      <SourceBadge post={post} />
-      <div data-testid="quiz-question" className="mb-3 text-sm font-medium text-foreground">
-        {question}
-      </div>
-      <div className="space-y-2">
-        {options.map((option, index) => {
-          const isCorrect = index === correctIndex;
-          const isSelected = index === selectedIndex;
-          const optionState = getOptionState(index);
-
-          return (
-            <Button
-              key={index}
-              variant="outline"
-              className={cn(
-                "h-auto w-full justify-start whitespace-normal px-3 py-2.5 text-left text-sm transition-all",
-                !answered && "hover:border-primary/40 hover:bg-primary/[0.08]",
-                answered &&
-                  isCorrect &&
-                  "border-emerald-500/40 bg-emerald-500/[0.06] text-emerald-700 animate-in zoom-in-95 duration-200 dark:text-emerald-400",
-                answered &&
-                  isSelected &&
-                  !isCorrect &&
-                  "border-red-500/40 bg-red-500/[0.06] text-red-700 animate-shake dark:text-red-400",
-                answered && !isSelected && !isCorrect && "opacity-50",
-              )}
-              onClick={(e) => {
-                e.stopPropagation();
-                if (!answered) setSelectedIndex(index);
-              }}
-              disabled={answered}
-              data-testid="quiz-option"
-              data-option-state={optionState}
-            >
-              <span className="flex items-center gap-2">
-                {answered && isCorrect && (
-                  <CheckCircle2 className="size-4 shrink-0 text-emerald-500" />
-                )}
-                {answered && isSelected && !isCorrect && (
-                  <XCircle className="size-4 shrink-0 text-red-500" />
-                )}
-                {option}
-              </span>
-            </Button>
-          );
-        })}
-      </div>
-      {answered && (
-        <div
-          data-testid="quiz-explanation"
-          className={cn(
-            "mt-3 rounded-lg border p-3 text-sm leading-relaxed text-muted-foreground",
-            selectedIndex === correctIndex
-              ? "border-emerald-500/30 bg-transparent"
-              : "border-red-500/30 bg-transparent",
-            "animate-in fade-in slide-in-from-top-2 duration-300",
-          )}
+    <PostShell post={post} quizVariant={post.typeData.variant} onViewed={onViewed}>
+      <div>
+        <p
+          data-testid="quiz-question"
+          className="mb-4 font-logo text-[20px] font-medium leading-tight tracking-tight text-foreground"
         >
-          {explanation}
+          {question}
+        </p>
+        <div className="flex flex-col gap-1.5">
+          {options.map((option, i) => {
+            const isCorrect = i === correctIndex;
+            const isPicked = i === selectedIndex;
+            const state = getOptionState(i);
+            return (
+              <button
+                key={i}
+                type="button"
+                disabled={answered}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!answered) setSelectedIndex(i);
+                }}
+                data-testid="quiz-option"
+                data-option-state={state}
+                className={cn(
+                  "grid grid-cols-[28px_1fr_auto] items-center gap-2.5 border border-border bg-transparent px-3.5 py-2.5 text-left text-[14.5px] transition-colors",
+                  !answered && "cursor-pointer hover:border-primary/40 hover:bg-primary/5",
+                  answered && isCorrect && "border-emerald-500/45 bg-emerald-500/[0.06]",
+                  answered &&
+                    isPicked &&
+                    !isCorrect &&
+                    "border-red-500/45 bg-red-500/[0.06] text-red-500",
+                  answered && !isPicked && !isCorrect && "opacity-45",
+                )}
+              >
+                <span
+                  className={cn(
+                    "font-mono text-[11px] tracking-wider",
+                    answered && isCorrect
+                      ? "text-emerald-600 dark:text-emerald-400"
+                      : answered && isPicked
+                        ? "text-red-500"
+                        : "text-foreground/35",
+                  )}
+                >
+                  {String.fromCharCode(65 + i)}
+                </span>
+                <span>{option}</span>
+                <span className="font-mono text-[10.5px] uppercase tracking-wider">
+                  {answered && isCorrect && (
+                    <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+                      <CheckCircle2 className="size-3.5" /> Correct
+                    </span>
+                  )}
+                  {answered && isPicked && !isCorrect && (
+                    <span className="inline-flex items-center gap-1 text-red-500">
+                      <XCircle className="size-3.5" /> Your pick
+                    </span>
+                  )}
+                </span>
+              </button>
+            );
+          })}
         </div>
-      )}
+        {answered && (
+          <div
+            data-testid="quiz-explanation"
+            className={cn(
+              "mt-3 border px-3.5 py-2.5 text-[13.5px] leading-[1.55] text-foreground/85",
+              selectedIndex === correctIndex ? "border-emerald-500/35" : "border-red-500/35",
+            )}
+          >
+            {explanation}
+          </div>
+        )}
+      </div>
     </PostShell>
   );
 }

--- a/apps/web/src/components/posts/quiz-reveal-post.tsx
+++ b/apps/web/src/components/posts/quiz-reveal-post.tsx
@@ -4,56 +4,61 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-import { PostShell, SourceBadge } from "./post-shell";
+import { PostShell } from "./post-shell";
 import type { PostView, QuizTypeData } from "./types";
 
 interface QuizRevealPostProps {
   post: PostView & { typeData: QuizTypeData };
+  onViewed?: (postId: string) => void;
 }
 
-export function QuizRevealPost({ post }: QuizRevealPostProps) {
+export function QuizRevealPost({ post, onViewed }: QuizRevealPostProps) {
   const [revealed, setRevealed] = useState(false);
   const { question, options, correctIndex, explanation } = post.typeData;
 
   return (
-    <PostShell post={post} quizVariant={post.typeData.variant}>
-      <SourceBadge post={post} />
-      <div data-testid="quiz-question" className="mb-3 text-sm font-medium text-foreground">
-        {question}
-      </div>
-      {!revealed ? (
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full gap-2 border-emerald-500/30 text-emerald-600 transition-colors hover:border-emerald-500/50 hover:bg-emerald-500/5 dark:text-emerald-400"
-          onClick={(e) => {
-            e.stopPropagation();
-            setRevealed(true);
-          }}
-          data-testid="quiz-reveal-button"
+    <PostShell post={post} quizVariant={post.typeData.variant} onViewed={onViewed}>
+      <div>
+        <p
+          data-testid="quiz-question"
+          className="mb-4 font-logo text-[20px] font-medium leading-tight tracking-tight text-foreground"
         >
-          <Eye className="size-3.5" />
-          Reveal answer
-        </Button>
-      ) : (
-        <div
-          data-testid="quiz-answer"
-          className={cn(
-            "space-y-2 border border-emerald-500/30 bg-transparent p-3",
-            "animate-in fade-in slide-in-from-top-2 duration-300",
-          )}
-        >
-          <p className="text-sm font-medium text-emerald-600 dark:text-emerald-400">
-            {options[correctIndex] ?? "Answer unavailable"}
-          </p>
-          <p
-            data-testid="quiz-explanation"
-            className="text-sm leading-relaxed text-muted-foreground"
+          {question}
+        </p>
+        {!revealed ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full gap-2 rounded-none border-emerald-500/30 text-emerald-600 transition-colors hover:border-emerald-500/50 hover:bg-emerald-500/5 dark:text-emerald-400"
+            onClick={(e) => {
+              e.stopPropagation();
+              setRevealed(true);
+            }}
+            data-testid="quiz-reveal-button"
           >
-            {explanation}
-          </p>
-        </div>
-      )}
+            <Eye className="size-3.5" />
+            Reveal answer
+          </Button>
+        ) : (
+          <div
+            data-testid="quiz-answer"
+            className={cn(
+              "space-y-2 border border-emerald-500/35 bg-transparent p-3.5",
+              "animate-in fade-in slide-in-from-top-2 duration-300",
+            )}
+          >
+            <p className="font-logo text-[16px] font-medium text-emerald-600 dark:text-emerald-400">
+              {options[correctIndex] ?? "Answer unavailable"}
+            </p>
+            <p
+              data-testid="quiz-explanation"
+              className="text-[13.5px] leading-[1.55] text-foreground/85"
+            >
+              {explanation}
+            </p>
+          </div>
+        )}
+      </div>
     </PostShell>
   );
 }

--- a/apps/web/src/components/posts/quote-post.tsx
+++ b/apps/web/src/components/posts/quote-post.tsx
@@ -1,45 +1,41 @@
-import { useState } from "react";
-
-import { cn } from "@/lib/utils";
-
-import { PostShell, SourceBadge } from "./post-shell";
+import { PostShell } from "./post-shell";
 import type { PostView, QuoteTypeData } from "./types";
 
 interface QuotePostProps {
   post: PostView & { typeData: QuoteTypeData };
+  onViewed?: (postId: string) => void;
 }
 
-export function QuotePost({ post }: QuotePostProps) {
+export function QuotePost({ post, onViewed }: QuotePostProps) {
   const { quotedText, attribution } = post.typeData;
-  const [expanded, setExpanded] = useState(false);
 
   return (
-    <PostShell post={post}>
-      <SourceBadge post={post} />
+    <PostShell post={post} onViewed={onViewed}>
       <div>
         <blockquote
           data-testid="quoted-text"
-          className="text-base leading-relaxed text-foreground/90"
+          className="relative pl-8 font-logo text-[25px] font-medium leading-[1.3] tracking-tight text-foreground"
         >
+          <span
+            aria-hidden
+            className="absolute -top-2 left-0 font-logo text-[72px] font-semibold leading-none text-amber-500/45"
+          >
+            &ldquo;
+          </span>
           {quotedText}
         </blockquote>
         {attribution && (
-          <p data-testid="quote-attribution" className="mt-2 text-sm text-muted-foreground/70">
+          <p
+            data-testid="quote-attribution"
+            className="mt-3 pl-8 font-mono text-[11px] uppercase tracking-[0.16em] text-amber-600/90 dark:text-amber-400/90"
+          >
             &mdash; {attribution}
           </p>
         )}
         {post.content && (
           <p
             data-testid="quote-context"
-            className={cn(
-              "mt-1.5 cursor-pointer text-xs not-italic text-muted-foreground/50",
-              !expanded && "line-clamp-2",
-              expanded && "text-sm",
-            )}
-            onClick={(e) => {
-              e.stopPropagation();
-              setExpanded((prev) => !prev);
-            }}
+            className="mt-3 border-l border-border pl-3 text-[13.5px] leading-[1.55] text-muted-foreground"
           >
             {post.content}
           </p>

--- a/apps/web/src/components/posts/summary-post.tsx
+++ b/apps/web/src/components/posts/summary-post.tsx
@@ -1,45 +1,56 @@
 import Markdown from "react-markdown";
 
-import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 
-import { PostShell, SourceBadge } from "./post-shell";
+import { PostShell } from "./post-shell";
 import type { PostView, SummaryTypeData } from "./types";
 
 interface SummaryPostProps {
   post: PostView & { typeData: SummaryTypeData };
+  onViewed?: (postId: string) => void;
 }
 
-export function SummaryPost({ post }: SummaryPostProps) {
+export function SummaryPost({ post, onViewed }: SummaryPostProps) {
   const { bulletPoints } = post.typeData;
 
-  return (
-    <PostShell post={post}>
-      <div className="mb-3 flex items-center gap-2">
-        <SourceBadge post={post} className="mb-0" />
-        <Badge
-          data-testid="summary-badge"
-          className="rounded-none border-blue-500/30 bg-transparent text-blue-600 dark:text-blue-400"
-        >
-          Summary
-        </Badge>
-      </div>
-      {bulletPoints.length > 0 ? (
-        <ul data-testid="summary-bullets" className="space-y-1.5 text-sm text-foreground/80">
-          {bulletPoints.map((point, index) => (
-            <li key={index} className="flex gap-2">
-              <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-blue-500/40" />
-              <span>{point}</span>
-            </li>
-          ))}
-        </ul>
-      ) : (
+  if (bulletPoints.length === 0) {
+    return (
+      <PostShell post={post} onViewed={onViewed}>
         <div
           data-testid="summary-content"
-          className="prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+          className="prose prose-sm prose-neutral max-w-none leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 dark:prose-invert"
         >
           <Markdown>{post.content}</Markdown>
         </div>
-      )}
+      </PostShell>
+    );
+  }
+
+  return (
+    <PostShell post={post} onViewed={onViewed}>
+      <div>
+        {post.sectionTitle && (
+          <p className="mb-3 font-logo text-[19px] font-medium tracking-tight text-foreground">
+            {post.sectionTitle}
+          </p>
+        )}
+        <ol data-testid="summary-bullets" className="m-0 list-none p-0">
+          {bulletPoints.map((pt, i) => (
+            <li
+              key={i}
+              className={cn(
+                "grid grid-cols-[32px_1fr] gap-1 py-2",
+                i > 0 && "border-t border-dashed border-border",
+              )}
+            >
+              <span className="pt-0.5 font-mono text-[11px] tracking-wide text-blue-500">
+                {String(i + 1).padStart(2, "0")}
+              </span>
+              <span className="text-[14.5px] leading-[1.55] text-foreground/90">{pt}</span>
+            </li>
+          ))}
+        </ol>
+      </div>
     </PostShell>
   );
 }

--- a/apps/web/src/components/sign-in-form.tsx
+++ b/apps/web/src/components/sign-in-form.tsx
@@ -5,9 +5,7 @@ import z from "zod";
 
 import { authClient } from "@/lib/auth-client";
 
-import { ScrollectLogo } from "./scrollect-logo";
 import { Button } from "./ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 
@@ -44,92 +42,91 @@ export default function SignInForm({ onSwitchToSignUp }: { onSwitchToSignUp: () 
   });
 
   return (
-    <div className="flex flex-1 items-center justify-center px-4">
-      <Card className="w-full max-w-md animate-in fade-in slide-in-from-bottom-4 duration-500">
-        <CardHeader className="text-center">
-          <div className="mx-auto mb-2 text-primary">
-            <ScrollectLogo size="lg" />
-          </div>
-          <CardTitle className="text-2xl">Welcome back</CardTitle>
-          <CardDescription>Sign in to your Scrollect account</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              form.handleSubmit();
-            }}
-            className="space-y-4"
-          >
-            <form.Field name="email">
-              {(field) => (
-                <div className="space-y-2">
-                  <Label htmlFor={field.name}>Email</Label>
-                  <Input
-                    id={field.name}
-                    name={field.name}
-                    type="email"
-                    placeholder="you@example.com"
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                  {field.state.meta.errors.map((error) => (
-                    <p key={error?.message} className="text-sm text-destructive">
-                      {error?.message}
-                    </p>
-                  ))}
-                </div>
-              )}
-            </form.Field>
+    <div>
+      <div className="mb-8">
+        <h1 className="font-logo text-3xl font-semibold leading-[1.05] tracking-[-0.015em] sm:text-[2.25rem]">
+          Sign in
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Enter your email to continue to your feed.
+        </p>
+      </div>
 
-            <form.Field name="password">
-              {(field) => (
-                <div className="space-y-2">
-                  <Label htmlFor={field.name}>Password</Label>
-                  <Input
-                    id={field.name}
-                    name={field.name}
-                    type="password"
-                    placeholder="Enter your password"
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                  {field.state.meta.errors.map((error) => (
-                    <p key={error?.message} className="text-sm text-destructive">
-                      {error?.message}
-                    </p>
-                  ))}
-                </div>
-              )}
-            </form.Field>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          form.handleSubmit();
+        }}
+        className="space-y-4"
+      >
+        <form.Field name="email">
+          {(field) => (
+            <div className="space-y-2">
+              <Label htmlFor={field.name}>Email</Label>
+              <Input
+                id={field.name}
+                name={field.name}
+                type="email"
+                placeholder="you@example.com"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              {field.state.meta.errors.map((error) => (
+                <p key={error?.message} className="text-sm text-destructive">
+                  {error?.message}
+                </p>
+              ))}
+            </div>
+          )}
+        </form.Field>
 
-            <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
-              {([canSubmit, isSubmitting]) => (
-                <Button
-                  type="submit"
-                  className="w-full active:scale-[0.98]"
-                  disabled={!canSubmit || isSubmitting}
-                >
-                  {isSubmitting ? "Signing in..." : "Sign In"}
-                </Button>
-              )}
-            </form.Subscribe>
-          </form>
+        <form.Field name="password">
+          {(field) => (
+            <div className="space-y-2">
+              <Label htmlFor={field.name}>Password</Label>
+              <Input
+                id={field.name}
+                name={field.name}
+                type="password"
+                placeholder="Enter your password"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              {field.state.meta.errors.map((error) => (
+                <p key={error?.message} className="text-sm text-destructive">
+                  {error?.message}
+                </p>
+              ))}
+            </div>
+          )}
+        </form.Field>
 
-          <div className="mt-6 text-center text-sm text-muted-foreground">
-            Don&apos;t have an account?{" "}
-            <button
-              onClick={onSwitchToSignUp}
-              className="font-medium text-primary underline-offset-4 hover:underline"
+        <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
+          {([canSubmit, isSubmitting]) => (
+            <Button
+              type="submit"
+              size="lg"
+              className="mt-2 w-full border border-primary bg-primary text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.98]"
+              disabled={!canSubmit || isSubmitting}
             >
-              Sign up
-            </button>
-          </div>
-        </CardContent>
-      </Card>
+              {isSubmitting ? "Signing in..." : "Sign in"}
+            </Button>
+          )}
+        </form.Subscribe>
+      </form>
+
+      <div className="mt-8 text-sm text-muted-foreground">
+        New here?{" "}
+        <button
+          onClick={onSwitchToSignUp}
+          className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
+        >
+          Create an account
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/sign-up-form.tsx
+++ b/apps/web/src/components/sign-up-form.tsx
@@ -6,9 +6,7 @@ import z from "zod";
 
 import { authClient } from "@/lib/auth-client";
 
-import { ScrollectLogo } from "./scrollect-logo";
 import { Button } from "./ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 
@@ -48,133 +46,132 @@ export default function SignUpForm({ onSwitchToSignIn }: { onSwitchToSignIn: () 
   });
 
   return (
-    <div className="flex flex-1 items-center justify-center px-4">
-      <Card className="w-full max-w-md animate-in fade-in slide-in-from-bottom-4 duration-500">
-        <CardHeader className="text-center">
-          <div className="mx-auto mb-2 text-primary">
-            <ScrollectLogo size="lg" />
-          </div>
-          <CardTitle className="text-2xl">Create account</CardTitle>
-          <CardDescription>Start building your personal learning feed</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              form.handleSubmit();
-            }}
-            className="space-y-4"
-          >
-            <form.Field name="name">
-              {(field) => (
-                <div className="space-y-2">
-                  <Label htmlFor={field.name}>Name</Label>
-                  <Input
-                    id={field.name}
-                    name={field.name}
-                    placeholder="Your name"
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                  {field.state.meta.errors.map((error) => (
-                    <p key={error?.message} className="text-sm text-destructive">
-                      {error?.message}
-                    </p>
-                  ))}
-                </div>
-              )}
-            </form.Field>
+    <div>
+      <div className="mb-8">
+        <h1 className="font-logo text-3xl font-semibold leading-[1.05] tracking-[-0.015em] sm:text-[2.25rem]">
+          Create account
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Start your learning feed in under a minute.
+        </p>
+      </div>
 
-            <form.Field name="email">
-              {(field) => (
-                <div className="space-y-2">
-                  <Label htmlFor={field.name}>Email</Label>
-                  <Input
-                    id={field.name}
-                    name={field.name}
-                    type="email"
-                    placeholder="you@example.com"
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                  {field.state.meta.errors.map((error) => (
-                    <p key={error?.message} className="text-sm text-destructive">
-                      {error?.message}
-                    </p>
-                  ))}
-                </div>
-              )}
-            </form.Field>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          form.handleSubmit();
+        }}
+        className="space-y-4"
+      >
+        <form.Field name="name">
+          {(field) => (
+            <div className="space-y-2">
+              <Label htmlFor={field.name}>Name</Label>
+              <Input
+                id={field.name}
+                name={field.name}
+                placeholder="Your name"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              {field.state.meta.errors.map((error) => (
+                <p key={error?.message} className="text-sm text-destructive">
+                  {error?.message}
+                </p>
+              ))}
+            </div>
+          )}
+        </form.Field>
 
-            <form.Field name="password">
-              {(field) => (
-                <div className="space-y-2">
-                  <Label htmlFor={field.name}>Password</Label>
-                  <Input
-                    id={field.name}
-                    name={field.name}
-                    type="password"
-                    placeholder="At least 8 characters"
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                  {field.state.meta.errors.map((error) => (
-                    <p key={error?.message} className="text-sm text-destructive">
-                      {error?.message}
-                    </p>
-                  ))}
-                </div>
-              )}
-            </form.Field>
+        <form.Field name="email">
+          {(field) => (
+            <div className="space-y-2">
+              <Label htmlFor={field.name}>Email</Label>
+              <Input
+                id={field.name}
+                name={field.name}
+                type="email"
+                placeholder="you@example.com"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              {field.state.meta.errors.map((error) => (
+                <p key={error?.message} className="text-sm text-destructive">
+                  {error?.message}
+                </p>
+              ))}
+            </div>
+          )}
+        </form.Field>
 
-            <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
-              {([canSubmit, isSubmitting]) => (
-                <Button
-                  type="submit"
-                  className="w-full active:scale-[0.98]"
-                  disabled={!canSubmit || isSubmitting}
-                >
-                  {isSubmitting ? "Creating account..." : "Create Account"}
-                </Button>
-              )}
-            </form.Subscribe>
-          </form>
+        <form.Field name="password">
+          {(field) => (
+            <div className="space-y-2">
+              <Label htmlFor={field.name}>Password</Label>
+              <Input
+                id={field.name}
+                name={field.name}
+                type="password"
+                placeholder="At least 8 characters"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              {field.state.meta.errors.map((error) => (
+                <p key={error?.message} className="text-sm text-destructive">
+                  {error?.message}
+                </p>
+              ))}
+            </div>
+          )}
+        </form.Field>
 
-          <p className="mt-4 text-center text-xs text-muted-foreground">
-            By creating an account, you agree to our{" "}
-            <Link
-              to="/terms-and-conditions"
-              target="_blank"
-              className="underline underline-offset-4 hover:text-foreground focus-visible:text-foreground focus-visible:outline-none"
+        <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
+          {([canSubmit, isSubmitting]) => (
+            <Button
+              type="submit"
+              size="lg"
+              className="mt-2 w-full border border-primary bg-primary text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.98]"
+              disabled={!canSubmit || isSubmitting}
             >
-              Terms & Conditions
-            </Link>{" "}
-            and{" "}
-            <Link
-              to="/privacy-policy"
-              target="_blank"
-              className="underline underline-offset-4 hover:text-foreground focus-visible:text-foreground focus-visible:outline-none"
-            >
-              Privacy Policy
-            </Link>
-            .
-          </p>
+              {isSubmitting ? "Creating account..." : "Create account"}
+            </Button>
+          )}
+        </form.Subscribe>
+      </form>
 
-          <div className="mt-6 text-center text-sm text-muted-foreground">
-            Already have an account?{" "}
-            <button
-              onClick={onSwitchToSignIn}
-              className="font-medium text-primary underline-offset-4 hover:underline"
-            >
-              Sign in
-            </button>
-          </div>
-        </CardContent>
-      </Card>
+      <p className="mt-5 text-xs text-muted-foreground">
+        By creating an account, you agree to our{" "}
+        <Link
+          to="/terms-and-conditions"
+          target="_blank"
+          className="underline underline-offset-4 hover:text-foreground focus-visible:text-foreground focus-visible:outline-none"
+        >
+          Terms & Conditions
+        </Link>{" "}
+        and{" "}
+        <Link
+          to="/privacy-policy"
+          target="_blank"
+          className="underline underline-offset-4 hover:text-foreground focus-visible:text-foreground focus-visible:outline-none"
+        >
+          Privacy Policy
+        </Link>
+        .
+      </p>
+
+      <div className="mt-6 text-sm text-muted-foreground">
+        Already have an account?{" "}
+        <button
+          onClick={onSwitchToSignIn}
+          className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
+        >
+          Sign in
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/upload/upload-file-tab.tsx
+++ b/apps/web/src/components/upload/upload-file-tab.tsx
@@ -9,7 +9,6 @@ import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import type { LearningGoalOnboardingPrompt } from "@/components/upload/learning-goal-onboarding-dialog";
 import { useUploadErrorHandler } from "@/components/upload/upload-error-provider";
 import { useBilling } from "@/hooks/use-billing";
@@ -48,6 +47,8 @@ export function UploadFileTab({ onDocumentCreated }: UploadFileTabProps) {
 
   const generateUploadUrl = useMutation(api.content.documents.generateUploadUrl);
   const createDocument = useMutation(api.content.documents.create);
+
+  const isUploading = uploads.some((u) => u.status === "uploading");
 
   const uploadFile = useCallback(
     async (file: File) => {
@@ -143,15 +144,23 @@ export function UploadFileTab({ onDocumentCreated }: UploadFileTabProps) {
     (e: React.DragEvent) => {
       e.preventDefault();
       setDragOver(false);
+      if (isUploading) return;
       handleFiles(e.dataTransfer.files);
     },
-    [handleFiles],
+    [handleFiles, isUploading],
   );
 
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    setDragOver(true);
-  }, []);
+  const handleDragOver = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      if (isUploading) {
+        e.dataTransfer.dropEffect = "none";
+        return;
+      }
+      setDragOver(true);
+    },
+    [isUploading],
+  );
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -161,71 +170,135 @@ export function UploadFileTab({ onDocumentCreated }: UploadFileTabProps) {
   const activeUploads = uploads.filter((u) => u.status === "uploading");
   const settledUploads = uploads.filter((u) => u.status === "done" || u.status === "error");
 
+  const openFileDialog = () => {
+    if (isUploading) return;
+    fileInputRef.current?.click();
+  };
+
   return (
-    <>
-      <Card
+    <div>
+      <div
         data-testid="file-drop-zone"
+        role="button"
+        tabIndex={isUploading ? -1 : 0}
+        aria-disabled={isUploading}
+        onKeyDown={(e) => {
+          if (isUploading) return;
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            openFileDialog();
+          }
+        }}
         className={cn(
-          "group relative flex min-h-[320px] cursor-pointer flex-col items-center justify-center gap-5 overflow-hidden border-2 border-dashed p-8 transition-all",
-          dragOver
+          "group relative flex min-h-[340px] flex-col items-center justify-center gap-6 overflow-hidden border border-dashed px-8 py-12 transition-all",
+          isUploading
+            ? "cursor-not-allowed border-border/60 bg-muted/30 opacity-70"
+            : "cursor-pointer",
+          !isUploading && dragOver
             ? "border-primary bg-primary/5"
-            : "border-muted-foreground/20 hover:border-primary/40 hover:bg-muted/30",
+            : !isUploading &&
+                "border-muted-foreground/30 hover:border-primary/50 hover:bg-muted/30",
         )}
         onDrop={handleDrop}
         onDragOver={handleDragOver}
         onDragEnter={handleDragOver}
         onDragLeave={handleDragLeave}
-        onClick={() => fileInputRef.current?.click()}
+        onClick={openFileDialog}
       >
+        <Corner position="tl" active={dragOver && !isUploading} />
+        <Corner position="tr" active={dragOver && !isUploading} />
+        <Corner position="bl" active={dragOver && !isUploading} />
+        <Corner position="br" active={dragOver && !isUploading} />
+
+        <div className="flex items-center gap-3">
+          <span
+            aria-hidden
+            className={cn(
+              "inline-block size-1.5 rounded-full transition-colors",
+              isUploading ? "bg-muted-foreground/40" : dragOver ? "bg-primary" : "bg-primary/60",
+            )}
+          />
+          <span className="font-mono text-[10px] font-medium uppercase tracking-[0.32em] text-muted-foreground">
+            {isUploading ? "Upload In Progress" : "Drop Zone"}
+          </span>
+        </div>
+
         <div
           className={cn(
             "relative flex size-16 items-center justify-center border transition-colors",
-            dragOver
-              ? "border-primary/30 text-primary"
-              : "border-border text-muted-foreground group-hover:border-primary/30 group-hover:text-primary",
+            isUploading
+              ? "border-muted-foreground/30 text-muted-foreground/50"
+              : dragOver
+                ? "border-primary/30 text-primary"
+                : "border-border text-muted-foreground group-hover:border-primary/40 group-hover:text-primary",
           )}
         >
-          <CloudUpload className={cn("size-8", dragOver && "animate-float")} />
+          {isUploading ? (
+            <Loader2 className="size-7 animate-spin" />
+          ) : (
+            <CloudUpload className={cn("size-7", dragOver && "animate-float")} />
+          )}
         </div>
+
         <div className="text-center">
-          <p className="text-lg font-semibold">
-            {dragOver ? "Drop your files here" : "Drag & drop files here"}
+          <p className="font-logo text-2xl font-semibold tracking-tight md:text-3xl">
+            {isUploading
+              ? "Hold tight, uploading..."
+              : dragOver
+                ? "Release to upload"
+                : "Drop your files here"}
           </p>
-          <p className="mt-1 text-sm text-muted-foreground">or click to browse your computer</p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {isUploading
+              ? "Finish the current upload before adding more files."
+              : "or click anywhere in this area to browse"}
+          </p>
         </div>
+
         <Button
           variant="outline"
           type="button"
+          size="sm"
+          disabled={isUploading}
           onClick={(e) => {
             e.stopPropagation();
-            fileInputRef.current?.click();
+            openFileDialog();
           }}
         >
           <FileUp data-icon="inline-start" />
           Choose files
         </Button>
-        <p className="text-xs text-muted-foreground">
-          Accepts .pdf (max {formatFileSize(fileSizeLimits.pdf)}), .epub (max{" "}
-          {formatFileSize(fileSizeLimits.epub)}), and .md (max {formatFileSize(fileSizeLimits.md)})
-        </p>
+
+        <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
+          <FormatChip ext="pdf" limit={fileSizeLimits.pdf} />
+          <FormatChip ext="epub" limit={fileSizeLimits.epub} />
+          <FormatChip ext="md" limit={fileSizeLimits.md} />
+        </div>
+
         <input
           ref={fileInputRef}
           data-testid="file-input"
           type="file"
           accept=".pdf,.epub,.md"
           multiple
+          disabled={isUploading}
           className="hidden"
           onChange={(e) => {
-            if (e.target.files) handleFiles(e.target.files);
+            if (e.target.files && !isUploading) handleFiles(e.target.files);
             e.target.value = "";
           }}
         />
-      </Card>
+      </div>
 
       {activeUploads.length > 0 && (
-        <div className="mt-4 flex items-center gap-2 border border-primary/30 px-4 py-3 text-sm text-primary animate-in fade-in slide-in-from-bottom-2 duration-300">
+        <div className="mt-4 flex items-center gap-3 border border-primary/30 bg-primary/5 px-4 py-3 text-sm text-primary animate-in fade-in slide-in-from-bottom-2 duration-300">
           <Loader2 className="size-4 animate-spin" />
-          Uploading {activeUploads.length} file{activeUploads.length > 1 ? "s" : ""}...
+          <span className="font-medium">
+            Uploading {activeUploads.length} file{activeUploads.length > 1 ? "s" : ""}
+          </span>
+          <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.22em] opacity-70">
+            Locked
+          </span>
         </div>
       )}
 
@@ -248,12 +321,14 @@ export function UploadFileTab({ onDocumentCreated }: UploadFileTabProps) {
               )}
               <span className="min-w-0 truncate font-medium">{u.file.name}</span>
               {u.status === "done" && (
-                <span className="ml-auto shrink-0 text-xs opacity-70">
-                  Processing in background
+                <span className="ml-auto shrink-0 font-mono text-[10px] uppercase tracking-[0.2em] opacity-70">
+                  Processing
                 </span>
               )}
               {u.status === "error" && (
-                <span className="ml-auto shrink-0 text-xs opacity-70">Upload failed</span>
+                <span className="ml-auto shrink-0 font-mono text-[10px] uppercase tracking-[0.2em] opacity-70">
+                  Failed
+                </span>
               )}
             </div>
           ))}
@@ -270,6 +345,34 @@ export function UploadFileTab({ onDocumentCreated }: UploadFileTabProps) {
           </div>
         </div>
       )}
-    </>
+    </div>
+  );
+}
+
+function FormatChip({ ext, limit }: { ext: string; limit: number }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="text-foreground/70">.{ext}</span>
+      <span className="text-muted-foreground/50">≤ {formatFileSize(limit)}</span>
+    </span>
+  );
+}
+
+function Corner({ position, active }: { position: "tl" | "tr" | "bl" | "br"; active: boolean }) {
+  const positions = {
+    tl: "left-2 top-2 border-l border-t",
+    tr: "right-2 top-2 border-r border-t",
+    bl: "left-2 bottom-2 border-l border-b",
+    br: "right-2 bottom-2 border-r border-b",
+  } as const;
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute size-4 transition-colors",
+        positions[position],
+        active ? "border-primary" : "border-transparent",
+      )}
+    />
   );
 }

--- a/apps/web/src/components/upload/upload-text-tab.tsx
+++ b/apps/web/src/components/upload/upload-text-tab.tsx
@@ -2,19 +2,18 @@ import { api } from "@scrollect/backend/convex/_generated/api";
 import { formatFileSize, getFileSizeLimits } from "@scrollect/backend/src/platform/fileSizeLimits";
 import { useMutation } from "convex/react";
 import { Link } from "@tanstack/react-router";
-import { FileText, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import type { LearningGoalOnboardingPrompt } from "@/components/upload/learning-goal-onboarding-dialog";
 import { useUploadErrorHandler } from "@/components/upload/upload-error-provider";
 import { useBilling } from "@/hooks/use-billing";
+import { cn } from "@/lib/utils";
 
 type UploadTextTabProps = {
   onDocumentCreated: (prompt: LearningGoalOnboardingPrompt) => void;
@@ -34,22 +33,27 @@ export function UploadTextTab({ onDocumentCreated }: UploadTextTabProps) {
   const generateUploadUrl = useMutation(api.content.documents.generateUploadUrl);
   const createFromText = useMutation(api.content.documents.createFromText);
 
+  const trimmedText = text.trim();
+  const trimmedTitle = title.trim();
+  const bytes = trimmedText ? new Blob([trimmedText]).size : 0;
+  const overLimit = bytes > fileSizeLimits.text;
+
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
-      const trimmedText = text.trim();
-      const trimmedTitle = title.trim();
+      const valueText = text.trim();
+      const valueTitle = title.trim();
 
-      if (!trimmedText) {
+      if (!valueText) {
         toast.error("Please enter some text content.");
         return;
       }
-      if (!trimmedTitle) {
+      if (!valueTitle) {
         toast.error("Please enter a title.");
         return;
       }
 
-      const textBytes = new Blob([trimmedText]).size;
+      const textBytes = new Blob([valueText]).size;
       if (textBytes > fileSizeLimits.text) {
         toast.error(
           `Text too large (${formatFileSize(textBytes)}). Maximum is ${formatFileSize(fileSizeLimits.text)}.`,
@@ -63,7 +67,7 @@ export function UploadTextTab({ onDocumentCreated }: UploadTextTabProps) {
         const result = await fetch(uploadUrl, {
           method: "POST",
           headers: { "Content-Type": "text/markdown" },
-          body: trimmedText,
+          body: valueText,
         });
 
         if (!result.ok) {
@@ -73,10 +77,10 @@ export function UploadTextTab({ onDocumentCreated }: UploadTextTabProps) {
         const { storageId } = (await result.json()) as { storageId: string };
 
         const documentId = await createFromText({
-          title: trimmedTitle,
+          title: valueTitle,
           storageId: storageId as never,
         });
-        onDocumentCreated({ documentId, documentTitle: trimmedTitle, sourceType: "text" });
+        onDocumentCreated({ documentId, documentTitle: valueTitle, sourceType: "text" });
 
         setTitle("");
         setText("");
@@ -84,11 +88,11 @@ export function UploadTextTab({ onDocumentCreated }: UploadTextTabProps) {
         setTextTouched(false);
         posthog.capture("content.uploaded", {
           source_type: "text",
-          file_size: new Blob([trimmedText]).size,
+          file_size: new Blob([valueText]).size,
         });
         toast.success(
           <span>
-            <strong>{trimmedTitle}</strong> added! Processing typically takes 3-5 minutes and
+            <strong>{valueTitle}</strong> added! Processing typically takes 3-5 minutes and
             continues in the background. Add a learning goal now so posts use it.{" "}
             <Link to="/app/library" className="underline">
               View in library
@@ -115,31 +119,42 @@ export function UploadTextTab({ onDocumentCreated }: UploadTextTabProps) {
   );
 
   return (
-    <Card className="border border-border p-8">
-      <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-        <div className="flex flex-col items-center gap-3 text-center">
-          <div className="flex size-16 items-center justify-center border border-border text-muted-foreground">
-            <FileText className="size-8" />
-          </div>
-          <div>
-            <p className="text-lg font-semibold">Paste Text</p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Paste any text to add it to your library (max {formatFileSize(fileSizeLimits.text)}
-              ).
-            </p>
-          </div>
+    <div className="border border-border bg-card">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-5 p-6 md:p-8">
+        <div className="flex items-center gap-3">
+          <span aria-hidden className="inline-block size-1.5 rounded-full bg-primary/70" />
+          <span className="font-mono text-[10px] font-medium uppercase tracking-[0.32em] text-muted-foreground">
+            Write or paste
+          </span>
+          <div className="h-px flex-1 bg-border" />
+        </div>
+
+        <div>
+          <h2 className="font-logo text-2xl font-semibold tracking-tight md:text-[1.75rem]">
+            Your own notes
+          </h2>
+          <p className="mt-1.5 text-sm text-muted-foreground">
+            Paste meeting notes, a summary, or any text worth keeping. Max{" "}
+            {formatFileSize(fileSizeLimits.text)}.
+          </p>
         </div>
 
         <div className="flex flex-col gap-2">
-          <Label htmlFor="text-title">Title</Label>
+          <label
+            htmlFor="text-title"
+            className="font-mono text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground"
+          >
+            Title
+          </label>
           <Input
             id="text-title"
             data-testid="text-title-input"
-            placeholder="e.g., Meeting notes, Research summary"
+            placeholder="e.g., Q3 strategy notes"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             onBlur={() => setTitleTouched(true)}
             disabled={submitting}
+            className="h-11"
           />
           {titleTouched && !title.trim() && (
             <p className="text-sm text-destructive">Title is required</p>
@@ -147,7 +162,12 @@ export function UploadTextTab({ onDocumentCreated }: UploadTextTabProps) {
         </div>
 
         <div className="flex flex-col gap-2">
-          <Label htmlFor="text-content">Content</Label>
+          <label
+            htmlFor="text-content"
+            className="font-mono text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground"
+          >
+            Content
+          </label>
           <Textarea
             id="text-content"
             data-testid="text-content-input"
@@ -156,24 +176,32 @@ export function UploadTextTab({ onDocumentCreated }: UploadTextTabProps) {
             onChange={(e) => setText(e.target.value)}
             onBlur={() => setTextTouched(true)}
             disabled={submitting}
-            rows={6}
+            rows={10}
             className="resize-y"
           />
-          {textTouched && !text.trim() && (
-            <p className="text-sm text-destructive">Text content is required</p>
-          )}
-          {text.trim() && (
-            <p className="text-xs text-muted-foreground">
-              {formatFileSize(new Blob([text.trim()]).size)} of{" "}
-              {formatFileSize(fileSizeLimits.text)}
-            </p>
-          )}
+          <div className="flex items-center justify-between">
+            {textTouched && !text.trim() ? (
+              <p className="text-sm text-destructive">Text content is required</p>
+            ) : (
+              <span className="text-xs text-muted-foreground">
+                {trimmedText ? `${trimmedText.length.toLocaleString()} characters` : ""}
+              </span>
+            )}
+            <span
+              className={cn(
+                "font-mono text-[10px] tabular-nums uppercase tracking-[0.2em]",
+                overLimit ? "text-destructive" : "text-muted-foreground/70",
+              )}
+            >
+              {formatFileSize(bytes)} / {formatFileSize(fileSizeLimits.text)}
+            </span>
+          </div>
         </div>
 
         <Button
           data-testid="text-submit"
           type="submit"
-          disabled={submitting || !text.trim() || !title.trim()}
+          disabled={submitting || !trimmedText || !trimmedTitle || overLimit}
           className="w-full"
         >
           {submitting ? (
@@ -182,10 +210,10 @@ export function UploadTextTab({ onDocumentCreated }: UploadTextTabProps) {
               Processing...
             </>
           ) : (
-            "Add to Library"
+            "Add to library"
           )}
         </Button>
       </form>
-    </Card>
+    </div>
   );
 }

--- a/apps/web/src/components/upload/upload-url-tab.tsx
+++ b/apps/web/src/components/upload/upload-url-tab.tsx
@@ -8,7 +8,6 @@ import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import type { LearningGoalOnboardingPrompt } from "@/components/upload/learning-goal-onboarding-dialog";
 import { useUploadErrorHandler } from "@/components/upload/upload-error-provider";
@@ -46,23 +45,24 @@ export function UploadUrlTab({ onDocumentCreated }: UploadUrlTabProps) {
 
   const createFromUrl = useMutation(api.content.documents.createFromUrl);
 
-  const detectedType = url.trim() ? detectUrlType(url.trim()) : null;
-  const urlValid = url.trim() ? isValidUrl(url.trim()) : null;
+  const trimmed = url.trim();
+  const detectedType = trimmed ? detectUrlType(trimmed) : null;
+  const urlValid = trimmed ? isValidUrl(trimmed) : null;
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
-      const trimmed = url.trim();
-      if (!trimmed || !isValidUrl(trimmed)) {
+      const value = url.trim();
+      if (!value || !isValidUrl(value)) {
         toast.error("Please enter a valid URL starting with http:// or https://");
         return;
       }
 
       setSubmitting(true);
       try {
-        const fileType = detectUrlType(trimmed);
-        const documentId = await createFromUrl({ url: trimmed, fileType });
-        onDocumentCreated({ documentId, documentTitle: trimmed, sourceType: fileType });
+        const fileType = detectUrlType(value);
+        const documentId = await createFromUrl({ url: value, fileType });
+        onDocumentCreated({ documentId, documentTitle: value, sourceType: fileType });
         posthog.capture("content.uploaded", {
           source_type: fileType,
         });
@@ -90,30 +90,42 @@ export function UploadUrlTab({ onDocumentCreated }: UploadUrlTabProps) {
   );
 
   return (
-    <Card className="border border-border p-8">
-      <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-        <div className="flex flex-col items-center gap-3 text-center">
-          <div className="flex size-16 items-center justify-center border border-border text-muted-foreground">
-            <Globe className="size-8" />
-          </div>
-          <div>
-            <p className="text-lg font-semibold">Paste a URL</p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Add an article or YouTube video to your library.
-            </p>
-          </div>
+    <div className="border border-border bg-card">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-5 p-6 md:p-8">
+        <div className="flex items-center gap-3">
+          <span aria-hidden className="inline-block size-1.5 rounded-full bg-primary/70" />
+          <span className="font-mono text-[10px] font-medium uppercase tracking-[0.32em] text-muted-foreground">
+            From the web
+          </span>
+          <div className="h-px flex-1 bg-border" />
+        </div>
+
+        <div>
+          <h2 className="font-logo text-2xl font-semibold tracking-tight md:text-[1.75rem]">
+            Paste a link
+          </h2>
+          <p className="mt-1.5 text-sm text-muted-foreground">
+            Articles, blog posts, and YouTube videos are supported.
+          </p>
         </div>
 
         <div className="flex flex-col gap-2">
+          <label
+            htmlFor="url-input"
+            className="font-mono text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground"
+          >
+            URL
+          </label>
           <div className="relative">
             <Input
+              id="url-input"
               data-testid="url-input"
               type="url"
               placeholder="https://example.com/article or YouTube URL"
               value={url}
               onChange={(e) => setUrl(e.target.value)}
               disabled={submitting}
-              className="pr-24"
+              className="h-11 pr-28"
             />
             {detectedType && urlValid && (
               <div className="absolute right-2 top-1/2 -translate-y-1/2">
@@ -133,20 +145,17 @@ export function UploadUrlTab({ onDocumentCreated }: UploadUrlTabProps) {
               </div>
             )}
           </div>
-          {url.trim() && urlValid === false && (
+          {trimmed && urlValid === false && (
             <p className="text-sm text-destructive">
               Please enter a valid URL starting with https://
             </p>
           )}
-          <p className="text-xs text-muted-foreground">
-            Supported: articles, blog posts, YouTube videos
-          </p>
         </div>
 
         <Button
           data-testid="url-submit"
           type="submit"
-          disabled={submitting || !url.trim() || !urlValid}
+          disabled={submitting || !trimmed || !urlValid}
           className="w-full"
         >
           {submitting ? (
@@ -155,10 +164,10 @@ export function UploadUrlTab({ onDocumentCreated }: UploadUrlTabProps) {
               Processing...
             </>
           ) : (
-            "Add"
+            "Add to library"
           )}
         </Button>
       </form>
-    </Card>
+    </div>
   );
 }

--- a/apps/web/src/hooks/__tests__/use-feed-unread-posts.test.ts
+++ b/apps/web/src/hooks/__tests__/use-feed-unread-posts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { mergeUnreadPostIds, pruneStore, uniquePostIds } from "../use-feed-unread-posts";
+
+describe("feed unread post helpers", () => {
+  it("deduplicates post ids while keeping the first occurrence", () => {
+    expect(uniquePostIds(["post-a", "post-b", "post-a", "", "post-c"])).toEqual([
+      "post-a",
+      "post-b",
+      "post-c",
+    ]);
+  });
+
+  it("keeps newly generated ids before older unread ids", () => {
+    expect(mergeUnreadPostIds(["old-a", "old-b"], ["new-a", "old-a", "new-b"])).toEqual([
+      "new-a",
+      "old-a",
+      "new-b",
+      "old-b",
+    ]);
+  });
+
+  it("drops invalid and stale scope entries from storage", () => {
+    const now = new Date("2026-04-20T12:00:00.000Z").getTime();
+    const staleCreatedAt = now - 8 * 24 * 60 * 60 * 1000;
+
+    expect(
+      pruneStore(
+        {
+          all: { postIds: ["post-a", "post-a"], createdAt: now },
+          "document:doc-a": { postIds: ["post-b"], createdAt: staleCreatedAt },
+          broken: { postIds: "post-c", createdAt: now },
+        },
+        now,
+      ),
+    ).toEqual({
+      all: { postIds: ["post-a"], createdAt: now },
+    });
+  });
+});

--- a/apps/web/src/hooks/use-feed-unread-posts.ts
+++ b/apps/web/src/hooks/use-feed-unread-posts.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+const STORAGE_KEY = "scrollect.feed.unreadPostBatches.v1";
+const MAX_BATCH_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+type FeedUnreadStore = Record<string, FeedUnreadEntry>;
+
+type FeedUnreadEntry = {
+  postIds: string[];
+  createdAt: number;
+};
+
+function readStore(): FeedUnreadStore {
+  if (typeof window === "undefined") return {};
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return pruneStore(parsed, Date.now());
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: FeedUnreadStore) {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // Browsing the feed should keep working even if storage is unavailable.
+  }
+}
+
+function isValidEntry(value: unknown): value is FeedUnreadEntry {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Partial<FeedUnreadEntry>;
+  return Array.isArray(entry.postIds) && typeof entry.createdAt === "number";
+}
+
+export function pruneStore(value: unknown, now: number): FeedUnreadStore {
+  if (!value || typeof value !== "object") return {};
+
+  const store: FeedUnreadStore = {};
+  for (const [scopeKey, entry] of Object.entries(value)) {
+    if (!isValidEntry(entry)) continue;
+    if (now - entry.createdAt > MAX_BATCH_AGE_MS) continue;
+
+    const postIds = uniquePostIds(entry.postIds);
+    if (postIds.length === 0) continue;
+    store[scopeKey] = { postIds, createdAt: entry.createdAt };
+  }
+
+  return store;
+}
+
+export function uniquePostIds(postIds: string[]) {
+  return [...new Set(postIds.filter(Boolean))];
+}
+
+export function mergeUnreadPostIds(currentIds: string[], nextIds: string[]) {
+  return uniquePostIds([...nextIds, ...currentIds]);
+}
+
+export function useFeedUnreadPosts(scopeKey: string) {
+  const [store, setStore] = useState<FeedUnreadStore>(() => readStore());
+  const activeEntry = store[scopeKey];
+  const unreadPostIds = activeEntry?.postIds ?? [];
+  const unreadPostIdSet = useMemo(() => new Set(unreadPostIds), [unreadPostIds]);
+
+  useEffect(() => {
+    writeStore(store);
+  }, [store]);
+
+  const registerBatch = useCallback(
+    (postIds: string[]) => {
+      const nextIds = uniquePostIds(postIds);
+      if (nextIds.length === 0) return;
+
+      setStore((current) => {
+        const existing = current[scopeKey]?.postIds ?? [];
+        return {
+          ...current,
+          [scopeKey]: {
+            postIds: mergeUnreadPostIds(existing, nextIds),
+            createdAt: Date.now(),
+          },
+        };
+      });
+    },
+    [scopeKey],
+  );
+
+  const clearBatch = useCallback(() => {
+    setStore((current) => {
+      if (!current[scopeKey]) return current;
+
+      const { [scopeKey]: _removed, ...rest } = current;
+      return rest;
+    });
+  }, [scopeKey]);
+
+  const markBatchSeenForPost = useCallback(
+    (postId: string) => {
+      if (!unreadPostIdSet.has(postId)) return;
+      clearBatch();
+    },
+    [clearBatch, unreadPostIdSet],
+  );
+
+  return {
+    firstUnreadPostId: unreadPostIds[0],
+    unreadCount: unreadPostIds.length,
+    unreadPostIdSet,
+    registerBatch,
+    clearBatch,
+    markBatchSeenForPost,
+  };
+}

--- a/apps/web/src/hooks/use-post-impression.ts
+++ b/apps/web/src/hooks/use-post-impression.ts
@@ -1,37 +1,71 @@
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useRef } from "react";
 
-export function usePostImpression(postId: string, properties: Record<string, unknown>) {
+interface UsePostImpressionOptions {
+  dwellTimeMs?: number;
+  onViewed?: () => void;
+  threshold?: number;
+}
+
+export function usePostImpression(
+  postId: string,
+  properties: Record<string, unknown>,
+  options: UsePostImpressionOptions = {},
+) {
   const posthog = usePostHog();
   const hasTracked = useRef(false);
   const ref = useRef<HTMLElement>(null);
   const propertiesRef = useRef(properties);
+  const onViewedRef = useRef(options.onViewed);
+  const dwellTimeMs = options.dwellTimeMs ?? 500;
+  const threshold = options.threshold ?? 0.5;
   propertiesRef.current = properties;
+  onViewedRef.current = options.onViewed;
 
   useEffect(() => {
     hasTracked.current = false;
     const element = ref.current;
     if (!element) return;
+    let dwellTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const clearDwellTimer = () => {
+      if (!dwellTimer) return;
+      clearTimeout(dwellTimer);
+      dwellTimer = undefined;
+    };
+
+    const trackViewed = () => {
+      if (hasTracked.current) return;
+      hasTracked.current = true;
+      const props = { ...propertiesRef.current };
+      if (typeof props.created_at === "number") {
+        props.post_age_hours = Math.round((Date.now() - props.created_at) / 3600000);
+        delete props.created_at;
+      }
+      posthog.capture("post.viewed", props);
+      onViewedRef.current?.();
+      observer.disconnect();
+    };
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting && !hasTracked.current) {
-          hasTracked.current = true;
-          const props = { ...propertiesRef.current };
-          if (typeof props.created_at === "number") {
-            props.post_age_hours = Math.round((Date.now() - props.created_at) / 3600000);
-            delete props.created_at;
-          }
-          posthog.capture("post.viewed", props);
-          observer.disconnect();
+        if (hasTracked.current) return;
+        if (entry.isIntersecting) {
+          clearDwellTimer();
+          dwellTimer = setTimeout(trackViewed, dwellTimeMs);
+        } else {
+          clearDwellTimer();
         }
       },
-      { threshold: 0.5 },
+      { threshold },
     );
 
     observer.observe(element);
-    return () => observer.disconnect();
-  }, [posthog, postId]);
+    return () => {
+      clearDwellTimer();
+      observer.disconnect();
+    };
+  }, [dwellTimeMs, posthog, postId, threshold]);
 
   return ref;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -60,7 +60,7 @@
   --secondary: oklch(0.2 0.025 240);
   --secondary-foreground: oklch(0.93 0.01 200);
   --muted: oklch(0.2 0.025 240);
-  --muted-foreground: oklch(0.55 0.025 200);
+  --muted-foreground: oklch(0.62 0.025 200);
   --accent: oklch(0.22 0.03 200);
   --accent-foreground: oklch(0.93 0.01 200);
   --destructive: oklch(0.704 0.191 22.216);

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -29,9 +29,8 @@ function AuthenticatedLayout() {
   const isFeedRoute = pathname === "/app/feed" || pathname === "/app/saved";
   const isLibraryList = pathname === "/app/library" || pathname === "/app/library/";
   const detailGridClassName =
-    "grid min-w-0 flex-1 grid-cols-1 lg:h-[calc(100svh-3.5rem)] lg:min-h-0 lg:overflow-hidden lg:grid-cols-[minmax(0,60%)_minmax(0,40%)]";
-  const detailMainClassName =
-    "min-w-0 border-r border-border lg:min-h-0 lg:overflow-y-auto lg:overscroll-contain";
+    "grid min-h-[calc(100svh-3.5rem)] min-w-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,60%)_minmax(0,40%)]";
+  const detailMainClassName = "min-w-0";
 
   return (
     <SidebarProvider open={true}>
@@ -46,9 +45,9 @@ function AuthenticatedLayout() {
           <UserMenu />
         </div>
       </header>
-      <div className="flex min-h-svh w-full min-w-0 pt-14 lg:h-svh lg:overflow-hidden">
+      <div className="flex min-h-svh w-full min-w-0 pt-14">
         <AppSidebar />
-        <SidebarInset className="min-h-[calc(100svh-3.5rem)] min-w-0 overflow-x-hidden lg:h-[calc(100svh-3.5rem)] lg:min-h-0 lg:overflow-hidden">
+        <SidebarInset className="min-h-[calc(100svh-3.5rem)] min-w-0 overflow-x-hidden">
           {isFeedRoute ? (
             <DetailPanelProvider>
               <div className={detailGridClassName}>
@@ -68,7 +67,7 @@ function AuthenticatedLayout() {
               </div>
             </LibraryDetailProvider>
           ) : (
-            <main className="w-full max-w-3xl shrink-0">
+            <main className="w-full min-w-0">
               <Outlet />
             </main>
           )}

--- a/apps/web/src/routes/_authenticated/app/feed.tsx
+++ b/apps/web/src/routes/_authenticated/app/feed.tsx
@@ -9,11 +9,14 @@ import { usePostHog } from "posthog-js/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { StatusBadge } from "@/components/document-status";
+import { UnreadPostsBanner } from "@/components/feed/unread-posts-banner";
+import { PageHeader } from "@/components/page-header";
 import { Post } from "@/components/posts";
 import { buildTagMap } from "@/components/tags";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useFeedUnreadPosts } from "@/hooks/use-feed-unread-posts";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 
 type FeedSearch = {
@@ -57,6 +60,7 @@ function FeedPage() {
     () => (scopedDocumentId ? { documentId: scopedDocumentId } : {}),
     [scopedDocumentId],
   );
+  const feedScopeKey = scopedDocumentId ? `document:${scopedDocumentId}` : "all";
 
   const { results, status, loadMore } = usePaginatedQuery(api.feed.queries.list, feedArgs, {
     initialNumItems: 10,
@@ -66,13 +70,26 @@ function FeedPage() {
   const { data: scopedDocument } = useQuery(
     convexQuery(api.content.documents.get, scopedDocumentId ? { id: scopedDocumentId } : "skip"),
   );
+  const feedScopeLabel = scopedDocumentId
+    ? (scopedDocument?.title ?? "this document feed")
+    : "your feed";
 
   const [serving, setServing] = useState(false);
   const [serveReason, setServeReason] = useState<"no_drafts" | "processing" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pendingJumpPostId, setPendingJumpPostId] = useState<string | null>(null);
   const autoServedScopeRef = useRef<string | null>(null);
+  const jumpLoadRequestRef = useRef<string | null>(null);
 
   const posthog = usePostHog();
+  const {
+    firstUnreadPostId,
+    unreadCount,
+    unreadPostIdSet,
+    registerBatch,
+    clearBatch,
+    markBatchSeenForPost,
+  } = useFeedUnreadPosts(feedScopeKey);
 
   const servingRef = useRef(false);
 
@@ -92,6 +109,11 @@ function FeedPage() {
         scope: scopedDocumentId ? "document" : "all",
         documentId: scopedDocumentId ?? null,
       });
+      if (result.posts.length > 0) {
+        const postIds = result.posts.map((postId) => postId as string);
+        registerBatch(postIds);
+        setPendingJumpPostId(postIds[0] ?? null);
+      }
       if (result.reason) {
         setServeReason(result.reason);
       }
@@ -103,7 +125,7 @@ function FeedPage() {
       servingRef.current = false;
       setServing(false);
     }
-  }, [serveDocumentFeed, serveFeed, posthog, scopedDocumentId]);
+  }, [serveDocumentFeed, serveFeed, posthog, scopedDocumentId, registerBatch]);
 
   useEffect(() => {
     if (noAutoServe) return;
@@ -149,6 +171,40 @@ function FeedPage() {
     });
   }, [navigate, posthog, scopedDocumentId]);
 
+  const jumpToUnreadPost = useCallback(() => {
+    if (!firstUnreadPostId) return;
+    posthog.capture("feed.unread_jump_clicked", {
+      count: unreadCount,
+      scope: scopedDocumentId ? "document" : "all",
+      documentId: scopedDocumentId ?? null,
+    });
+    setPendingJumpPostId(firstUnreadPostId);
+  }, [firstUnreadPostId, posthog, scopedDocumentId, unreadCount]);
+
+  const dismissUnreadPosts = useCallback(() => {
+    posthog.capture("feed.unread_batch_dismissed", {
+      count: unreadCount,
+      scope: scopedDocumentId ? "document" : "all",
+      documentId: scopedDocumentId ?? null,
+    });
+    clearBatch();
+  }, [clearBatch, posthog, scopedDocumentId, unreadCount]);
+
+  const handlePostViewed = useCallback(
+    (postId: string) => {
+      const wasUnread = unreadPostIdSet.has(postId);
+      markBatchSeenForPost(postId);
+      if (!wasUnread) return;
+
+      posthog.capture("feed.unread_batch_seen", {
+        count: unreadCount,
+        scope: scopedDocumentId ? "document" : "all",
+        documentId: scopedDocumentId ?? null,
+      });
+    },
+    [markBatchSeenForPost, posthog, scopedDocumentId, unreadCount, unreadPostIdSet],
+  );
+
   const sentinelRef = useInfiniteScroll(status, loadMore);
 
   const docIdKey = results.map((p) => p.primarySourceDocumentId).join(",");
@@ -174,6 +230,27 @@ function FeedPage() {
       })),
     [results, tagsByDocId],
   );
+  const postIdKey = enrichedResults.map((post) => post._id).join(",");
+
+  useEffect(() => {
+    if (!pendingJumpPostId) return;
+    const didScroll = scrollToPostId(pendingJumpPostId);
+    if (!didScroll) {
+      const loadRequestKey = `${pendingJumpPostId}:${postIdKey}`;
+      if (status === "CanLoadMore" && jumpLoadRequestRef.current !== loadRequestKey) {
+        jumpLoadRequestRef.current = loadRequestKey;
+        loadMore(10);
+      }
+      return;
+    }
+
+    posthog.capture("feed.unread_jump_performed", {
+      scope: scopedDocumentId ? "document" : "all",
+      documentId: scopedDocumentId ?? null,
+    });
+    jumpLoadRequestRef.current = null;
+    setPendingJumpPostId(null);
+  }, [loadMore, pendingJumpPostId, posthog, postIdKey, scopedDocumentId, status]);
 
   const exhaustedTracked = useRef(false);
   useEffect(() => {
@@ -190,12 +267,13 @@ function FeedPage() {
 
   if (status === "LoadingFirstPage") {
     return (
-      <div className="py-6">
-        <div className="mb-6 px-4 md:px-6">
-          <h1 className="text-2xl font-bold tracking-tight">Feed</h1>
-          <p className="mt-1 text-sm text-muted-foreground">Your AI-generated learning posts.</p>
-        </div>
-        <div className="border-y border-border">
+      <div className="pb-6">
+        <PageHeader
+          eyebrow="Your Feed"
+          title="Feed"
+          description="Your AI-generated learning posts."
+        />
+        <div className="border-b border-border">
           {[1, 2, 3].map((i) => (
             <div
               key={i}
@@ -220,28 +298,29 @@ function FeedPage() {
   }
 
   return (
-    <div className="py-6">
-      <div className="mb-6 flex items-center justify-between px-4 md:px-6">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Feed</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {scopedDocumentId
-              ? "Learning posts from this document."
-              : "Your AI-generated learning posts."}
-          </p>
-        </div>
-        <Button onClick={handleServe} disabled={serving} data-testid="feed-serve-button">
-          {serving ? (
-            <Loader2 className="size-4 animate-spin" data-icon="inline-start" />
-          ) : (
-            <Sparkles className="size-4" data-icon="inline-start" />
-          )}
-          Generate
-        </Button>
-      </div>
+    <div className="pb-6">
+      <PageHeader
+        eyebrow={scopedDocumentId ? "Document Feed" : "Your Feed"}
+        title="Feed"
+        description={
+          scopedDocumentId
+            ? "Learning posts from this document."
+            : "Your AI-generated learning posts."
+        }
+        actions={
+          <Button onClick={handleServe} disabled={serving} data-testid="feed-serve-button">
+            {serving ? (
+              <Loader2 className="size-4 animate-spin" data-icon="inline-start" />
+            ) : (
+              <Sparkles className="size-4" data-icon="inline-start" />
+            )}
+            Generate
+          </Button>
+        }
+      />
 
       {scopedDocumentId && (
-        <div className="mb-6 px-4 md:px-6">
+        <div className="mt-6 px-4 md:px-6">
           <Alert data-testid="feed-scope-banner">
             <BookOpen data-icon="inline-start" />
             <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -265,7 +344,7 @@ function FeedPage() {
       )}
 
       {error && (
-        <Alert variant="destructive" className="mb-6">
+        <Alert variant="destructive" className="mx-4 mt-6 md:mx-6">
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
@@ -278,10 +357,23 @@ function FeedPage() {
         )
       ) : (
         <div className="animate-stagger-in">
-          <div className="border-y border-border">
-            {enrichedResults.map((post) => (
-              <Post key={post._id} post={post} />
-            ))}
+          <UnreadPostsBanner
+            count={unreadCount}
+            scopeLabel={feedScopeLabel}
+            onJump={jumpToUnreadPost}
+            onDismiss={dismissUnreadPosts}
+          />
+          <div className="border-b border-border">
+            {enrichedResults.map((post) => {
+              const isUnread = unreadPostIdSet.has(post._id);
+              return (
+                <Post
+                  key={post._id}
+                  post={{ ...post, isNew: isUnread }}
+                  onViewed={handlePostViewed}
+                />
+              );
+            })}
           </div>
 
           <div ref={sentinelRef} className="h-1" />
@@ -322,6 +414,21 @@ function FeedPage() {
       )}
     </div>
   );
+}
+
+function scrollToPostId(postId: string) {
+  const post = Array.from(document.querySelectorAll<HTMLElement>("[data-post-id]")).find(
+    (element) => element.dataset.postId === postId,
+  );
+  if (!post) return false;
+
+  const rect = post.getBoundingClientRect();
+  const isComfortablyVisible = rect.top >= 96 && rect.top <= window.innerHeight * 0.7;
+  if (!isComfortablyVisible) {
+    post.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  return true;
 }
 
 interface DocumentFeedEmptyStateProps {

--- a/apps/web/src/routes/_authenticated/app/library/index.tsx
+++ b/apps/web/src/routes/_authenticated/app/library/index.tsx
@@ -10,6 +10,7 @@ import { usePostHog } from "posthog-js/react";
 import { DocumentUsageMeter } from "@/components/billing/document-usage-meter";
 import { UpgradeDialog } from "@/components/billing/upgrade-dialog";
 import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard";
+import { PageHeader } from "@/components/page-header";
 import { StatusBadge, fileTypeIcons } from "@/components/document-status";
 import {
   ProcessingProgressBar,
@@ -45,6 +46,19 @@ export const Route = createFileRoute("/_authenticated/app/library/")({
   },
   component: LibraryPage,
 });
+
+const KIND_LABELS: Record<string, string> = {
+  pdf: "PDF",
+  epub: "Book",
+  md: "Markdown",
+  txt: "Note",
+  html: "Article",
+  youtube: "Video",
+};
+
+function kindLabel(fileType: string): string {
+  return KIND_LABELS[fileType] ?? fileType.toUpperCase();
+}
 
 function LibraryPage() {
   const {
@@ -86,6 +100,11 @@ function LibraryPage() {
     });
   }, [documents, selectedTags, docTagMap]);
 
+  const readyCount = useMemo(
+    () => filteredDocuments.filter((d) => d.status === "ready").length,
+    [filteredDocuments],
+  );
+
   const handleToggleTag = useCallback(
     (tagName: string) => {
       posthog.capture("library.tag_filtered", {
@@ -114,50 +133,56 @@ function LibraryPage() {
   const onboardingActive = userProfile ? !userProfile.onboardingCompleted : false;
 
   return (
-    <div className="py-6">
-      <div className="mb-6 flex flex-col gap-4 px-4 md:px-6 md:flex-row md:items-start md:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">My Library</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Your uploaded documents and their processing status.
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-4">
-          <DocumentUsageMeter onUpgradeClick={() => setUpgradeOpen(true)} />
-          {hasDocuments && (
-            <Button size="sm" variant="outline" render={<Link to="/app/upload" />}>
-              <Upload className="size-4" />
-              Upload
-            </Button>
-          )}
-        </div>
-      </div>
+    <div className="pb-10">
+      <PageHeader
+        eyebrow="The Archive"
+        title="My Library"
+        description="Everything you've saved, indexed, and made ready to scroll."
+        actions={
+          <>
+            <DocumentUsageMeter onUpgradeClick={() => setUpgradeOpen(true)} />
+            {hasDocuments && (
+              <Button size="sm" variant="outline" render={<Link to="/app/upload" />}>
+                <Upload className="size-4" />
+                Upload document
+              </Button>
+            )}
+          </>
+        }
+      />
       <UpgradeDialog open={upgradeOpen} onOpenChange={setUpgradeOpen} source="library_header" />
 
       <OnboardingWizard documents={documents} />
 
       {status === "LoadingFirstPage" ? (
-        <div className="border-y border-r border-border">
+        <div data-testid="library-loading-list">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div
-              key={i}
-              className="border-l-[2px] border-l-muted border-t border-border first:border-t-0 px-6 py-5"
-            >
-              <Skeleton className="h-4 w-48" />
-              <Skeleton className="mt-3 h-3 w-32" />
+            <div key={i} className="relative border-b border-border px-4 py-6 md:px-8">
+              <div className="absolute left-0 top-0 bottom-0 w-[2px] bg-muted" aria-hidden />
+              <div className="grid grid-cols-[2rem_1fr_5rem] gap-4 md:grid-cols-[2.5rem_1fr_6rem] md:gap-6">
+                <Skeleton className="h-3 w-5" />
+                <div className="min-w-0">
+                  <Skeleton className="h-3 w-20" />
+                  <Skeleton className="mt-3 h-5 w-4/5" />
+                  <Skeleton className="mt-4 h-3 w-1/2" />
+                </div>
+                <Skeleton className="h-24 w-full md:h-28" />
+              </div>
             </div>
           ))}
         </div>
       ) : !hasDocuments ? (
         onboardingActive ? null : (
-          <div className="mt-8 flex flex-col items-center gap-4 text-center">
+          <div className="mt-16 flex flex-col items-center gap-5 px-6 text-center">
             <div className="flex size-16 items-center justify-center border border-primary/30 bg-transparent">
               <FileText className="size-8 text-primary/70" />
             </div>
             <div>
-              <p className="text-lg font-semibold">No documents yet</p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Upload your first file to get started.
+              <p className="font-logo text-2xl font-semibold tracking-tight">
+                Your archive is empty
+              </p>
+              <p className="mt-1.5 max-w-sm text-sm leading-relaxed text-muted-foreground">
+                Upload your first document to start building a personal learning library.
               </p>
             </div>
             <Button render={<Link to="/app/upload" />}>
@@ -169,121 +194,195 @@ function LibraryPage() {
       ) : (
         <>
           {tagOptions.length > 0 && (
-            <div className="mb-6 px-4 md:px-6">
+            <section className="border-b border-border px-4 pt-5 pb-4 md:px-8">
+              <div className="mb-3 flex items-center gap-3">
+                <span className="font-mono text-[10px] font-medium uppercase tracking-[0.28em] text-muted-foreground">
+                  Filter
+                </span>
+                <div className="h-px flex-1 bg-border" />
+              </div>
               <TagFilterBar
                 allTags={tagOptions}
                 selectedTags={selectedTags}
                 onToggle={handleToggleTag}
                 onClear={handleClearTags}
               />
-            </div>
+            </section>
           )}
+
+          <div className="flex items-center justify-between gap-4 border-b border-border px-4 py-3 md:px-8">
+            <span className="font-mono text-[10.5px] tabular-nums uppercase tracking-[0.22em] text-muted-foreground">
+              <span className="text-foreground">
+                {String(filteredDocuments.length).padStart(2, "0")}
+              </span>
+              <span className="text-muted-foreground/60"> / </span>
+              {String(documents.length).padStart(2, "0")} Volumes
+            </span>
+            <span className="font-mono text-[10.5px] tabular-nums uppercase tracking-[0.22em] text-muted-foreground">
+              {readyCount} Ready
+            </span>
+          </div>
+
           <div className="animate-stagger-in">
-            <div className="border-y border-border">
-              {filteredDocuments.map((doc) => {
-                const docTags = docTagMap.get(doc._id) ?? [];
-                const statusColor =
-                  doc.status === "ready"
-                    ? "border-l-emerald-500"
-                    : doc.status === "error"
-                      ? "border-l-red-500"
-                      : "border-l-primary";
+            {filteredDocuments.map((doc, index) => {
+              const docTags = docTagMap.get(doc._id) ?? [];
+              const statusColor =
+                doc.status === "ready"
+                  ? "bg-emerald-500"
+                  : doc.status === "error"
+                    ? "bg-red-500"
+                    : "bg-primary";
 
-                const isSelected = libraryDetail?.selectedDocumentId === doc._id;
+              const isSelected = libraryDetail?.selectedDocumentId === doc._id;
 
-                return (
-                  <button
-                    type="button"
-                    key={doc._id}
-                    data-testid="document-item"
-                    onClick={() => {
-                      if (libraryDetail) {
-                        libraryDetail.openDetail(doc._id);
-                      } else {
-                        navigate({
-                          to: "/app/library/$documentId",
-                          params: { documentId: doc._id },
-                        });
-                      }
-                    }}
+              return (
+                <button
+                  type="button"
+                  key={doc._id}
+                  data-testid="document-item"
+                  onClick={() => {
+                    if (libraryDetail) {
+                      libraryDetail.openDetail(doc._id);
+                    } else {
+                      navigate({
+                        to: "/app/library/$documentId",
+                        params: { documentId: doc._id },
+                      });
+                    }
+                  }}
+                  className={cn(
+                    "group relative block w-full cursor-pointer border-b border-border bg-card text-left transition-all duration-200",
+                    "hover:bg-accent/30",
+                    isSelected && "bg-accent/40",
+                  )}
+                >
+                  <div
+                    aria-hidden
                     className={cn(
-                      "block w-full cursor-pointer border-l-[2px] border-t border-border first:border-t-0 bg-card text-left transition-colors hover:bg-accent/30",
-                      isSelected ? "bg-accent/30" : "",
+                      "absolute left-0 top-0 bottom-0 w-[2px] transition-all",
                       statusColor,
+                      "group-hover:w-[3px]",
+                      isSelected && "w-[3px]",
                     )}
-                  >
-                    <div className="grid grid-cols-[1fr_6rem] sm:grid-cols-[1fr_8rem]">
-                      <div className="min-w-0 px-6 py-4">
-                        <div className="flex items-start gap-2.5">
-                          <span className="mt-0.5 shrink-0">
-                            {fileTypeIcons[doc.fileType] ?? (
-                              <FileText className="size-4 text-muted-foreground" />
-                            )}
+                  />
+
+                  <div className="grid grid-cols-[2rem_1fr_5rem] gap-4 px-4 py-5 md:grid-cols-[2.5rem_1fr_6rem] md:gap-6 md:px-8 md:py-6">
+                    <div className="flex flex-col items-start pt-1">
+                      <span className="font-mono text-[10.5px] tabular-nums tracking-[0.18em] text-muted-foreground/50 group-hover:text-muted-foreground">
+                        {String(index + 1).padStart(2, "0")}
+                      </span>
+                    </div>
+
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+                        <StatusBadge status={doc.status} />
+                        <div className="flex items-center gap-2 text-muted-foreground">
+                          <span className="shrink-0 [&_svg]:size-3.5">
+                            {fileTypeIcons[doc.fileType] ?? <FileText className="size-3.5" />}
                           </span>
-                          <span className="line-clamp-2 text-sm font-semibold">{doc.title}</span>
-                        </div>
-                        <div className="mt-3 flex flex-wrap items-center gap-3">
-                          <StatusBadge status={doc.status} />
-                          {isProcessingStatus(doc.status) && (
-                            <ProcessingProgressBar status={doc.status} />
-                          )}
-                          {doc.status === "ready" && (
-                            <span className="text-xs text-muted-foreground">
-                              {doc.chunkCount} chunk{doc.chunkCount !== 1 ? "s" : ""}
-                            </span>
-                          )}
+                          <span className="font-mono text-[10px] uppercase tracking-[0.22em]">
+                            {kindLabel(doc.fileType)}
+                          </span>
                           {doc.sourceUrl && (
                             <Globe
-                              className="size-3 text-muted-foreground"
+                              className="size-3 text-muted-foreground/70"
                               aria-label="Added from URL"
                             />
                           )}
-                          <span className="text-xs text-muted-foreground">
-                            {formatDistanceToNow(doc.createdAt, { addSuffix: true })}
-                          </span>
                         </div>
-                        {docTags.length > 0 && (
-                          <div className="mt-2">
-                            <TagList tags={docTags} maxVisible={2} size="sm" />
-                          </div>
-                        )}
                       </div>
-                      <div className="relative border-l border-border bg-transparent">
-                        {doc.thumbnailUrl && (
-                          <img
-                            src={doc.thumbnailUrl}
-                            alt=""
-                            loading="lazy"
-                            className="absolute inset-0 size-full object-cover"
-                          />
+
+                      <h2 className="mt-2.5 font-logo text-lg font-semibold leading-[1.25] tracking-tight text-foreground [&]:line-clamp-2 md:text-[1.35rem]">
+                        {doc.title}
+                      </h2>
+
+                      <div className="mt-2.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                        {isProcessingStatus(doc.status) && (
+                          <>
+                            <ProcessingProgressBar status={doc.status} />
+                            <span aria-hidden className="text-muted-foreground/40">
+                              ·
+                            </span>
+                          </>
                         )}
+                        {doc.status === "ready" && (
+                          <>
+                            <span className="tabular-nums">
+                              {doc.chunkCount.toLocaleString()} chunk
+                              {doc.chunkCount !== 1 ? "s" : ""}
+                            </span>
+                            <span aria-hidden className="text-muted-foreground/40">
+                              ·
+                            </span>
+                          </>
+                        )}
+                        <span>added {formatDistanceToNow(doc.createdAt, { addSuffix: true })}</span>
                       </div>
+
+                      {docTags.length > 0 && (
+                        <div className="mt-3">
+                          <TagList tags={docTags} maxVisible={3} size="sm" />
+                        </div>
+                      )}
                     </div>
-                  </button>
-                );
-              })}
-              {filteredDocuments.length === 0 && selectedTags.size > 0 && (
-                <div className="py-8 text-center text-sm text-muted-foreground">
+
+                    <div className="relative h-20 w-full shrink-0 overflow-hidden border border-border bg-muted/40 md:h-28">
+                      {doc.thumbnailUrl ? (
+                        <img
+                          src={doc.thumbnailUrl}
+                          alt=""
+                          loading="lazy"
+                          className="absolute inset-0 size-full object-cover transition-transform duration-500 ease-out group-hover:scale-[1.04]"
+                        />
+                      ) : (
+                        <div
+                          aria-hidden
+                          className="flex h-full items-center justify-center text-muted-foreground/30 [&_svg]:size-6"
+                        >
+                          {fileTypeIcons[doc.fileType] ?? <FileText className="size-6" />}
+                        </div>
+                      )}
+                      <div
+                        aria-hidden
+                        className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                      />
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+            {filteredDocuments.length === 0 && selectedTags.size > 0 && (
+              <div className="px-6 py-12 text-center">
+                <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-muted-foreground/60">
+                  No matches
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
                   {status === "Exhausted"
                     ? "No documents match the selected tags."
-                    : "No matches yet - loading more documents..."}
-                </div>
-              )}
-            </div>
+                    : "Loading more documents..."}
+                </p>
+              </div>
+            )}
           </div>
 
           <div ref={sentinelRef} className="h-1" />
 
           {status === "LoadingMore" && (
-            <div className="flex justify-center py-4 animate-in fade-in duration-300">
-              <Loader2 className="size-6 animate-spin text-muted-foreground" />
+            <div className="flex justify-center py-6 animate-in fade-in duration-300">
+              <Loader2 className="size-5 animate-spin text-muted-foreground" />
             </div>
           )}
 
           {status === "Exhausted" && filteredDocuments.length > 0 && (
-            <div className="flex flex-col items-center gap-3 py-10 text-center text-muted-foreground">
-              <div className="h-px w-16 bg-border" />
-              <p className="text-[11px] font-semibold uppercase tracking-[0.1em]">End of library</p>
+            <div className="flex flex-col items-center gap-3 py-12 text-center text-muted-foreground">
+              <div className="flex items-center gap-3">
+                <div className="h-px w-10 bg-border" />
+                <span aria-hidden className="inline-block h-1 w-1 rounded-full bg-primary/60" />
+                <div className="h-px w-10 bg-border" />
+              </div>
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.28em]">
+                End of library
+              </p>
             </div>
           )}
         </>

--- a/apps/web/src/routes/_authenticated/app/saved.tsx
+++ b/apps/web/src/routes/_authenticated/app/saved.tsx
@@ -3,6 +3,7 @@ import { api } from "@scrollect/backend/convex/_generated/api";
 import { usePaginatedQuery } from "convex/react";
 import { Bookmark, Loader2 } from "lucide-react";
 
+import { PageHeader } from "@/components/page-header";
 import { Post } from "@/components/posts";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
@@ -26,12 +27,13 @@ function SavedPage() {
 
   if (status === "LoadingFirstPage") {
     return (
-      <div className="py-6">
-        <div className="mb-6 px-4 md:px-6">
-          <h1 className="text-2xl font-bold tracking-tight">Saved</h1>
-          <p className="mt-1 text-sm text-muted-foreground">Your bookmarked learning posts.</p>
-        </div>
-        <div className="border-y border-border">
+      <div className="pb-6">
+        <PageHeader
+          eyebrow="Bookmarks"
+          title="Saved"
+          description="Your bookmarked learning posts."
+        />
+        <div className="border-b border-border">
           {[1, 2, 3].map((i) => (
             <div
               key={i}
@@ -56,11 +58,8 @@ function SavedPage() {
   }
 
   return (
-    <div className="py-6">
-      <div className="mb-6 px-4 md:px-6">
-        <h1 className="text-2xl font-bold tracking-tight">Saved</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Your bookmarked learning posts.</p>
-      </div>
+    <div className="pb-6">
+      <PageHeader eyebrow="Bookmarks" title="Saved" description="Your bookmarked learning posts." />
 
       {results.length === 0 ? (
         <div className="mt-16 flex flex-col items-center gap-5 text-center">
@@ -76,7 +75,7 @@ function SavedPage() {
         </div>
       ) : (
         <div className="animate-stagger-in">
-          <div className="border-y border-border">
+          <div className="border-b border-border">
             {results.map((bookmark) => {
               if (!bookmark.post) return null;
               return (

--- a/apps/web/src/routes/_authenticated/app/settings.tsx
+++ b/apps/web/src/routes/_authenticated/app/settings.tsx
@@ -6,6 +6,7 @@ import { Mail, User } from "lucide-react";
 
 import { BillingSection } from "@/components/billing/billing-section";
 import { DeleteAccountDialog } from "@/components/delete-account-dialog";
+import { PageHeader } from "@/components/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/_authenticated/app/settings")({
@@ -20,52 +21,54 @@ function SettingsPage() {
   const { data: user } = useQuery(convexQuery(api.access.auth.getCurrentUser, {}));
 
   return (
-    <div className="px-4 py-6 md:px-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold tracking-tight">Settings</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Manage your account and preferences.</p>
-      </div>
-
-      <section>
-        <h2 className="mb-3 text-sm font-semibold text-muted-foreground">Account</h2>
-        <div className="border border-border border-l-[2px] border-l-primary bg-card px-6 py-5">
-          <div className="flex items-center gap-3">
-            <User className="size-4 text-muted-foreground" />
-            {user ? (
-              <span className="text-sm">{user.name}</span>
-            ) : (
-              <Skeleton className="h-4 w-32" />
-            )}
-          </div>
-          <div className="mt-3 flex items-center gap-3">
-            <Mail className="size-4 text-muted-foreground" />
-            {user ? (
-              <span className="text-sm text-muted-foreground">{user.email}</span>
-            ) : (
-              <Skeleton className="h-4 w-48" />
-            )}
-          </div>
-        </div>
-      </section>
-
-      <div className="mt-8">
-        <BillingSection />
-      </div>
-
-      <section className="mt-8">
-        <h2 className="mb-3 text-sm font-semibold text-destructive">Danger zone</h2>
-        <div className="border border-border border-l-[2px] border-l-destructive bg-card px-6 py-5">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <p className="text-sm font-medium">Delete account</p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Permanently delete your account and all data. This cannot be undone.
-              </p>
+    <div className="pb-6">
+      <PageHeader
+        eyebrow="Preferences"
+        title="Settings"
+        description="Manage your account and preferences."
+      />
+      <div className="mx-auto w-full max-w-3xl px-4 pt-6 md:px-6">
+        <section>
+          <h2 className="mb-3 text-sm font-semibold text-muted-foreground">Account</h2>
+          <div className="border border-border border-l-[2px] border-l-primary bg-card px-6 py-5">
+            <div className="flex items-center gap-3">
+              <User className="size-4 text-muted-foreground" />
+              {user ? (
+                <span className="text-sm">{user.name}</span>
+              ) : (
+                <Skeleton className="h-4 w-32" />
+              )}
             </div>
-            <DeleteAccountDialog />
+            <div className="mt-3 flex items-center gap-3">
+              <Mail className="size-4 text-muted-foreground" />
+              {user ? (
+                <span className="text-sm text-muted-foreground">{user.email}</span>
+              ) : (
+                <Skeleton className="h-4 w-48" />
+              )}
+            </div>
           </div>
+        </section>
+
+        <div className="mt-8">
+          <BillingSection />
         </div>
-      </section>
+
+        <section className="mt-8">
+          <h2 className="mb-3 text-sm font-semibold text-destructive">Danger zone</h2>
+          <div className="border border-border border-l-[2px] border-l-destructive bg-card px-6 py-5">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">Delete account</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Permanently delete your account and all data. This cannot be undone.
+                </p>
+              </div>
+              <DeleteAccountDialog />
+            </div>
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/routes/_authenticated/app/upload.tsx
+++ b/apps/web/src/routes/_authenticated/app/upload.tsx
@@ -3,6 +3,7 @@ import { FileText, FileUp, Globe } from "lucide-react";
 import { useCallback, useState } from "react";
 
 import { DocumentUsageMeter } from "@/components/billing/document-usage-meter";
+import { PageHeader } from "@/components/page-header";
 import {
   LearningGoalOnboardingDialog,
   type LearningGoalOnboardingPrompt,
@@ -37,17 +38,13 @@ function UploadPage() {
 
   return (
     <UploadErrorProvider>
-      <div className="px-4 py-6 md:px-6">
-        <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight">Upload Content</h1>
-            <p className="mt-1 text-muted-foreground">
-              Upload files, paste a URL, or add text to your library.
-            </p>
-          </div>
-          <DocumentUsageMeter />
-        </div>
-
+      <PageHeader
+        eyebrow="Add Content"
+        title="Upload"
+        description="Upload files, paste a URL, or add text to your library."
+        actions={<DocumentUsageMeter />}
+      />
+      <div className="mx-auto w-full max-w-3xl px-4 pt-6 pb-6 md:px-6">
         <Tabs defaultValue="file" data-testid="upload-tabs">
           <TabsList className="mb-6 grid w-full grid-cols-3">
             <TabsTrigger value="file" data-testid="tab-file" className="gap-2">

--- a/apps/web/src/routes/signin.tsx
+++ b/apps/web/src/routes/signin.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useState } from "react";
 
+import { AuthEditorialPanel } from "@/components/auth/auth-editorial-panel";
 import SignInForm from "@/components/sign-in-form";
 import SignUpForm from "@/components/sign-up-form";
+
+type AuthMode = "signin" | "signup";
 
 export const Route = createFileRoute("/signin")({
   head: () => ({
@@ -18,15 +21,23 @@ export const Route = createFileRoute("/signin")({
 });
 
 function SignInPage() {
-  const [showSignIn, setShowSignIn] = useState(true);
+  const [mode, setMode] = useState<AuthMode>("signin");
 
   return (
-    <div className="flex flex-1 flex-col">
-      {showSignIn ? (
-        <SignInForm onSwitchToSignUp={() => setShowSignIn(false)} />
-      ) : (
-        <SignUpForm onSwitchToSignIn={() => setShowSignIn(true)} />
-      )}
+    <div className="grid flex-1 grid-cols-1 md:grid-cols-[1.1fr_1fr]">
+      <AuthEditorialPanel mode={mode} />
+      <div className="flex items-center justify-center px-5 py-12 sm:px-8 md:py-16 md:pl-12 md:pr-[max(2rem,calc((100vw-64rem)/2))] lg:pl-16">
+        <div
+          key={mode}
+          className="w-full max-w-sm animate-in fade-in slide-in-from-bottom-2 duration-500"
+        >
+          {mode === "signin" ? (
+            <SignInForm onSwitchToSignUp={() => setMode("signup")} />
+          ) : (
+            <SignUpForm onSwitchToSignIn={() => setMode("signin")} />
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/backend/convex/ops/testing.ts
+++ b/packages/backend/convex/ops/testing.ts
@@ -465,6 +465,28 @@ export const insertSeededData = internalMutation({
     const { userId, storageId } = args;
     const now = Date.now();
 
+    // A third source keeps the 7-post seeded feed compatible with the
+    // document-diversity assertion: 3 + 3 + 1 posts across documents.
+    const documentId3 = await ctx.db.insert("documents", {
+      title: "E2E Seed Document 3",
+      fileType: "article",
+      sourceUrl: "https://example.com/e2e-seed-3",
+      status: "ready",
+      chunkCount: 1,
+      userId,
+      createdAt: now - 2000,
+    });
+
+    const chunkId3 = await ctx.db.insert("chunks", {
+      documentId: documentId3,
+      content:
+        "Software pattern catalogs explain how recurring design ideas can be reused across product and architecture decisions.",
+      chunkIndex: 0,
+      tokenCount: 50,
+      embedded: true,
+      createdAt: now - 2000,
+    });
+
     // Create first document
     const documentId = await ctx.db.insert("documents", {
       title: "E2E Seed Document",
@@ -592,10 +614,10 @@ export const insertSeededData = internalMutation({
           type: "quote",
           quotedText: "The observer pattern establishes a one-to-many dependency between objects.",
         },
-        docId: documentId,
-        docTitle: "E2E Seed Document",
-        fileType: "md",
-        chunkId: chunkIds[2]!,
+        docId: documentId3,
+        docTitle: "E2E Seed Document 3",
+        fileType: "article",
+        chunkId: chunkId3,
         strategy: "section",
       },
       {

--- a/packages/backend/tests/indexing/logic/summaryPoints.test.ts
+++ b/packages/backend/tests/indexing/logic/summaryPoints.test.ts
@@ -82,7 +82,13 @@ describe("buildSummaryVectorPoints", () => {
       userId: "user1",
       docSummary: "doc summary",
       sectionResults: [
-        { sectionTitle: "Intro", summary: "intro summary", chunkStartIndex: 0, chunkEndIndex: 2 },
+        {
+          sectionTitle: "Intro",
+          summary: "intro summary",
+          isSubstantiveContent: true,
+          chunkStartIndex: 0,
+          chunkEndIndex: 2,
+        },
       ],
       vectors: [
         [0.1, 0.2],
@@ -107,8 +113,20 @@ describe("buildSummaryVectorPoints", () => {
       userId: "user1",
       docSummary: "doc summary",
       sectionResults: [
-        { sectionTitle: "A", summary: "a", chunkStartIndex: 0, chunkEndIndex: 1 },
-        { sectionTitle: "B", summary: "b", chunkStartIndex: 2, chunkEndIndex: 5 },
+        {
+          sectionTitle: "A",
+          summary: "a",
+          isSubstantiveContent: true,
+          chunkStartIndex: 0,
+          chunkEndIndex: 1,
+        },
+        {
+          sectionTitle: "B",
+          summary: "b",
+          isSubstantiveContent: true,
+          chunkStartIndex: 2,
+          chunkEndIndex: 5,
+        },
       ],
       vectors: [[1], [2], [3]],
       idToUuid: fakeIdToUuid,


### PR DESCRIPTION
…anels (#236)

* fix: detail panel ui

* feat(web): editorial UI polish pass across landing, app, and detail panels

Cohesive design pass applying the archive/editorial language across the web app. Highlights: new hero-variant document covers on the library detail panel, slim progress stepper on the onboarding wizard, refactored landing sections, and shared detail-rail helpers (RailMarker + ruled-paper background) used by both the feed and library panels.

* feat: improve feed browsing

* test(e2e): align seeded specs with UI polish pass

Restores the source-badge test hook on post-shell and updates E2E selectors after the UI polish removed SourceBadge, reworked the connection post layout, and moved library/feed navigation into the detail rail panel.

* fix(e2e): stabilize ui polish tests

* fix: a11y

* fix: a11y

* test(e2e): stabilize billing onboarding assertion

## Summary

{Brief description of changes - what and why}

## Changes

- {Key change 1}
- {Key change 2}
- {Key change 3}

## Testing

- [ ] {How to test change 1}
- [ ] {How to test change 2}
- [ ] {Manual verification steps}
