### PR TITLE
feat(#221): topics - goal-scoped grouping and scoped feed

### DIFF
--- a/apps/e2e/tests/topics-scoped-feed.spec.ts
+++ b/apps/e2e/tests/topics-scoped-feed.spec.ts
@@ -1,0 +1,211 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+import { reseedAccount } from "./helpers";
+
+/**
+ * Issue #221 acceptance criterion: create topic -> assign a document -> open
+ * topic-scoped feed -> verify the topic feed differs from the unscoped feed
+ * for the same user.
+ *
+ * Tolerance note (per the issue brief):
+ * - Strict signal: the topic-scoped post-id sequence is not equal to the
+ *   prefix of the unscoped feed restricted to the assigned document.
+ * - Tolerated fallback: with the small seeded dataset the two sequences may
+ *   coincide. The wiring is still proven by the topic banner being visible,
+ *   the scoped feed being non-empty, and every scoped post belonging to the
+ *   assigned document.
+ *
+ * Topic analytics events (`topic_created`, `document_assigned_to_topic`,
+ * `feed_scope_opened`) are emitted via `captureTopicAnalytics` which calls
+ * PostHog directly and does NOT write to the `e2eAnalyticsEvents` buffer.
+ * They cannot be observed via `waitForAnalyticsEvents` from this test.
+ * UI-visible signals (toast, scope banner, filtered post list) are used
+ * instead. If these events ever need E2E coverage, route them through
+ * `recordE2EAnalyticsEvent` like `feed/servingAnalytics.ts` does.
+ *
+ * Project: `seeded`. Pre-seeded posts cover the assertion without an upload
+ * + processing roundtrip; `reseedAccount` in afterEach removes the topic
+ * along with the rest of the seeded user's data.
+ */
+
+const TOPIC_NAME_BASE = "E2E Topic - Event-Driven Architecture";
+const TOPIC_GOAL = "Understand event-driven architecture and microservice messaging tradeoffs.";
+const ASSIGNED_DOCUMENT_TITLE = "E2E Seed Document 2";
+
+const POST_CARD = '[data-testid="post-card"]';
+const SOURCE_BADGE = '[data-testid="source-badge"]';
+const FEED_SCOPE_BANNER = '[data-testid="feed-scope-banner"]';
+
+test.describe("Topics: scoped feed (issue #221)", { tag: "@seeded" }, () => {
+  test.setTimeout(90_000);
+
+  test.afterEach(async () => {
+    await reseedAccount();
+  });
+
+  test("creates a topic, assigns a document, and renders a scoped feed", async ({ page }) => {
+    const topicName = `${TOPIC_NAME_BASE} ${Date.now()}`;
+    const topicId = await createTopicAndCaptureId(page, {
+      name: topicName,
+      learningGoal: TOPIC_GOAL,
+    });
+    await assignDocumentToTopicViaLibrary(page, {
+      topicId,
+      topicName,
+      documentTitle: ASSIGNED_DOCUMENT_TITLE,
+    });
+
+    const unscopedAssignedOrder = await capturePostsForTitle(page, {
+      url: "/app/feed?noAutoServe",
+      title: ASSIGNED_DOCUMENT_TITLE,
+      requireBanner: false,
+    });
+    expect(
+      unscopedAssignedOrder.length,
+      "unscoped feed must surface at least one post from the assigned document",
+    ).toBeGreaterThan(0);
+
+    const scopedOrder = await capturePostsForTitle(page, {
+      url: `/app/feed?topicId=${topicId}&noAutoServe`,
+      title: ASSIGNED_DOCUMENT_TITLE,
+      requireBanner: true,
+      bannerLabel: topicName,
+    });
+    expect(scopedOrder.length, "scoped feed must contain at least one post").toBeGreaterThan(0);
+
+    const scopedTitles = await uniqueSourceTitles(page);
+    expect(scopedTitles.size, "scoped feed should only show posts from the assigned document").toBe(
+      1,
+    );
+    expect(scopedTitles.has(ASSIGNED_DOCUMENT_TITLE)).toBe(true);
+
+    // Strict signal (acceptance) when ranking diverges; tolerated otherwise.
+    const orderingsDiffer =
+      scopedOrder.length !== unscopedAssignedOrder.length ||
+      scopedOrder.some((id, idx) => id !== unscopedAssignedOrder[idx]);
+    if (!orderingsDiffer) {
+      expect(scopedOrder.length).toBeGreaterThan(0);
+    }
+
+    await page.locator('[data-testid="feed-view-all"]').click();
+    await expect(page).toHaveURL(/\/app\/feed(?:\?.*)?$/, { timeout: 15_000 });
+    await expect(page.locator(FEED_SCOPE_BANNER)).toBeHidden();
+    expect(new URL(page.url()).searchParams.has("topicId")).toBe(false);
+  });
+});
+
+async function createTopicAndCaptureId(
+  page: Page,
+  opts: { name: string; learningGoal: string },
+): Promise<string> {
+  await page.goto("/app/topics");
+  await page.waitForLoadState("networkidle");
+
+  await page.locator('[data-testid="topics-create-button"]').click();
+  const dialog = page.locator('[data-testid="create-topic-dialog"]');
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+  await dialog.locator('[data-testid="topic-name-input"]').fill(opts.name);
+  await dialog.locator('[data-testid="topic-learning-goal-input"]').fill(opts.learningGoal);
+  await dialog.locator('[data-testid="topic-create-button"]').click();
+
+  await expect(page.locator("[data-sonner-toast]").getByText("Topic created")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(dialog).toBeHidden({ timeout: 10_000 });
+
+  // Creating from /app/topics redirects to the new topic's detail page.
+  await expect(page).toHaveURL(/\/app\/topics\/[^/?#]+/, { timeout: 10_000 });
+  const topicId = page.url().split("/app/topics/")[1]?.split(/[?#]/)[0];
+  if (!topicId) throw new Error(`Could not parse topicId from URL: ${page.url()}`);
+  return topicId;
+}
+
+async function assignDocumentToTopicViaLibrary(
+  page: Page,
+  opts: { topicId: string; topicName: string; documentTitle: string },
+): Promise<void> {
+  await page.goto("/app/library");
+  await page.waitForLoadState("networkidle");
+
+  const documentItem = page
+    .locator('[data-testid="document-item"]')
+    .filter({ hasText: opts.documentTitle })
+    .first();
+  await expect(documentItem).toBeVisible({ timeout: 15_000 });
+  await documentItem.click();
+
+  const detailPanel = page.locator('[data-testid="library-detail-panel"]');
+  await expect(detailPanel).toBeVisible({ timeout: 15_000 });
+
+  // The detail panel renders an "Open in feed" link with the document id in
+  // the search params. We use it as a stable handle to pivot to the full
+  // document detail route, which is where TopicAssignmentSection lives.
+  const openInFeedLink = detailPanel.getByRole("link", { name: /open in feed/i });
+  await expect(openInFeedLink).toBeVisible({ timeout: 10_000 });
+  const href = await openInFeedLink.getAttribute("href");
+  if (!href) throw new Error("library-detail-panel did not expose an Open-in-feed link");
+  const documentId = new URL(href, "http://localhost").searchParams.get("documentId");
+  if (!documentId) {
+    throw new Error(`Could not extract documentId from Open-in-feed href: ${href}`);
+  }
+
+  await page.goto(`/app/library/${documentId}`);
+  await page.waitForLoadState("networkidle");
+
+  const topicSection = page.locator('[data-testid="topic-assignment-section"]');
+  await expect(topicSection).toBeVisible({ timeout: 15_000 });
+  await topicSection.locator('[data-testid="topic-picker-trigger"]').click();
+
+  const topicOption = page.locator(`[data-testid="topic-option-${opts.topicId}"]`);
+  await expect(topicOption).toBeVisible({ timeout: 10_000 });
+  await topicOption.click();
+
+  await expect(topicSection.locator('[data-testid="topic-picker-trigger"]')).toContainText(
+    opts.topicName,
+    { timeout: 10_000 },
+  );
+}
+
+async function capturePostsForTitle(
+  page: Page,
+  opts: {
+    url: string;
+    title: string;
+    requireBanner: boolean;
+    bannerLabel?: string;
+  },
+): Promise<string[]> {
+  await page.goto(opts.url);
+  await page.waitForLoadState("networkidle");
+
+  if (opts.requireBanner) {
+    const banner = page.locator(FEED_SCOPE_BANNER);
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+    await expect(banner).toHaveAttribute("data-scope", "topic");
+    if (opts.bannerLabel) await expect(banner).toContainText(opts.bannerLabel);
+  }
+
+  const cards = page.locator(POST_CARD);
+  await expect(cards.first()).toBeVisible({ timeout: 15_000 });
+
+  const rows = await cards.evaluateAll((els) =>
+    els.map((el) => ({
+      postId: (el as HTMLElement).dataset.postId ?? "",
+      title:
+        (
+          el.querySelector('[data-testid="source-badge"]') as HTMLElement | null
+        )?.textContent?.trim() ?? "",
+    })),
+  );
+  return rows.filter((r) => r.title === opts.title).map((r) => r.postId);
+}
+
+async function uniqueSourceTitles(page: Page): Promise<Set<string>> {
+  const cards = page.locator(POST_CARD);
+  const sourceBadgeTexts = await cards
+    .locator(SOURCE_BADGE)
+    .evaluateAll((els) => els.map((el) => el.textContent?.trim() ?? ""));
+  return new Set(sourceBadgeTexts);
+}

--- a/apps/e2e/tests/upload-and-library.spec.ts
+++ b/apps/e2e/tests/upload-and-library.spec.ts
@@ -343,48 +343,6 @@ test.describe("Library desktop layout", { tag: "@seeded" }, () => {
   });
 });
 
-test.describe("Library desktop layout", { tag: "@seeded" }, () => {
-  test.beforeEach(async () => {
-    await reseedAccount();
-  });
-
-  test.afterEach(async () => {
-    await resetTestData(SEEDED_USER.email);
-  });
-
-  test("right detail divider is a single collapsed border", async ({ page }) => {
-    await page.setViewportSize({ width: 1536, height: 864 });
-    await page.goto("/app/library");
-
-    const main = page.locator('[data-testid="app-main-scroll"]');
-    const panel = page.locator('[data-testid="library-detail-panel"]');
-    await expect(panel).toBeVisible();
-    await expect
-      .poll(() => main.evaluate((el) => getComputedStyle(el).borderRightWidth))
-      .toBe("0px");
-    await expect
-      .poll(() => panel.evaluate((el) => getComputedStyle(el).borderLeftWidth))
-      .toBe("1px");
-
-    const docButton = page.locator('[data-testid="document-item"]').first();
-    await expect(docButton).toBeVisible({ timeout: 15000 });
-    await docButton.click();
-
-    await expect(panel).toBeVisible();
-    await expect
-      .poll(() => panel.evaluate((el) => getComputedStyle(el).borderLeftWidth))
-      .toBe("1px");
-
-    const horizontalOverflow = await page.evaluate(() => {
-      const root = document.documentElement;
-      const body = document.body;
-      return Math.max(root.scrollWidth, body.scrollWidth) - root.clientWidth;
-    });
-
-    expect(horizontalOverflow).toBeLessThanOrEqual(1);
-  });
-});
-
 test.describe("Unauthenticated access", () => {
   test("unauthenticated user is redirected from /upload", async ({ page }) => {
     await page.goto("/app/upload");

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Bookmark, BookOpen, Rss, Settings, Upload } from "lucide-react";
+import { Bookmark, BookOpen, Layers, Rss, Settings, Upload } from "lucide-react";
 
 import {
   Sidebar,
@@ -15,7 +15,8 @@ const navLinks = [
   { to: "/app/feed" as const, label: "Feed", icon: Rss, shortcut: "01" },
   { to: "/app/saved" as const, label: "Saved", icon: Bookmark, shortcut: "02" },
   { to: "/app/library" as const, label: "Library", icon: BookOpen, shortcut: "03" },
-  { to: "/app/upload" as const, label: "Upload", icon: Upload, shortcut: "04" },
+  { to: "/app/topics" as const, label: "Topics", icon: Layers, shortcut: "04" },
+  { to: "/app/upload" as const, label: "Upload", icon: Upload, shortcut: "05" },
 ] as const;
 
 const menuButtonClassName =

--- a/apps/web/src/components/feed/feed-scope-banner.tsx
+++ b/apps/web/src/components/feed/feed-scope-banner.tsx
@@ -1,0 +1,166 @@
+import type { Doc } from "@scrollect/backend/convex/_generated/dataModel";
+import { BookOpen, Pencil, X } from "lucide-react";
+import { useState } from "react";
+
+import { EditTopicDialog } from "@/components/topics/edit-topic-dialog";
+import { resolveTopicColor, resolveTopicIcon } from "@/components/topics/topic-appearance";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const GOAL_PREVIEW_MAX = 140;
+
+type FeedScopeBannerProps =
+  | { scope: "topic"; topic: Doc<"topics">; onReset: () => void }
+  | { scope: "document"; documentTitle: string; onReset: () => void };
+
+export function FeedScopeBanner(props: FeedScopeBannerProps) {
+  if (props.scope === "topic") {
+    return <TopicScopeBanner topic={props.topic} onReset={props.onReset} />;
+  }
+  return <DocumentScopeBanner documentTitle={props.documentTitle} onReset={props.onReset} />;
+}
+
+function TopicScopeBanner({ topic, onReset }: { topic: Doc<"topics">; onReset: () => void }) {
+  const [editOpen, setEditOpen] = useState(false);
+  const colorMeta = resolveTopicColor(topic.color);
+  const { Icon } = resolveTopicIcon(topic.icon);
+  const goal = truncate(topic.learningGoal, GOAL_PREVIEW_MAX);
+
+  return (
+    <div className="mt-6 px-4 md:px-6">
+      <div
+        data-testid="feed-scope-banner"
+        data-scope="topic"
+        className={cn(
+          "relative flex flex-col gap-3 border border-border bg-card/60 px-4 py-3.5 sm:flex-row sm:items-start sm:gap-4 sm:px-5",
+          "before:absolute before:inset-y-0 before:left-0 before:w-[3px]",
+          colorMeta.bannerAccent,
+        )}
+      >
+        <span
+          aria-hidden
+          className={cn(
+            "mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md border",
+            colorMeta.accent,
+          )}
+        >
+          <Icon className="size-4" />
+        </span>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+              Ranking against
+            </span>
+            <span aria-hidden className="h-px flex-1 bg-border" />
+          </div>
+          <p className="font-logo text-base font-semibold leading-tight tracking-tight text-foreground">
+            {topic.name}
+          </p>
+          {goal.length > 0 && (
+            <p
+              data-testid="feed-scope-banner-goal"
+              className="text-xs leading-relaxed text-muted-foreground"
+            >
+              {goal}
+            </p>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1 self-start sm:self-center">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 rounded-none px-2 text-xs"
+            onClick={() => setEditOpen(true)}
+            data-testid="feed-scope-banner-edit"
+          >
+            <Pencil className="size-3.5" data-icon="inline-start" />
+            Edit
+          </Button>
+          <span aria-hidden className="h-4 w-px bg-border" />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 rounded-none px-2 text-xs"
+            onClick={onReset}
+            data-testid="feed-view-all"
+          >
+            <X className="size-3.5" data-icon="inline-start" />
+            View all
+          </Button>
+        </div>
+      </div>
+
+      <EditTopicDialog
+        topicId={topic._id}
+        initialName={topic.name}
+        initialLearningGoal={topic.learningGoal}
+        initialDescription={topic.description}
+        initialColor={topic.color}
+        initialIcon={topic.icon}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+      />
+    </div>
+  );
+}
+
+function DocumentScopeBanner({
+  documentTitle,
+  onReset,
+}: {
+  documentTitle: string;
+  onReset: () => void;
+}) {
+  return (
+    <div className="mt-6 px-4 md:px-6">
+      <div
+        data-testid="feed-scope-banner"
+        data-scope="document"
+        className={cn(
+          "relative flex flex-col gap-3 border border-border bg-card/60 px-4 py-3.5 sm:flex-row sm:items-start sm:gap-4 sm:px-5",
+          "before:absolute before:inset-y-0 before:left-0 before:w-[3px] before:bg-primary",
+        )}
+      >
+        <span
+          aria-hidden
+          className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md border border-primary/30 bg-primary/5 text-primary"
+        >
+          <BookOpen className="size-4" />
+        </span>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+              Scoped to
+            </span>
+            <span aria-hidden className="h-px flex-1 bg-border" />
+          </div>
+          <p className="line-clamp-2 font-logo text-base font-semibold leading-tight tracking-tight text-foreground">
+            {documentTitle}
+          </p>
+        </div>
+
+        <div className="shrink-0 self-start sm:self-center">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 rounded-none px-2 text-xs"
+            onClick={onReset}
+            data-testid="feed-view-all"
+          >
+            <X className="size-3.5" data-icon="inline-start" />
+            View all
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function truncate(text: string, max: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max - 1).trimEnd()}…`;
+}

--- a/apps/web/src/components/library-detail-panel.tsx
+++ b/apps/web/src/components/library-detail-panel.tsx
@@ -19,6 +19,7 @@ import { ImportHighlightsDialog } from "@/components/documents/import-highlights
 import { LearningGoalSection } from "@/components/documents/learning-goal-section";
 import { PipelineError } from "@/components/documents/pipeline-error";
 import { ProcessingProgress, isProcessingStatus } from "@/components/documents/processing-progress";
+import { TopicAssignmentSection } from "@/components/library/topic-assignment-section";
 import { DocumentTagSection } from "@/components/tags/document-tag-section";
 import {
   AlertDialog,
@@ -367,6 +368,7 @@ function DocumentDetailContent({
         {(document.status === "ready" || document.learningGoalOnboardingStatus === "pending") && (
           <div className="flex flex-col">
             {document.status === "ready" && <DocumentTagSection documentId={document._id} />}
+            {document.status === "ready" && <TopicAssignmentSection documentId={document._id} />}
             <LearningGoalSection
               documentId={document._id}
               initialGoal={document.learningGoal}

--- a/apps/web/src/components/library/library-row-topic-chip.tsx
+++ b/apps/web/src/components/library/library-row-topic-chip.tsx
@@ -1,0 +1,51 @@
+import type { Doc } from "@scrollect/backend/convex/_generated/dataModel";
+import { useNavigate } from "@tanstack/react-router";
+
+import { resolveTopicColor, resolveTopicIcon } from "@/components/topics/topic-appearance";
+import { cn } from "@/lib/utils";
+
+interface LibraryRowTopicChipProps {
+  topic: Doc<"topics"> | null;
+}
+
+export function LibraryRowTopicChip({ topic }: LibraryRowTopicChipProps) {
+  const navigate = useNavigate();
+
+  if (!topic) return null;
+
+  const colorMeta = resolveTopicColor(topic.color);
+  const { Icon } = resolveTopicIcon(topic.icon);
+
+  const goToTopicFeed = () => {
+    navigate({ to: "/app/feed", search: { topicId: topic._id } });
+  };
+
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      data-testid="library-row-topic-chip"
+      onClick={(event) => {
+        event.stopPropagation();
+        goToTopicFeed();
+      }}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        event.stopPropagation();
+        goToTopicFeed();
+      }}
+      className={cn(
+        "inline-flex max-w-[14rem] cursor-pointer items-center gap-1.5 border px-2 py-[3px] font-mono text-[10px] uppercase tracking-[0.18em] transition-colors outline-none",
+        "focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0",
+        colorMeta.accent,
+        "hover:brightness-110",
+      )}
+    >
+      <Icon className="size-3 shrink-0" aria-hidden />
+      <span className="truncate normal-case tracking-normal text-[11px] font-medium">
+        {topic.name}
+      </span>
+    </span>
+  );
+}

--- a/apps/web/src/components/library/topic-assignment-section.tsx
+++ b/apps/web/src/components/library/topic-assignment-section.tsx
@@ -1,0 +1,234 @@
+import { convexQuery } from "@convex-dev/react-query";
+import { api } from "@scrollect/backend/convex/_generated/api";
+import type { Id } from "@scrollect/backend/convex/_generated/dataModel";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useMutation } from "convex/react";
+import { Check, ChevronsUpDown, Layers, Plus } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { CreateTopicDialog } from "@/components/topics/create-topic-dialog";
+import { resolveTopicColor, resolveTopicIcon } from "@/components/topics/topic-appearance";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface TopicAssignmentSectionProps {
+  documentId: Id<"documents">;
+}
+
+export function TopicAssignmentSection({ documentId }: TopicAssignmentSectionProps) {
+  const { data: topics } = useQuery(convexQuery(api.topics.topics.listTopics, {}));
+  const { data: currentTopic } = useQuery(
+    convexQuery(api.topics.topics.getDocumentTopic, { documentId }),
+  );
+  const assignDocumentToTopic = useMutation(api.topics.topics.assignDocumentToTopic);
+  const removeDocumentFromTopic = useMutation(api.topics.topics.removeDocumentFromTopic);
+  const posthog = usePostHog();
+
+  const [open, setOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+
+  if (topics === undefined || currentTopic === undefined) {
+    return (
+      <div
+        data-testid="topic-assignment-section-loading"
+        className="mt-6 border-t border-border pt-5"
+      >
+        <h2 className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <Layers className="size-3.5" />
+          Topic
+        </h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <Skeleton className="h-9 w-48" />
+        </div>
+      </div>
+    );
+  }
+
+  const handleSelectTopic = async (topicId: Id<"topics">) => {
+    setOpen(false);
+    try {
+      await assignDocumentToTopic({ documentId, topicId });
+      posthog.capture("document.assigned_to_topic", {
+        topic_id: topicId,
+        document_id: documentId,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to assign topic";
+      posthog.captureException(error instanceof Error ? error : new Error(message));
+      toast.error(message);
+    }
+  };
+
+  const handleClearTopic = async () => {
+    setOpen(false);
+    if (!currentTopic) return;
+    try {
+      await removeDocumentFromTopic({ documentId, topicId: currentTopic._id });
+      posthog.capture("document.removed_from_topic", {
+        topic_id: currentTopic._id,
+        document_id: documentId,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to remove topic";
+      posthog.captureException(error instanceof Error ? error : new Error(message));
+      toast.error(message);
+    }
+  };
+
+  const handleTopicCreated = async (topicId: Id<"topics">) => {
+    try {
+      await assignDocumentToTopic({ documentId, topicId });
+      posthog.capture("document.assigned_to_topic", {
+        topic_id: topicId,
+        document_id: documentId,
+        from_inline_create: true,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to assign new topic";
+      posthog.captureException(error instanceof Error ? error : new Error(message));
+      toast.error(message);
+    }
+  };
+
+  const triggerLabel = currentTopic ? currentTopic.name : "No topic";
+  const triggerColor = currentTopic ? resolveTopicColor(currentTopic.color) : null;
+  const TriggerIcon = currentTopic ? resolveTopicIcon(currentTopic.icon).Icon : Layers;
+
+  return (
+    <div data-testid="topic-assignment-section" className="mt-6 border-t border-border pt-5">
+      <h2 className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <Layers className="size-3.5" />
+        Topic
+      </h2>
+      <div className="flex flex-wrap items-center gap-2">
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger
+            render={
+              <Button
+                variant="outline"
+                data-testid="topic-picker-trigger"
+                aria-expanded={open}
+                aria-haspopup="listbox"
+                className="min-w-48 justify-between gap-2"
+              />
+            }
+          >
+            <span className="flex items-center gap-2 truncate">
+              <span
+                className={cn(
+                  "flex size-5 shrink-0 items-center justify-center rounded border",
+                  triggerColor?.accent ?? "border-border text-muted-foreground",
+                )}
+                aria-hidden
+              >
+                <TriggerIcon className="size-3" />
+              </span>
+              <span className="truncate">{triggerLabel}</span>
+            </span>
+            <ChevronsUpDown className="size-3.5 shrink-0 text-muted-foreground" />
+          </PopoverTrigger>
+          <PopoverContent className="w-72 p-0" align="start">
+            <Command>
+              <CommandInput placeholder="Search topics..." data-testid="topic-search-input" />
+              <CommandList>
+                <CommandEmpty>No topics found.</CommandEmpty>
+                <CommandGroup>
+                  <CommandItem
+                    value="__no_topic__"
+                    data-testid="topic-option-none"
+                    onSelect={handleClearTopic}
+                    disabled={!currentTopic}
+                  >
+                    <span className="flex size-5 items-center justify-center rounded border border-border text-muted-foreground">
+                      <Layers className="size-3" />
+                    </span>
+                    <span className="flex-1">No topic</span>
+                    {!currentTopic && <Check className="size-3.5 text-primary" />}
+                  </CommandItem>
+                </CommandGroup>
+                {topics.length > 0 && (
+                  <CommandGroup heading="Your topics">
+                    {topics.map((topic) => {
+                      const colorMeta = resolveTopicColor(topic.color);
+                      const { Icon } = resolveTopicIcon(topic.icon);
+                      const selected = currentTopic?._id === topic._id;
+                      return (
+                        <CommandItem
+                          key={topic._id}
+                          value={topic.name}
+                          data-testid={`topic-option-${topic._id}`}
+                          onSelect={() => handleSelectTopic(topic._id)}
+                        >
+                          <span
+                            className={cn(
+                              "flex size-5 items-center justify-center rounded border",
+                              colorMeta.accent,
+                            )}
+                            aria-hidden
+                          >
+                            <Icon className="size-3" />
+                          </span>
+                          <span className="flex-1 truncate">{topic.name}</span>
+                          {selected && <Check className="size-3.5 text-primary" />}
+                        </CommandItem>
+                      );
+                    })}
+                  </CommandGroup>
+                )}
+                <CommandGroup>
+                  <CommandItem
+                    value="__create_topic__"
+                    data-testid="topic-option-create"
+                    onSelect={() => {
+                      setOpen(false);
+                      setCreateOpen(true);
+                    }}
+                  >
+                    <Plus className="size-3.5 text-muted-foreground" />
+                    <span>Create new topic...</span>
+                  </CommandItem>
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+
+        {currentTopic && (
+          <Button
+            variant="ghost"
+            size="sm"
+            data-testid="topic-open-link"
+            render={<Link to="/app/topics/$topicId" params={{ topicId: currentTopic._id }} />}
+          >
+            View topic
+          </Button>
+        )}
+
+        {topics.length === 0 && !currentTopic && (
+          <span className="text-xs text-muted-foreground">
+            No topics yet. Create one to focus this document.
+          </span>
+        )}
+      </div>
+
+      <CreateTopicDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={handleTopicCreated}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/topics/create-topic-dialog.tsx
+++ b/apps/web/src/components/topics/create-topic-dialog.tsx
@@ -1,0 +1,274 @@
+import { api } from "@scrollect/backend/convex/_generated/api";
+import type { Id } from "@scrollect/backend/convex/_generated/dataModel";
+import { useNavigate } from "@tanstack/react-router";
+import { useMutation } from "convex/react";
+import { Loader2 } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  DEFAULT_TOPIC_COLOR,
+  DEFAULT_TOPIC_ICON,
+  TOPIC_COLORS,
+  TOPIC_ICONS,
+  type TopicColorKey,
+  type TopicIconKey,
+} from "@/components/topics/topic-appearance";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+const NAME_MAX_LENGTH = 80;
+const GOAL_MAX_LENGTH = 500;
+const DESCRIPTION_MAX_LENGTH = 1000;
+
+interface CreateTopicDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated?: (topicId: Id<"topics">) => void;
+  initialName?: string;
+}
+
+export function CreateTopicDialog({
+  open,
+  onOpenChange,
+  onCreated,
+  initialName,
+}: CreateTopicDialogProps) {
+  const [name, setName] = useState(initialName ?? "");
+  const [learningGoal, setLearningGoal] = useState("");
+  const [description, setDescription] = useState("");
+  const [color, setColor] = useState<TopicColorKey>(DEFAULT_TOPIC_COLOR);
+  const [icon, setIcon] = useState<TopicIconKey>(DEFAULT_TOPIC_ICON);
+  const [submitting, setSubmitting] = useState(false);
+  const createTopic = useMutation(api.topics.topics.createTopic);
+  const posthog = usePostHog();
+  const navigate = useNavigate();
+  const shouldNavigateOnCreate = onCreated === undefined;
+
+  const reset = useCallback(() => {
+    setName(initialName ?? "");
+    setLearningGoal("");
+    setDescription("");
+    setColor(DEFAULT_TOPIC_COLOR);
+    setIcon(DEFAULT_TOPIC_ICON);
+    setSubmitting(false);
+  }, [initialName]);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (submitting) return;
+      onOpenChange(next);
+      if (!next) reset();
+    },
+    [onOpenChange, reset, submitting],
+  );
+
+  const trimmedName = name.trim();
+  const trimmedGoal = learningGoal.trim();
+  const canSubmit = trimmedName.length > 0 && trimmedGoal.length > 0 && !submitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    let createdTopicId: Id<"topics"> | null = null;
+    try {
+      const trimmedDescription = description.trim();
+      createdTopicId = await createTopic({
+        name: trimmedName,
+        learningGoal: trimmedGoal,
+        description: trimmedDescription.length > 0 ? trimmedDescription : undefined,
+        color,
+        icon,
+      });
+      posthog.capture("topic.created", {
+        has_description: trimmedDescription.length > 0,
+      });
+      toast.success("Topic created");
+      onCreated?.(createdTopicId);
+      onOpenChange(false);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to create topic";
+      posthog.captureException(error instanceof Error ? error : new Error(message));
+      toast.error(message);
+    } finally {
+      setSubmitting(false);
+    }
+    if (createdTopicId && shouldNavigateOnCreate) {
+      await navigate({ to: "/app/topics/$topicId", params: { topicId: createdTopicId } });
+    }
+  }, [
+    canSubmit,
+    color,
+    createTopic,
+    description,
+    icon,
+    navigate,
+    onCreated,
+    onOpenChange,
+    posthog,
+    shouldNavigateOnCreate,
+    trimmedGoal,
+    trimmedName,
+  ]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg" data-testid="create-topic-dialog">
+        <DialogHeader>
+          <DialogTitle>Create a topic</DialogTitle>
+          <DialogDescription>
+            Topics group your documents around a goal. Scrollect biases generated posts toward this
+            goal.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="topic-name">Name</Label>
+            <Input
+              id="topic-name"
+              data-testid="topic-name-input"
+              placeholder="e.g., Distributed Systems"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={NAME_MAX_LENGTH}
+              disabled={submitting}
+              className="h-10"
+              autoFocus
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="topic-learning-goal">Learning goal</Label>
+            <Textarea
+              id="topic-learning-goal"
+              data-testid="topic-learning-goal-input"
+              placeholder="What do you want to learn from documents in this topic?"
+              value={learningGoal}
+              onChange={(e) => setLearningGoal(e.target.value)}
+              maxLength={GOAL_MAX_LENGTH}
+              disabled={submitting}
+              rows={4}
+            />
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>Name the outcome, decision, or context you want help with.</span>
+              <span data-testid="topic-learning-goal-char-count">
+                {learningGoal.length}/{GOAL_MAX_LENGTH}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="topic-description">Description (optional)</Label>
+            <Textarea
+              id="topic-description"
+              data-testid="topic-description-input"
+              placeholder="A short note for yourself."
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={DESCRIPTION_MAX_LENGTH}
+              disabled={submitting}
+              rows={2}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>Color</Label>
+            <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Topic color">
+              {TOPIC_COLORS.map((option) => {
+                const selected = option.key === color;
+                return (
+                  <button
+                    key={option.key}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    aria-label={option.label}
+                    data-testid={`topic-color-${option.key}`}
+                    onClick={() => setColor(option.key)}
+                    disabled={submitting}
+                    className={cn(
+                      "size-7 rounded-full border-2 transition-all",
+                      option.swatch,
+                      selected
+                        ? "border-foreground scale-110"
+                        : "border-transparent hover:scale-105",
+                    )}
+                  />
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>Icon</Label>
+            <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Topic icon">
+              {TOPIC_ICONS.map(({ key, label, Icon }) => {
+                const selected = key === icon;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    aria-label={label}
+                    data-testid={`topic-icon-${key}`}
+                    onClick={() => setIcon(key)}
+                    disabled={submitting}
+                    className={cn(
+                      "flex size-9 items-center justify-center rounded-md border transition-colors",
+                      selected
+                        ? "border-foreground bg-accent text-accent-foreground"
+                        : "border-border bg-background text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    <Icon className="size-4" />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={submitting}
+            data-testid="topic-cancel-button"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            data-testid="topic-create-button"
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="animate-spin" data-icon="inline-start" />
+                Creating...
+              </>
+            ) : (
+              "Create topic"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/topics/edit-topic-dialog.tsx
+++ b/apps/web/src/components/topics/edit-topic-dialog.tsx
@@ -1,0 +1,263 @@
+import { api } from "@scrollect/backend/convex/_generated/api";
+import type { Id } from "@scrollect/backend/convex/_generated/dataModel";
+import { useMutation } from "convex/react";
+import { Loader2 } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  TOPIC_COLORS,
+  TOPIC_ICONS,
+  resolveTopicColor,
+  resolveTopicIcon,
+  type TopicColorKey,
+  type TopicIconKey,
+} from "@/components/topics/topic-appearance";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+const NAME_MAX_LENGTH = 80;
+const GOAL_MAX_LENGTH = 500;
+const DESCRIPTION_MAX_LENGTH = 1000;
+
+interface EditTopicDialogProps {
+  topicId: Id<"topics">;
+  initialName: string;
+  initialLearningGoal: string;
+  initialDescription?: string;
+  initialColor?: string;
+  initialIcon?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function EditTopicDialog(props: EditTopicDialogProps) {
+  const { open, onOpenChange, topicId } = props;
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <EditTopicDialogBody key={topicId} {...props} />
+    </Dialog>
+  );
+}
+
+function EditTopicDialogBody({
+  topicId,
+  initialName,
+  initialLearningGoal,
+  initialDescription,
+  initialColor,
+  initialIcon,
+  onOpenChange,
+}: EditTopicDialogProps) {
+  const updateTopic = useMutation(api.topics.topics.updateTopic);
+  const posthog = usePostHog();
+
+  const [name, setName] = useState(initialName);
+  const [learningGoal, setLearningGoal] = useState(initialLearningGoal);
+  const [description, setDescription] = useState(initialDescription ?? "");
+  const [color, setColor] = useState<TopicColorKey>(() => resolveTopicColor(initialColor).key);
+  const [icon, setIcon] = useState<TopicIconKey>(() => resolveTopicIcon(initialIcon).key);
+  const [submitting, setSubmitting] = useState(false);
+
+  const trimmedName = name.trim();
+  const trimmedGoal = learningGoal.trim();
+  const canSubmit = trimmedName.length > 0 && trimmedGoal.length > 0 && !submitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      const trimmedDescription = description.trim();
+      const goalChanged = trimmedGoal !== initialLearningGoal;
+      const initialColorKey = resolveTopicColor(initialColor).key;
+      const initialIconKey = resolveTopicIcon(initialIcon).key;
+      await updateTopic({
+        topicId,
+        name: trimmedName !== initialName ? trimmedName : undefined,
+        learningGoal: goalChanged ? trimmedGoal : undefined,
+        description:
+          trimmedDescription !== (initialDescription ?? "") ? trimmedDescription : undefined,
+        color: color !== initialColorKey ? color : undefined,
+        icon: icon !== initialIconKey ? icon : undefined,
+      });
+      posthog.capture("topic.updated", {
+        topic_id: topicId,
+        goal_changed: goalChanged,
+      });
+      toast.success("Topic updated");
+      onOpenChange(false);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to update topic";
+      posthog.captureException(error instanceof Error ? error : new Error(message));
+      toast.error(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    canSubmit,
+    color,
+    description,
+    icon,
+    initialColor,
+    initialDescription,
+    initialIcon,
+    initialLearningGoal,
+    initialName,
+    onOpenChange,
+    posthog,
+    topicId,
+    trimmedGoal,
+    trimmedName,
+    updateTopic,
+  ]);
+
+  return (
+    <DialogContent className="sm:max-w-lg" data-testid="edit-topic-dialog">
+      <DialogHeader>
+        <DialogTitle>Edit topic</DialogTitle>
+        <DialogDescription>
+          Editing the goal re-embeds it and shapes the next posts generated for this topic.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="edit-topic-name">Name</Label>
+          <Input
+            id="edit-topic-name"
+            data-testid="edit-topic-name-input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={NAME_MAX_LENGTH}
+            disabled={submitting}
+            className="h-10"
+            autoFocus
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="edit-topic-learning-goal">Learning goal</Label>
+          <Textarea
+            id="edit-topic-learning-goal"
+            data-testid="edit-topic-learning-goal-input"
+            value={learningGoal}
+            onChange={(e) => setLearningGoal(e.target.value)}
+            maxLength={GOAL_MAX_LENGTH}
+            disabled={submitting}
+            rows={4}
+          />
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>Changing the goal re-embeds it on the server.</span>
+            <span data-testid="edit-topic-learning-goal-char-count">
+              {learningGoal.length}/{GOAL_MAX_LENGTH}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="edit-topic-description">Description (optional)</Label>
+          <Textarea
+            id="edit-topic-description"
+            data-testid="edit-topic-description-input"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            maxLength={DESCRIPTION_MAX_LENGTH}
+            disabled={submitting}
+            rows={2}
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label>Color</Label>
+          <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Topic color">
+            {TOPIC_COLORS.map((option) => {
+              const selected = option.key === color;
+              return (
+                <button
+                  key={option.key}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  aria-label={option.label}
+                  onClick={() => setColor(option.key)}
+                  disabled={submitting}
+                  className={cn(
+                    "size-7 rounded-full border-2 transition-all",
+                    option.swatch,
+                    selected ? "border-foreground scale-110" : "border-transparent hover:scale-105",
+                  )}
+                />
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label>Icon</Label>
+          <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Topic icon">
+            {TOPIC_ICONS.map(({ key, label, Icon }) => {
+              const selected = key === icon;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  aria-label={label}
+                  onClick={() => setIcon(key)}
+                  disabled={submitting}
+                  className={cn(
+                    "flex size-9 items-center justify-center rounded-md border transition-colors",
+                    selected
+                      ? "border-foreground bg-accent text-accent-foreground"
+                      : "border-border bg-background text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <Icon className="size-4" />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => onOpenChange(false)}
+          disabled={submitting}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          data-testid="topic-save-button"
+        >
+          {submitting ? (
+            <>
+              <Loader2 className="animate-spin" data-icon="inline-start" />
+              Saving...
+            </>
+          ) : (
+            "Save changes"
+          )}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
+}

--- a/apps/web/src/components/topics/topic-appearance.ts
+++ b/apps/web/src/components/topics/topic-appearance.ts
@@ -1,0 +1,143 @@
+import {
+  Activity,
+  Atom,
+  BookOpen,
+  Brain,
+  Briefcase,
+  Code,
+  Compass,
+  FlaskConical,
+  Lightbulb,
+  Palette,
+  Sparkles,
+  Target,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+export type TopicColorKey = "indigo" | "emerald" | "amber" | "rose" | "sky" | "violet" | "slate";
+
+export type TopicIconKey =
+  | "lightbulb"
+  | "compass"
+  | "brain"
+  | "code"
+  | "book"
+  | "target"
+  | "atom"
+  | "flask"
+  | "briefcase"
+  | "palette"
+  | "activity"
+  | "sparkles";
+
+export const TOPIC_COLORS: ReadonlyArray<{
+  key: TopicColorKey;
+  label: string;
+  swatch: string;
+  accent: string;
+  bannerAccent: string;
+}> = [
+  {
+    key: "indigo",
+    label: "Indigo",
+    swatch: "bg-indigo-500",
+    accent: "border-indigo-500/40 bg-indigo-500/10 text-indigo-600 dark:text-indigo-300",
+    bannerAccent: "before:bg-indigo-500",
+  },
+  {
+    key: "emerald",
+    label: "Emerald",
+    swatch: "bg-emerald-500",
+    accent: "border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300",
+    bannerAccent: "before:bg-emerald-500",
+  },
+  {
+    key: "amber",
+    label: "Amber",
+    swatch: "bg-amber-500",
+    accent: "border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-300",
+    bannerAccent: "before:bg-amber-500",
+  },
+  {
+    key: "rose",
+    label: "Rose",
+    swatch: "bg-rose-500",
+    accent: "border-rose-500/40 bg-rose-500/10 text-rose-600 dark:text-rose-300",
+    bannerAccent: "before:bg-rose-500",
+  },
+  {
+    key: "sky",
+    label: "Sky",
+    swatch: "bg-sky-500",
+    accent: "border-sky-500/40 bg-sky-500/10 text-sky-600 dark:text-sky-300",
+    bannerAccent: "before:bg-sky-500",
+  },
+  {
+    key: "violet",
+    label: "Violet",
+    swatch: "bg-violet-500",
+    accent: "border-violet-500/40 bg-violet-500/10 text-violet-600 dark:text-violet-300",
+    bannerAccent: "before:bg-violet-500",
+  },
+  {
+    key: "slate",
+    label: "Slate",
+    swatch: "bg-slate-500",
+    accent: "border-slate-500/40 bg-slate-500/10 text-slate-600 dark:text-slate-300",
+    bannerAccent: "before:bg-slate-500",
+  },
+];
+
+export const TOPIC_ICONS: ReadonlyArray<{
+  key: TopicIconKey;
+  label: string;
+  Icon: LucideIcon;
+}> = [
+  { key: "lightbulb", label: "Lightbulb", Icon: Lightbulb },
+  { key: "compass", label: "Compass", Icon: Compass },
+  { key: "brain", label: "Brain", Icon: Brain },
+  { key: "code", label: "Code", Icon: Code },
+  { key: "book", label: "Book", Icon: BookOpen },
+  { key: "target", label: "Target", Icon: Target },
+  { key: "atom", label: "Atom", Icon: Atom },
+  { key: "flask", label: "Flask", Icon: FlaskConical },
+  { key: "briefcase", label: "Briefcase", Icon: Briefcase },
+  { key: "palette", label: "Palette", Icon: Palette },
+  { key: "activity", label: "Activity", Icon: Activity },
+  { key: "sparkles", label: "Sparkles", Icon: Sparkles },
+];
+
+const COLOR_KEYS = new Set(TOPIC_COLORS.map((c) => c.key));
+const ICON_KEYS = new Set(TOPIC_ICONS.map((i) => i.key));
+
+export const DEFAULT_TOPIC_COLOR: TopicColorKey = "indigo";
+export const DEFAULT_TOPIC_ICON: TopicIconKey = "lightbulb";
+
+export function resolveTopicColor(color: string | undefined): {
+  key: TopicColorKey;
+  swatch: string;
+  accent: string;
+  bannerAccent: string;
+} {
+  const safeKey = (
+    color && COLOR_KEYS.has(color as TopicColorKey) ? (color as TopicColorKey) : DEFAULT_TOPIC_COLOR
+  ) satisfies TopicColorKey;
+  const found = TOPIC_COLORS.find((c) => c.key === safeKey) ?? TOPIC_COLORS[0]!;
+  return {
+    key: found.key,
+    swatch: found.swatch,
+    accent: found.accent,
+    bannerAccent: found.bannerAccent,
+  };
+}
+
+export function resolveTopicIcon(icon: string | undefined): {
+  key: TopicIconKey;
+  Icon: LucideIcon;
+} {
+  const safeKey = (
+    icon && ICON_KEYS.has(icon as TopicIconKey) ? (icon as TopicIconKey) : DEFAULT_TOPIC_ICON
+  ) satisfies TopicIconKey;
+  const found = TOPIC_ICONS.find((i) => i.key === safeKey) ?? TOPIC_ICONS[0]!;
+  return { key: found.key, Icon: found.Icon };
+}

--- a/apps/web/src/lib/convex-id.ts
+++ b/apps/web/src/lib/convex-id.ts
@@ -1,0 +1,5 @@
+const CONVEX_ID_PATTERN = /^[a-z0-9]{20,}$/;
+
+export function looksLikeConvexId(value: string): boolean {
+  return CONVEX_ID_PATTERN.test(value);
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -20,7 +20,9 @@ import { Route as AuthenticatedAppUploadRouteImport } from './routes/_authentica
 import { Route as AuthenticatedAppSettingsRouteImport } from './routes/_authenticated/app/settings'
 import { Route as AuthenticatedAppSavedRouteImport } from './routes/_authenticated/app/saved'
 import { Route as AuthenticatedAppFeedRouteImport } from './routes/_authenticated/app/feed'
+import { Route as AuthenticatedAppTopicsIndexRouteImport } from './routes/_authenticated/app/topics/index'
 import { Route as AuthenticatedAppLibraryIndexRouteImport } from './routes/_authenticated/app/library/index'
+import { Route as AuthenticatedAppTopicsTopicIdRouteImport } from './routes/_authenticated/app/topics/$topicId'
 import { Route as AuthenticatedAppLibraryDocumentIdRouteImport } from './routes/_authenticated/app/library/$documentId'
 
 const TermsAndConditionsRoute = TermsAndConditionsRouteImport.update({
@@ -78,10 +80,22 @@ const AuthenticatedAppFeedRoute = AuthenticatedAppFeedRouteImport.update({
   path: '/app/feed',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedAppTopicsIndexRoute =
+  AuthenticatedAppTopicsIndexRouteImport.update({
+    id: '/app/topics/',
+    path: '/app/topics/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAppLibraryIndexRoute =
   AuthenticatedAppLibraryIndexRouteImport.update({
     id: '/app/library/',
     path: '/app/library/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+const AuthenticatedAppTopicsTopicIdRoute =
+  AuthenticatedAppTopicsTopicIdRouteImport.update({
+    id: '/app/topics/$topicId',
+    path: '/app/topics/$topicId',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 const AuthenticatedAppLibraryDocumentIdRoute =
@@ -103,7 +117,9 @@ export interface FileRoutesByFullPath {
   '/app/upload': typeof AuthenticatedAppUploadRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/app/library/$documentId': typeof AuthenticatedAppLibraryDocumentIdRoute
+  '/app/topics/$topicId': typeof AuthenticatedAppTopicsTopicIdRoute
   '/app/library/': typeof AuthenticatedAppLibraryIndexRoute
+  '/app/topics/': typeof AuthenticatedAppTopicsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -117,7 +133,9 @@ export interface FileRoutesByTo {
   '/app/upload': typeof AuthenticatedAppUploadRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/app/library/$documentId': typeof AuthenticatedAppLibraryDocumentIdRoute
+  '/app/topics/$topicId': typeof AuthenticatedAppTopicsTopicIdRoute
   '/app/library': typeof AuthenticatedAppLibraryIndexRoute
+  '/app/topics': typeof AuthenticatedAppTopicsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -133,7 +151,9 @@ export interface FileRoutesById {
   '/_authenticated/app/upload': typeof AuthenticatedAppUploadRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/_authenticated/app/library/$documentId': typeof AuthenticatedAppLibraryDocumentIdRoute
+  '/_authenticated/app/topics/$topicId': typeof AuthenticatedAppTopicsTopicIdRoute
   '/_authenticated/app/library/': typeof AuthenticatedAppLibraryIndexRoute
+  '/_authenticated/app/topics/': typeof AuthenticatedAppTopicsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -149,7 +169,9 @@ export interface FileRouteTypes {
     | '/app/upload'
     | '/api/auth/$'
     | '/app/library/$documentId'
+    | '/app/topics/$topicId'
     | '/app/library/'
+    | '/app/topics/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -163,7 +185,9 @@ export interface FileRouteTypes {
     | '/app/upload'
     | '/api/auth/$'
     | '/app/library/$documentId'
+    | '/app/topics/$topicId'
     | '/app/library'
+    | '/app/topics'
   id:
     | '__root__'
     | '/'
@@ -178,7 +202,9 @@ export interface FileRouteTypes {
     | '/_authenticated/app/upload'
     | '/api/auth/$'
     | '/_authenticated/app/library/$documentId'
+    | '/_authenticated/app/topics/$topicId'
     | '/_authenticated/app/library/'
+    | '/_authenticated/app/topics/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -270,11 +296,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppFeedRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/app/topics/': {
+      id: '/_authenticated/app/topics/'
+      path: '/app/topics'
+      fullPath: '/app/topics/'
+      preLoaderRoute: typeof AuthenticatedAppTopicsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/app/library/': {
       id: '/_authenticated/app/library/'
       path: '/app/library'
       fullPath: '/app/library/'
       preLoaderRoute: typeof AuthenticatedAppLibraryIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/app/topics/$topicId': {
+      id: '/_authenticated/app/topics/$topicId'
+      path: '/app/topics/$topicId'
+      fullPath: '/app/topics/$topicId'
+      preLoaderRoute: typeof AuthenticatedAppTopicsTopicIdRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/app/library/$documentId': {
@@ -293,7 +333,9 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAppSettingsRoute: typeof AuthenticatedAppSettingsRoute
   AuthenticatedAppUploadRoute: typeof AuthenticatedAppUploadRoute
   AuthenticatedAppLibraryDocumentIdRoute: typeof AuthenticatedAppLibraryDocumentIdRoute
+  AuthenticatedAppTopicsTopicIdRoute: typeof AuthenticatedAppTopicsTopicIdRoute
   AuthenticatedAppLibraryIndexRoute: typeof AuthenticatedAppLibraryIndexRoute
+  AuthenticatedAppTopicsIndexRoute: typeof AuthenticatedAppTopicsIndexRoute
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
@@ -303,7 +345,9 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAppUploadRoute: AuthenticatedAppUploadRoute,
   AuthenticatedAppLibraryDocumentIdRoute:
     AuthenticatedAppLibraryDocumentIdRoute,
+  AuthenticatedAppTopicsTopicIdRoute: AuthenticatedAppTopicsTopicIdRoute,
   AuthenticatedAppLibraryIndexRoute: AuthenticatedAppLibraryIndexRoute,
+  AuthenticatedAppTopicsIndexRoute: AuthenticatedAppTopicsIndexRoute,
 }
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(

--- a/apps/web/src/routes/_authenticated/app/feed.tsx
+++ b/apps/web/src/routes/_authenticated/app/feed.tsx
@@ -4,11 +4,21 @@ import { Link, createFileRoute } from "@tanstack/react-router";
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
 import { useMutation, usePaginatedQuery } from "convex/react";
-import { BookOpen, CheckCircle, FileUp, Loader2, Rss, Sparkles, Timer } from "lucide-react";
+import {
+  BookOpen,
+  CheckCircle,
+  FileUp,
+  Library,
+  Loader2,
+  Rss,
+  Sparkles,
+  Timer,
+} from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { StatusBadge } from "@/components/document-status";
+import { FeedScopeBanner } from "@/components/feed/feed-scope-banner";
 import { UnreadPostsBanner } from "@/components/feed/unread-posts-banner";
 import { PageHeader } from "@/components/page-header";
 import { Post } from "@/components/posts";
@@ -18,11 +28,17 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useFeedUnreadPosts } from "@/hooks/use-feed-unread-posts";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
+import { looksLikeConvexId } from "@/lib/convex-id";
 
+/**
+ * Feed search params. `topicId` and `documentId` are mutually exclusive;
+ * `topicId` wins when both are present.
+ */
 type FeedSearch = {
   noAutoServe?: boolean;
-  scope?: "all" | "document";
+  scope?: "all" | "document" | "topic";
   documentId?: string;
+  topicId?: string;
 };
 
 export const Route = createFileRoute("/_authenticated/app/feed")({
@@ -31,10 +47,20 @@ export const Route = createFileRoute("/_authenticated/app/feed")({
     meta: [{ title: "Feed | Scrollect" }],
   }),
   validateSearch: (search: Record<string, unknown>): FeedSearch => {
+    const topicId =
+      typeof search.topicId === "string" && search.topicId.length > 0 ? search.topicId : undefined;
     const documentId =
-      typeof search.documentId === "string" && search.documentId.length > 0
+      !topicId && typeof search.documentId === "string" && search.documentId.length > 0
         ? search.documentId
         : undefined;
+
+    const scope: FeedSearch["scope"] = topicId
+      ? "topic"
+      : documentId
+        ? "document"
+        : search.scope === "all"
+          ? "all"
+          : undefined;
 
     return {
       noAutoServe:
@@ -44,35 +70,66 @@ export const Route = createFileRoute("/_authenticated/app/feed")({
         search.noAutoGenerate === true ||
         search.noAutoGenerate === "true" ||
         search.noAutoGenerate === "",
-      scope: documentId ? "document" : search.scope === "all" ? "all" : undefined,
+      scope,
       documentId,
+      topicId,
     };
   },
   component: FeedPage,
 });
 
 function FeedPage() {
-  const { noAutoServe, documentId } = Route.useSearch();
+  const { noAutoServe, documentId, topicId } = Route.useSearch();
   const navigate = Route.useNavigate();
-  const isDocumentScoped = documentId !== undefined;
-  const scopedDocumentId = isDocumentScoped ? (documentId as Id<"documents">) : undefined;
+  const validTopicId =
+    topicId && looksLikeConvexId(topicId) ? (topicId as Id<"topics">) : undefined;
+  const validDocumentId =
+    !validTopicId && documentId && looksLikeConvexId(documentId)
+      ? (documentId as Id<"documents">)
+      : undefined;
+  const malformedTopicId = topicId !== undefined && validTopicId === undefined;
+  const malformedDocumentId =
+    !validTopicId && documentId !== undefined && validDocumentId === undefined;
+  const scopedTopicId = validTopicId;
+  const scopedDocumentId = validDocumentId;
   const feedArgs = useMemo(
-    () => (scopedDocumentId ? { documentId: scopedDocumentId } : {}),
-    [scopedDocumentId],
+    () =>
+      scopedTopicId
+        ? { topicId: scopedTopicId }
+        : scopedDocumentId
+          ? { documentId: scopedDocumentId }
+          : {},
+    [scopedTopicId, scopedDocumentId],
   );
-  const feedScopeKey = scopedDocumentId ? `document:${scopedDocumentId}` : "all";
+  const feedScopeKey = scopedTopicId
+    ? `topic:${scopedTopicId}`
+    : scopedDocumentId
+      ? `document:${scopedDocumentId}`
+      : "all";
 
-  const { results, status, loadMore } = usePaginatedQuery(api.feed.queries.list, feedArgs, {
-    initialNumItems: 10,
-  });
+  const skipFeedQuery = malformedTopicId || malformedDocumentId;
+  const { results, status, loadMore } = usePaginatedQuery(
+    api.feed.queries.list,
+    skipFeedQuery ? "skip" : feedArgs,
+    {
+      initialNumItems: 10,
+    },
+  );
   const serveFeed = useMutation(api.feed.serving.serveFeed);
   const serveDocumentFeed = useMutation(api.feed.serving.serveDocumentFeed);
+  const serveTopicFeed = useMutation(api.feed.serving.serveTopicFeed);
   const { data: scopedDocument } = useQuery(
     convexQuery(api.content.documents.get, scopedDocumentId ? { id: scopedDocumentId } : "skip"),
   );
-  const feedScopeLabel = scopedDocumentId
-    ? (scopedDocument?.title ?? "this document feed")
-    : "your feed";
+  const { data: scopedTopicData } = useQuery(
+    convexQuery(api.topics.topics.getTopic, scopedTopicId ? { topicId: scopedTopicId } : "skip"),
+  );
+  const scopedTopic = scopedTopicData?.topic;
+  const feedScopeLabel = scopedTopicId
+    ? (scopedTopic?.name ?? "this topic feed")
+    : scopedDocumentId
+      ? (scopedDocument?.title ?? "this document feed")
+      : "your feed";
 
   const [serving, setServing] = useState(false);
   const [serveReason, setServeReason] = useState<"no_drafts" | "processing" | null>(null);
@@ -93,6 +150,18 @@ function FeedPage() {
 
   const servingRef = useRef(false);
 
+  const scopeKind: "topic" | "document" | "all" = scopedTopicId
+    ? "topic"
+    : scopedDocumentId
+      ? "document"
+      : "all";
+
+  const topicNotFound =
+    malformedTopicId || (scopedTopicId !== undefined && scopedTopicData === null);
+  const documentNotFound =
+    malformedDocumentId || (scopedDocumentId !== undefined && scopedDocument === null);
+  const scopeNotFound = topicNotFound || documentNotFound;
+
   const serve = useCallback(async () => {
     if (servingRef.current) return;
     servingRef.current = true;
@@ -100,14 +169,17 @@ function FeedPage() {
     setError(null);
     setServeReason(null);
     try {
-      const result = scopedDocumentId
-        ? await serveDocumentFeed({ documentId: scopedDocumentId })
-        : await serveFeed({});
+      const result = scopedTopicId
+        ? await serveTopicFeed({ topicId: scopedTopicId })
+        : scopedDocumentId
+          ? await serveDocumentFeed({ documentId: scopedDocumentId })
+          : await serveFeed({});
       posthog.capture("feed.served", {
         post_count: result.posts.length,
         reason: result.reason ?? null,
-        scope: scopedDocumentId ? "document" : "all",
+        scope: scopeKind,
         documentId: scopedDocumentId ?? null,
+        topicId: scopedTopicId ?? null,
       });
       if (result.posts.length > 0) {
         const postIds = result.posts.map((postId) => postId as string);
@@ -125,70 +197,88 @@ function FeedPage() {
       servingRef.current = false;
       setServing(false);
     }
-  }, [serveDocumentFeed, serveFeed, posthog, scopedDocumentId, registerBatch]);
+  }, [
+    serveDocumentFeed,
+    serveFeed,
+    serveTopicFeed,
+    posthog,
+    scopedDocumentId,
+    scopedTopicId,
+    scopeKind,
+    registerBatch,
+  ]);
 
   useEffect(() => {
     if (noAutoServe) return;
-    const autoServeKey = scopedDocumentId ?? "all";
+    if (scopeNotFound) return;
+    const autoServeKey = scopedTopicId ?? scopedDocumentId ?? "all";
     if (autoServedScopeRef.current === autoServeKey) return;
     if (status === "LoadingFirstPage") return;
     if (results.length > 0) return;
 
     autoServedScopeRef.current = autoServeKey;
     serve();
-  }, [noAutoServe, scopedDocumentId, status, results.length, serve]);
+  }, [noAutoServe, scopeNotFound, scopedDocumentId, scopedTopicId, status, results.length, serve]);
 
   const openedScopeRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!scopedDocumentId) return;
-    if (openedScopeRef.current === scopedDocumentId) return;
-    openedScopeRef.current = scopedDocumentId;
+    const scopeId = scopedTopicId ?? scopedDocumentId;
+    if (!scopeId) return;
+    if (scopeNotFound) return;
+    if (openedScopeRef.current === scopeId) return;
+    openedScopeRef.current = scopeId;
     posthog.capture("feed_scope_opened", {
-      scope: "document",
-      documentId: scopedDocumentId,
+      scope: scopeKind,
+      documentId: scopedDocumentId ?? null,
+      topicId: scopedTopicId ?? null,
     });
-  }, [posthog, scopedDocumentId]);
+  }, [posthog, scopeNotFound, scopedDocumentId, scopedTopicId, scopeKind]);
 
   const handleServe = useCallback(() => {
     posthog.capture("feed.serve_clicked", {
       existing_post_count: results.length,
-      scope: scopedDocumentId ? "document" : "all",
+      scope: scopeKind,
       documentId: scopedDocumentId ?? null,
+      topicId: scopedTopicId ?? null,
     });
     serve();
-  }, [posthog, serve, results.length, scopedDocumentId]);
+  }, [posthog, serve, results.length, scopedDocumentId, scopedTopicId, scopeKind]);
 
   const handleResetScope = useCallback(() => {
     posthog.capture("feed_scope_reset", {
-      from_scope: "document",
+      from_scope: scopeKind,
       documentId: scopedDocumentId ?? null,
+      topicId: scopedTopicId ?? null,
     });
     navigate({
       search: (prev) => ({
         ...prev,
         documentId: undefined,
+        topicId: undefined,
       }),
     });
-  }, [navigate, posthog, scopedDocumentId]);
+  }, [navigate, posthog, scopedDocumentId, scopedTopicId, scopeKind]);
 
   const jumpToUnreadPost = useCallback(() => {
     if (!firstUnreadPostId) return;
     posthog.capture("feed.unread_jump_clicked", {
       count: unreadCount,
-      scope: scopedDocumentId ? "document" : "all",
+      scope: scopeKind,
       documentId: scopedDocumentId ?? null,
+      topicId: scopedTopicId ?? null,
     });
     setPendingJumpPostId(firstUnreadPostId);
-  }, [firstUnreadPostId, posthog, scopedDocumentId, unreadCount]);
+  }, [firstUnreadPostId, posthog, scopedDocumentId, scopedTopicId, scopeKind, unreadCount]);
 
   const dismissUnreadPosts = useCallback(() => {
     posthog.capture("feed.unread_batch_dismissed", {
       count: unreadCount,
-      scope: scopedDocumentId ? "document" : "all",
+      scope: scopeKind,
       documentId: scopedDocumentId ?? null,
+      topicId: scopedTopicId ?? null,
     });
     clearBatch();
-  }, [clearBatch, posthog, scopedDocumentId, unreadCount]);
+  }, [clearBatch, posthog, scopedDocumentId, scopedTopicId, scopeKind, unreadCount]);
 
   const handlePostViewed = useCallback(
     (postId: string) => {
@@ -198,11 +288,20 @@ function FeedPage() {
 
       posthog.capture("feed.unread_batch_seen", {
         count: unreadCount,
-        scope: scopedDocumentId ? "document" : "all",
+        scope: scopeKind,
         documentId: scopedDocumentId ?? null,
+        topicId: scopedTopicId ?? null,
       });
     },
-    [markBatchSeenForPost, posthog, scopedDocumentId, unreadCount, unreadPostIdSet],
+    [
+      markBatchSeenForPost,
+      posthog,
+      scopedDocumentId,
+      scopedTopicId,
+      scopeKind,
+      unreadCount,
+      unreadPostIdSet,
+    ],
   );
 
   const sentinelRef = useInfiniteScroll(status, loadMore);
@@ -245,12 +344,22 @@ function FeedPage() {
     }
 
     posthog.capture("feed.unread_jump_performed", {
-      scope: scopedDocumentId ? "document" : "all",
+      scope: scopeKind,
       documentId: scopedDocumentId ?? null,
+      topicId: scopedTopicId ?? null,
     });
     jumpLoadRequestRef.current = null;
     setPendingJumpPostId(null);
-  }, [loadMore, pendingJumpPostId, posthog, postIdKey, scopedDocumentId, status]);
+  }, [
+    loadMore,
+    pendingJumpPostId,
+    posthog,
+    postIdKey,
+    scopedDocumentId,
+    scopedTopicId,
+    scopeKind,
+    status,
+  ]);
 
   const exhaustedTracked = useRef(false);
   useEffect(() => {
@@ -265,7 +374,7 @@ function FeedPage() {
     }
   }, [status, posthog]); // eslint-disable-line react-hooks/exhaustive-deps -- enrichedResults.length intentionally omitted; we only fire when status changes
 
-  if (status === "LoadingFirstPage") {
+  if (status === "LoadingFirstPage" && !skipFeedQuery) {
     return (
       <div className="pb-6">
         <PageHeader
@@ -297,16 +406,23 @@ function FeedPage() {
     );
   }
 
+  const headerEyebrow = scopedTopicId
+    ? "Topic Feed"
+    : scopedDocumentId
+      ? "Document Feed"
+      : "Your Feed";
+  const headerDescription = scopedTopicId
+    ? "Learning posts focused on this topic's goal."
+    : scopedDocumentId
+      ? "Learning posts from this document."
+      : "Your AI-generated learning posts.";
+
   return (
     <div className="pb-6">
       <PageHeader
-        eyebrow={scopedDocumentId ? "Document Feed" : "Your Feed"}
+        eyebrow={headerEyebrow}
         title="Feed"
-        description={
-          scopedDocumentId
-            ? "Learning posts from this document."
-            : "Your AI-generated learning posts."
-        }
+        description={headerDescription}
         actions={
           <Button onClick={handleServe} disabled={serving} data-testid="feed-serve-button">
             {serving ? (
@@ -319,28 +435,15 @@ function FeedPage() {
         }
       />
 
-      {scopedDocumentId && (
-        <div className="mt-6 px-4 md:px-6">
-          <Alert data-testid="feed-scope-banner">
-            <BookOpen data-icon="inline-start" />
-            <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <span>
-                Currently viewing:{" "}
-                <strong className="font-semibold text-foreground">
-                  {scopedDocument?.title ?? "this document"}
-                </strong>
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleResetScope}
-                data-testid="feed-view-all"
-              >
-                View all
-              </Button>
-            </AlertDescription>
-          </Alert>
-        </div>
+      {scopedTopicId && scopedTopic && (
+        <FeedScopeBanner scope="topic" topic={scopedTopic} onReset={handleResetScope} />
+      )}
+      {!scopedTopicId && scopedDocumentId && scopedDocument && (
+        <FeedScopeBanner
+          scope="document"
+          documentTitle={scopedDocument.title}
+          onReset={handleResetScope}
+        />
       )}
 
       {error && (
@@ -349,8 +452,14 @@ function FeedPage() {
         </Alert>
       )}
 
-      {enrichedResults.length === 0 && !serving ? (
-        scopedDocumentId ? (
+      {topicNotFound ? (
+        <UnknownScopeState scope="topic" />
+      ) : documentNotFound ? (
+        <UnknownScopeState scope="document" />
+      ) : enrichedResults.length === 0 && !serving ? (
+        scopedTopicId ? (
+          <TopicFeedEmptyState topicName={scopedTopic?.name} reason={serveReason} />
+        ) : scopedDocumentId ? (
           <DocumentFeedEmptyState document={scopedDocument} reason={serveReason} />
         ) : (
           <FeedEmptyState reason={serveReason} onServe={handleServe} serving={serving} />
@@ -474,6 +583,88 @@ function DocumentFeedEmptyState({ document, reason }: DocumentFeedEmptyStateProp
           <p className="max-w-sm break-words text-xs text-muted-foreground">{document.title}</p>
           <StatusBadge status={document.status} />
         </div>
+      )}
+    </div>
+  );
+}
+
+interface UnknownScopeStateProps {
+  scope: "topic" | "document";
+}
+
+function UnknownScopeState({ scope }: UnknownScopeStateProps) {
+  const isTopic = scope === "topic";
+  return (
+    <div
+      data-testid={isTopic ? "feed-unknown-topic-state" : "feed-unknown-document-state"}
+      className="mt-12 flex flex-col items-center gap-5 px-4 text-center"
+    >
+      <div className="flex size-16 items-center justify-center border border-primary/30 bg-transparent">
+        {isTopic ? (
+          <Rss className="size-8 text-primary/70" />
+        ) : (
+          <BookOpen className="size-8 text-primary/70" />
+        )}
+      </div>
+      <div>
+        <p className="text-lg font-semibold tracking-tight">
+          {isTopic ? "Unknown topic" : "Unknown document"}
+        </p>
+        <p className="mx-auto mt-1.5 max-w-sm text-sm leading-relaxed text-muted-foreground">
+          {isTopic
+            ? "This topic doesn't exist or you don't have access to it."
+            : "This document doesn't exist or you don't have access to it."}
+        </p>
+      </div>
+      <Button
+        render={<Link to="/app/feed" />}
+        variant="outline"
+        data-testid="feed-unknown-scope-back"
+      >
+        Back to feed
+      </Button>
+    </div>
+  );
+}
+
+interface TopicFeedEmptyStateProps {
+  topicName: string | undefined;
+  reason: "no_drafts" | "processing" | null;
+}
+
+function TopicFeedEmptyState({ topicName, reason }: TopicFeedEmptyStateProps) {
+  const waitingForProcessing = reason === "processing";
+
+  return (
+    <div
+      data-testid="feed-topic-empty-state"
+      className="mt-12 flex flex-col items-center gap-5 px-4 text-center"
+    >
+      <div className="flex size-16 items-center justify-center border border-primary/30 bg-transparent">
+        {waitingForProcessing ? (
+          <Loader2 className="size-8 animate-spin text-primary/70" />
+        ) : (
+          <Rss className="size-8 text-primary/70" />
+        )}
+      </div>
+      <div>
+        <p className="text-lg font-semibold tracking-tight">
+          {waitingForProcessing ? "No posts yet - still generating" : "No posts for this topic"}
+        </p>
+        <p className="mx-auto mt-1.5 max-w-sm text-sm leading-relaxed text-muted-foreground">
+          {waitingForProcessing
+            ? "Scrollect is still preparing posts for this topic."
+            : "Assign documents to this topic from your library, then generate to populate the feed."}
+        </p>
+      </div>
+      {topicName && (
+        <p className="max-w-sm break-words text-xs text-muted-foreground">{topicName}</p>
+      )}
+      {!waitingForProcessing && (
+        <Button render={<Link to="/app/library" />} data-testid="feed-topic-empty-library-cta">
+          <Library className="size-4" data-icon="inline-start" />
+          Go to library
+        </Button>
       )}
     </div>
   );

--- a/apps/web/src/routes/_authenticated/app/library/$documentId.tsx
+++ b/apps/web/src/routes/_authenticated/app/library/$documentId.tsx
@@ -18,6 +18,7 @@ import { ImportHighlightsDialog } from "@/components/documents/import-highlights
 import { LearningGoalSection } from "@/components/documents/learning-goal-section";
 import { PipelineError } from "@/components/documents/pipeline-error";
 import { ProcessingProgress, isProcessingStatus } from "@/components/documents/processing-progress";
+import { TopicAssignmentSection } from "@/components/library/topic-assignment-section";
 import { NotFound } from "@/components/not-found";
 import { DocumentTagSection } from "@/components/tags/document-tag-section";
 import {
@@ -185,6 +186,7 @@ function DocumentDetailPage() {
       {(document.status === "ready" || document.learningGoalOnboardingStatus === "pending") && (
         <>
           {document.status === "ready" && <DocumentTagSection documentId={document._id} />}
+          {document.status === "ready" && <TopicAssignmentSection documentId={document._id} />}
           <LearningGoalSection
             documentId={document._id}
             initialGoal={document.learningGoal}

--- a/apps/web/src/routes/_authenticated/app/library/index.tsx
+++ b/apps/web/src/routes/_authenticated/app/library/index.tsx
@@ -16,6 +16,7 @@ import {
   ProcessingProgressBar,
   isProcessingStatus,
 } from "@/components/documents/processing-progress";
+import { LibraryRowTopicChip } from "@/components/library/library-row-topic-chip";
 import { useLibraryDetail } from "@/components/library-detail-panel";
 import { TagFilterBar, TagList, buildTagMap } from "@/components/tags";
 import { Button } from "@/components/ui/button";
@@ -85,6 +86,9 @@ function LibraryPage() {
   const { data: allUserTags } = useQuery(convexQuery(api.content.tags.listUserTags, {}));
   const { data: tagsBatch } = useQuery(
     convexQuery(api.content.tags.getDocumentTagsBatch, { documentIds }),
+  );
+  const { data: topicsBatch } = useQuery(
+    convexQuery(api.topics.topics.getDocumentTopicsBatch, { documentIds }),
   );
 
   const tagOptions = allUserTags ?? [];
@@ -235,24 +239,33 @@ function LibraryPage() {
 
               const isSelected = libraryDetail?.selectedDocumentId === doc._id;
 
+              const openRow = () => {
+                if (libraryDetail) {
+                  libraryDetail.openDetail(doc._id);
+                } else {
+                  navigate({
+                    to: "/app/library/$documentId",
+                    params: { documentId: doc._id },
+                  });
+                }
+              };
+
               return (
-                <button
-                  type="button"
+                <div
+                  role="button"
+                  tabIndex={0}
                   key={doc._id}
                   data-testid="document-item"
-                  onClick={() => {
-                    if (libraryDetail) {
-                      libraryDetail.openDetail(doc._id);
-                    } else {
-                      navigate({
-                        to: "/app/library/$documentId",
-                        params: { documentId: doc._id },
-                      });
+                  onClick={openRow}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      openRow();
                     }
                   }}
                   className={cn(
-                    "group relative block w-full cursor-pointer border-b border-border bg-card text-left transition-all duration-200",
-                    "hover:bg-accent/30",
+                    "group relative block w-full cursor-pointer border-b border-border bg-card text-left transition-all duration-200 outline-none",
+                    "hover:bg-accent/30 focus-visible:bg-accent/40 focus-visible:ring-1 focus-visible:ring-ring",
                     isSelected && "bg-accent/40",
                   )}
                 >
@@ -290,6 +303,9 @@ function LibraryPage() {
                             />
                           )}
                         </div>
+                        {doc.status === "ready" && (
+                          <LibraryRowTopicChip topic={topicsBatch?.[doc._id] ?? null} />
+                        )}
                       </div>
 
                       <h2 className="mt-2.5 font-logo text-lg font-semibold leading-[1.25] tracking-tight text-foreground [&]:line-clamp-2 md:text-[1.35rem]">
@@ -348,7 +364,7 @@ function LibraryPage() {
                       />
                     </div>
                   </div>
-                </button>
+                </div>
               );
             })}
             {filteredDocuments.length === 0 && selectedTags.size > 0 && (

--- a/apps/web/src/routes/_authenticated/app/topics/$topicId.tsx
+++ b/apps/web/src/routes/_authenticated/app/topics/$topicId.tsx
@@ -1,0 +1,262 @@
+import { convexQuery } from "@convex-dev/react-query";
+import { api } from "@scrollect/backend/convex/_generated/api";
+import type { Id } from "@scrollect/backend/convex/_generated/dataModel";
+import { useQuery } from "@tanstack/react-query";
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useMutation } from "convex/react";
+import { ArrowLeft, FileText, Layers, Loader2, Pencil, Rss, Trash2 } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { fileTypeIcons, StatusBadge, statusConfig } from "@/components/document-status";
+import { NotFound } from "@/components/not-found";
+import { EditTopicDialog } from "@/components/topics/edit-topic-dialog";
+import { resolveTopicColor, resolveTopicIcon } from "@/components/topics/topic-appearance";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { looksLikeConvexId } from "@/lib/convex-id";
+
+export const Route = createFileRoute("/_authenticated/app/topics/$topicId")({
+  ssr: false,
+  head: () => ({
+    meta: [{ title: "Topic | Scrollect" }],
+  }),
+  notFoundComponent: () => (
+    <NotFound>This topic doesn&apos;t exist or you don&apos;t have access to it.</NotFound>
+  ),
+  component: TopicDetailPage,
+});
+
+function TopicDetailPage() {
+  const { topicId } = Route.useParams();
+  const typedTopicId = topicId as Id<"topics">;
+  const isMalformedTopicId = !looksLikeConvexId(topicId);
+  const { data, error } = useQuery(
+    convexQuery(
+      api.topics.topics.getTopic,
+      isMalformedTopicId ? "skip" : { topicId: typedTopicId },
+    ),
+  );
+  const navigate = useNavigate();
+  const deleteTopic = useMutation(api.topics.topics.deleteTopic);
+  const posthog = usePostHog();
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  if (isMalformedTopicId || data === null || error != null) {
+    return (
+      <div
+        data-testid="topic-unknown-state"
+        className="mt-16 flex flex-col items-center gap-5 px-6 text-center"
+      >
+        <div className="flex size-16 items-center justify-center border border-primary/30 bg-transparent">
+          <Layers className="size-8 text-primary/70" />
+        </div>
+        <div>
+          <p className="font-logo text-2xl font-semibold tracking-tight">Unknown topic</p>
+          <p className="mt-1.5 max-w-sm text-sm leading-relaxed text-muted-foreground">
+            This topic doesn&apos;t exist or you don&apos;t have access to it.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          render={<Link to="/app/topics" />}
+          data-testid="topic-unknown-back"
+        >
+          <ArrowLeft data-icon="inline-start" />
+          Back to Topics
+        </Button>
+      </div>
+    );
+  }
+
+  if (data === undefined) {
+    return (
+      <div className="px-4 py-6 md:px-6">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="mt-6 h-9 w-2/3 rounded" />
+        <Skeleton className="mt-4 h-24 w-full" />
+      </div>
+    );
+  }
+
+  const { topic, documents } = data;
+  const colorMeta = resolveTopicColor(topic.color);
+  const { Icon } = resolveTopicIcon(topic.icon);
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await deleteTopic({ topicId: typedTopicId });
+      posthog.capture("topic.deleted", { topic_id: typedTopicId });
+      setDeleteOpen(false);
+      toast.success("Topic deleted");
+      await navigate({ to: "/app/topics" });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to delete topic";
+      posthog.captureException(error instanceof Error ? error : new Error(message));
+      toast.error(message);
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="px-4 py-6 md:px-6">
+      <Link
+        to="/app/topics"
+        className="group inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="size-4 transition-transform group-hover:-translate-x-0.5" />
+        Back to Topics
+      </Link>
+
+      <div className="mt-6 flex flex-col gap-4">
+        <div className="flex items-start gap-4">
+          <span
+            aria-hidden
+            className={`mt-1 flex size-12 shrink-0 items-center justify-center rounded-lg border ${colorMeta.accent}`}
+          >
+            <Icon className="size-6" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h1 className="break-words font-logo text-3xl font-semibold tracking-tight md:text-4xl">
+              {topic.name}
+            </h1>
+            <p
+              data-testid="topic-document-count"
+              className="mt-1 font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground"
+            >
+              {documents.length} document{documents.length === 1 ? "" : "s"}
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-muted/30 p-4">
+          <p className="font-mono text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+            Learning goal
+          </p>
+          <p className="mt-1.5 text-sm leading-relaxed text-foreground">{topic.learningGoal}</p>
+          {topic.description && (
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              {topic.description}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            data-testid="topic-open-feed-button"
+            render={<Link to="/app/feed" search={{ topicId: typedTopicId }} />}
+          >
+            <Rss data-icon="inline-start" />
+            Open feed for this topic
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => setEditOpen(true)}
+            data-testid="topic-edit-button"
+          >
+            <Pencil data-icon="inline-start" />
+            Edit
+          </Button>
+          <AlertDialog
+            open={deleteOpen}
+            onOpenChange={(next) => {
+              if (!deleting) setDeleteOpen(next);
+            }}
+          >
+            <AlertDialogTrigger
+              render={<Button variant="destructive" data-testid="topic-delete-button" />}
+            >
+              <Trash2 data-icon="inline-start" />
+              Delete
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete topic</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Delete &ldquo;{topic.name}&rdquo;? Documents will stay in your library, but this
+                  topic and its document assignments will be removed. This cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  disabled={deleting}
+                  onClick={handleDelete}
+                  data-testid="topic-confirm-delete-button"
+                >
+                  {deleting && <Loader2 className="animate-spin" data-icon="inline-start" />}
+                  Delete topic
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </div>
+
+      <EditTopicDialog
+        topicId={typedTopicId}
+        initialName={topic.name}
+        initialLearningGoal={topic.learningGoal}
+        initialDescription={topic.description}
+        initialColor={topic.color}
+        initialIcon={topic.icon}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+      />
+
+      <section className="mt-8">
+        <h2 className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <FileText className="size-3.5" />
+          Documents
+        </h2>
+        {documents.length === 0 ? (
+          <div
+            data-testid="topic-no-documents"
+            className="rounded-lg border border-dashed border-border bg-muted/20 p-6 text-center text-sm text-muted-foreground"
+          >
+            No documents assigned yet. Open a document in your library and pick this topic.
+          </div>
+        ) : (
+          <ul className="flex flex-col divide-y divide-border rounded-lg border border-border">
+            {documents.map((doc) => (
+              <li key={doc._id}>
+                <Link
+                  to="/app/library/$documentId"
+                  params={{ documentId: doc._id }}
+                  data-testid="topic-document-link"
+                  className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-accent/40"
+                >
+                  <span className="shrink-0 text-muted-foreground [&_svg]:size-4">
+                    {fileTypeIcons[doc.fileType] ?? <FileText className="size-4" />}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                    {doc.title}
+                  </span>
+                  {doc.status in statusConfig && (
+                    <StatusBadge status={doc.status as keyof typeof statusConfig} />
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_authenticated/app/topics/index.tsx
+++ b/apps/web/src/routes/_authenticated/app/topics/index.tsx
@@ -1,0 +1,109 @@
+import { convexQuery } from "@convex-dev/react-query";
+import { api } from "@scrollect/backend/convex/_generated/api";
+import { useQuery } from "@tanstack/react-query";
+import { Link, createFileRoute } from "@tanstack/react-router";
+import { Layers, Plus } from "lucide-react";
+import { useState } from "react";
+
+import { PageHeader } from "@/components/page-header";
+import { CreateTopicDialog } from "@/components/topics/create-topic-dialog";
+import { resolveTopicColor, resolveTopicIcon } from "@/components/topics/topic-appearance";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const Route = createFileRoute("/_authenticated/app/topics/")({
+  ssr: false,
+  head: () => ({
+    meta: [{ title: "Topics | Scrollect" }],
+  }),
+  component: TopicsPage,
+});
+
+function TopicsPage() {
+  const { data: topics } = useQuery(convexQuery(api.topics.topics.listTopics, {}));
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const isLoading = topics === undefined;
+  const hasTopics = topics !== undefined && topics.length > 0;
+
+  return (
+    <div className="pb-10">
+      <PageHeader
+        eyebrow="Knowledge Areas"
+        title="Topics"
+        description="Group documents by goal so Scrollect can shape posts around a focus."
+        actions={
+          <Button onClick={() => setCreateOpen(true)} data-testid="topics-create-button">
+            <Plus className="size-4" data-icon="inline-start" />
+            Create topic
+          </Button>
+        }
+      />
+
+      <CreateTopicDialog open={createOpen} onOpenChange={setCreateOpen} />
+
+      {isLoading ? (
+        <div className="grid gap-3 px-4 py-6 md:grid-cols-2 md:px-8 lg:grid-cols-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-32 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : !hasTopics ? (
+        <div
+          data-testid="topics-empty-state"
+          className="mt-16 flex flex-col items-center gap-5 px-6 text-center"
+        >
+          <div className="flex size-16 items-center justify-center border border-primary/30 bg-transparent">
+            <Layers className="size-8 text-primary/70" />
+          </div>
+          <div>
+            <p className="font-logo text-2xl font-semibold tracking-tight">No topics yet</p>
+            <p className="mt-1.5 max-w-sm text-sm leading-relaxed text-muted-foreground">
+              Create your first topic to focus your feed on a specific learning goal.
+            </p>
+          </div>
+          <Button onClick={() => setCreateOpen(true)} data-testid="topics-create-empty-button">
+            <Plus className="size-4" data-icon="inline-start" />
+            Create your first topic
+          </Button>
+        </div>
+      ) : (
+        <div className="grid gap-3 px-4 py-6 md:grid-cols-2 md:px-8 lg:grid-cols-3">
+          {topics.map((topic) => {
+            const colorMeta = resolveTopicColor(topic.color);
+            const { Icon } = resolveTopicIcon(topic.icon);
+            return (
+              <Link
+                key={topic._id}
+                to="/app/topics/$topicId"
+                params={{ topicId: topic._id }}
+                data-testid="topic-card"
+                className="group flex flex-col gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/20 hover:bg-accent/30"
+              >
+                <div className="flex items-center gap-3">
+                  <span
+                    className={`flex size-10 items-center justify-center rounded-lg border ${colorMeta.accent}`}
+                    aria-hidden
+                  >
+                    <Icon className="size-5" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <h2 className="line-clamp-1 font-logo text-lg font-semibold tracking-tight">
+                      {topic.name}
+                    </h2>
+                    <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                      {topic.documentCount} doc{topic.documentCount === 1 ? "" : "s"}
+                    </p>
+                  </div>
+                </div>
+                <p className="line-clamp-3 text-sm leading-relaxed text-muted-foreground">
+                  {topic.learningGoal}
+                </p>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/adr/019-topics-goal-scoped-feed.md
+++ b/docs/adr/019-topics-goal-scoped-feed.md
@@ -1,0 +1,86 @@
+---
+status: proposed
+date: 2026-04-25
+---
+
+# ADR-019: Topics - goal-scoped grouping of documents with scoped feed view
+
+## Context
+
+Issue #221, part of epic #219. Users upload documents that span unrelated areas (interview prep next to cooking next to language learning) into a single global pool. The feed today is single-pool: every Post Draft from every Document competes against every other, and the learning-goal seam introduced in ADR-018 §3 resolves to the per-Document goal only. There is no way to focus a session on one area; the unrelated documents dilute the learning signal. ADR-018 explicitly anticipated this case and reserved `getEffectiveLearningGoalEmbedding` (`packages/backend/convex/feed/learningGoal.ts`) as the single seam where topic-aware resolution would land. This ADR is that landing.
+
+## Decision
+
+### 1. New `topics` table
+
+Add a `topics` table owned per-user. Fields:
+
+```
+userId, name, learningGoal,
+learningGoalEmbedding?, description?, color?, icon?,
+parentTopicId?, createdAt
+```
+
+Indexes: `by_userId`, `by_userId_name`. `parentTopicId` is reserved for future one-level subtopic nesting (Obsidian/Reddit style); v1 ships no UI for it but the column exists so a future ADR does not need a backfill. `color` and `icon` are optional UI affordances and do not affect scoring.
+
+### 2. New `documentTopics` junction table
+
+Add `documentTopics` with `documentId`, `topicId`, `userId`, `createdAt`. Indexes: `by_documentId`, `by_topicId`, `by_userId`. Schema is N:N. V1 UI is single-select per document (the `assignDocumentToTopic` mutation replaces in place), but the schema does not assume that constraint - a future multi-select UI does not require a migration. Uniqueness on `(documentId, topicId)` is enforced at the mutation layer, not in the schema.
+
+### 3. Resolver precedence: topic -> document -> undefined
+
+`getEffectiveLearningGoalEmbedding(ctx, documentId)` resolves in order:
+
+1. Look up `documentTopics` for `documentId`. If a topic is found and `topics.learningGoalEmbedding` is present, return it.
+2. Otherwise return `documents.learningGoalEmbedding` for that document.
+3. Otherwise return `undefined` (scorer treats as `goalRelevance = 1.0`).
+
+This diverges from issue #221's literal text. The issue specifies that step 2 should fall back to `userProfiles.learningGoalEmbedding` and that `documents.learningGoal` should no longer be consulted by the resolver. ADR-018 §3 explicitly rejected the `userProfiles` fallback as a correctness bug: a Document whose own goal text says "learn X" could end up scored against another Document's embedding because the most recent profile-level goal belonged to a different doc. Per-Document colocation eliminates that class of bug. We honor ADR-018's rationale here. The user has confirmed this resolution. ADR-019 supersedes the resolver-fallback wording in #221.
+
+The scorer in `src/feed/logic/scoring.ts` is untouched - it consumes whatever vector the resolver returns. All existing feed unit tests and `feedServing.eval.ts` continue to pass.
+
+### 4. Re-rank, do not re-generate
+
+When a Document is assigned to a Topic, its existing Post Drafts were generated under whatever goal was active at draft time (per-Document goal, or none). Those drafts are not regenerated. Serving simply re-ranks the existing pool against the Topic's goal vector. For narrow Topics this means "best subset of a general pool" rather than "topic-tailored generation."
+
+This is an accepted v1 limitation. The cost of regeneration on assignment (re-running `SectionDraftRankerLlm` plus per-section validator calls per Document, multiplied by every Topic membership change) is not justified at personal scale. A future ADR may introduce topic-aware draft generation if user evidence shows the re-rank-only path produces visibly off-topic feeds for narrow Topics.
+
+### 5. Topic-scoped serving query
+
+Add `serveTopicFeed({ topicId, limit })` mirroring the existing `serveDocumentFeed` pattern (PR #232 / issue #220). It resolves member documentIds via `documentTopics.by_topicId` and reuses the shared `serveFeedForScope` internal that `serveDocumentFeed` already calls. We do not overload `serveFeed` with an optional `scope` parameter - the three callers (global, per-document, per-topic) have meaningfully different argument shapes and analytics payloads, and a discriminated query name is easier to grep, easier to authorize, and easier to instrument.
+
+### 6. Topic deletion cascade
+
+`deleteTopic` cascades only the `documentTopics` rows for that Topic. The Documents themselves survive and revert to per-Document goal resolution on the next serve. Contrast with Document deletion, which already cascades a long chain (vectors, chunks, section summaries, post drafts, posts, bookmarks, highlights, connection pairs); Document deletion now also cascades any `documentTopics` rows pointing at the Document.
+
+### 7. Goal-text edit triggers re-embedding
+
+Editing `topics.learningGoal` schedules `embedTopicGoal` (new action in `convex/topicsActions.ts`), which writes `topics.learningGoalEmbedding`. This mirrors the `updateLearningGoal` -> `embedLearningGoal` pattern in `convex/content/documents.ts` and `convex/content/documentActions.ts`. Any text change recomputes; clearing the goal text clears the embedding. No cross-Topic reconciliation - each Topic's vector is colocated with its own text.
+
+### Alternatives considered
+
+- **`userProfiles` fallback per issue #221** - Rejected. ADR-018 §3 already documented this as a correctness bug: a Document's content can be scored against an unrelated profile-level goal whenever the most recent profile edit belonged to a different Document area. The per-Document fallback is correct by construction.
+- **Multi-topic-per-document UI in v1** - Deferred. Schema is already N:N so no migration is needed when a multi-select UI ships. V1 stays single-select to keep the picker simple and to avoid the "which Topic's goal wins?" resolver question (current resolver picks the first match; a future ADR will define the policy).
+- **Card regeneration on assignment** - Deferred. See §4. The LLM cost and the scheduling complexity (debouncing assignment churn, handling partial regeneration) are not justified without evidence that re-ranking is insufficient.
+- **Subtopic nesting** - Deferred. Schema reserves `parentTopicId`. A future ADR will define resolver behavior for nested Topics (parent goal vs leaf goal, walk order).
+- **Overload `serveFeed` with optional `topicId`/`documentId` scope params** - Rejected. Three discriminated queries (`serveFeed`, `serveDocumentFeed`, `serveTopicFeed`) match the three call sites in the UI and keep authorization, analytics, and validator surface clean. Already established by PR #232.
+- **Materialize Topic membership as `documents.topicId` (1:1)** - Rejected. The schema cost of N:N is one extra index; the cost of re-migrating later when multi-Topic ships is much higher. YAGNI does not apply when the cheaper option preserves future optionality at near-zero present cost.
+
+## Consequences
+
+- **Topic-aware ranking with no scoring code change.** ADR-018's resolver seam was designed for exactly this; only `getEffectiveLearningGoalEmbedding` changes. `src/feed/logic/scoring.ts` is byte-for-byte untouched.
+- **Existing drafts keep working.** No backfill, no migration. Documents not in a Topic resolve to their per-Document goal; Documents in a Topic with no embedding yet resolve to their per-Document goal as a safe degrade.
+- **Narrow Topics may serve generally-drafted Posts.** Until topic-aware generation lands, a Topic with one Document and a tight goal will rank that Document's existing pool against the new vector but cannot conjure new content. Documented as a known v1 limitation per #221.
+- **One new write surface on Document delete.** Document deletion now cascades `documentTopics` in addition to its existing chain. Deleting a Topic does not touch Documents.
+- **Schema indexes match access patterns.** `documentTopics.by_documentId` powers the resolver hot path; `documentTopics.by_topicId` powers `serveTopicFeed`; `topics.by_userId_name` powers the picker.
+- **No public/shared Topics, no analytics dashboards, no subtopic UI.** Explicit non-goals per #221.
+- **Risk: silent drift between Topic goal text and embedding.** The embedding action is async; a serve immediately after an edit can read a stale vector. Same risk pattern as Document goals; mitigated by the safe `undefined` -> `1.0` fallback.
+
+## More Information
+
+- ADR-018 §3 introduced `getEffectiveLearningGoalEmbedding` and named the topic-aware future this ADR fulfills.
+- Issue #221 specifies the schema and routing; this ADR overrides its resolver-fallback step (see §3).
+- Epic #219 is the parent epic for goal-scoped grouping work.
+- Resolver implementation: `packages/backend/convex/feed/learningGoal.ts`.
+- Pattern reference for goal embedding actions: `packages/backend/convex/content/documents.ts` and `packages/backend/convex/content/documentActions.ts`.
+- Pattern reference for scoped serving: `serveDocumentFeed` (PR #232 / issue #220).

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -75,6 +75,8 @@ import type * as migrations from "../migrations.js";
 import type * as ops_healthCheck from "../ops/healthCheck.js";
 import type * as ops_testing from "../ops/testing.js";
 import type * as ops_testingActions from "../ops/testingActions.js";
+import type * as topics_topics from "../topics/topics.js";
+import type * as topics_topicsActions from "../topics/topicsActions.js";
 
 import type {
   ApiFromModules,
@@ -150,6 +152,8 @@ declare const fullApi: ApiFromModules<{
   "ops/healthCheck": typeof ops_healthCheck;
   "ops/testing": typeof ops_testing;
   "ops/testingActions": typeof ops_testingActions;
+  "topics/topics": typeof topics_topics;
+  "topics/topicsActions": typeof topics_topicsActions;
 }>;
 
 /**

--- a/packages/backend/convex/access/account.ts
+++ b/packages/backend/convex/access/account.ts
@@ -22,47 +22,51 @@ export const deleteRemainingUserData = internalMutation({
     deletedTags: v.number(),
     deletedReactionFeedback: v.number(),
     deletedEntitlementGrants: v.number(),
+    deletedTopics: v.number(),
+    deletedDocumentTopics: v.number(),
   }),
   handler: async (ctx, args) => {
-    const bookmarks = await ctx.db
-      .query("bookmarks")
-      .withIndex("by_userId_post", (q) => q.eq("userId", args.userId))
-      .collect();
-    for (const bookmark of bookmarks) {
-      await ctx.db.delete(bookmark._id);
-    }
+    const [bookmarks, bookmarkLists, tags, reactionFeedback, grants, topics, documentTopics] =
+      await Promise.all([
+        ctx.db
+          .query("bookmarks")
+          .withIndex("by_userId_post", (q) => q.eq("userId", args.userId))
+          .collect(),
+        ctx.db
+          .query("bookmarkLists")
+          .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+          .collect(),
+        ctx.db
+          .query("tags")
+          .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+          .collect(),
+        ctx.db
+          .query("reactionFeedback")
+          .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+          .collect(),
+        ctx.db
+          .query("entitlementGrants")
+          .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+          .collect(),
+        ctx.db
+          .query("topics")
+          .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+          .collect(),
+        ctx.db
+          .query("documentTopics")
+          .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+          .collect(),
+      ]);
 
-    const bookmarkLists = await ctx.db
-      .query("bookmarkLists")
-      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
-      .collect();
-    for (const list of bookmarkLists) {
-      await ctx.db.delete(list._id);
-    }
-
-    const tags = await ctx.db
-      .query("tags")
-      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
-      .collect();
-    for (const tag of tags) {
-      await ctx.db.delete(tag._id);
-    }
-
-    const reactionFeedback = await ctx.db
-      .query("reactionFeedback")
-      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
-      .collect();
-    for (const fb of reactionFeedback) {
-      await ctx.db.delete(fb._id);
-    }
-
-    const grants = await ctx.db
-      .query("entitlementGrants")
-      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
-      .collect();
-    for (const grant of grants) {
-      await ctx.db.delete(grant._id);
-    }
+    await Promise.all([
+      ...bookmarks.map((doc) => ctx.db.delete(doc._id)),
+      ...bookmarkLists.map((doc) => ctx.db.delete(doc._id)),
+      ...tags.map((doc) => ctx.db.delete(doc._id)),
+      ...reactionFeedback.map((doc) => ctx.db.delete(doc._id)),
+      ...grants.map((doc) => ctx.db.delete(doc._id)),
+      ...topics.map((doc) => ctx.db.delete(doc._id)),
+      ...documentTopics.map((doc) => ctx.db.delete(doc._id)),
+    ]);
 
     return {
       deletedBookmarks: bookmarks.length,
@@ -70,6 +74,8 @@ export const deleteRemainingUserData = internalMutation({
       deletedTags: tags.length,
       deletedReactionFeedback: reactionFeedback.length,
       deletedEntitlementGrants: grants.length,
+      deletedTopics: topics.length,
+      deletedDocumentTopics: documentTopics.length,
     };
   },
 });

--- a/packages/backend/convex/content/deletion.ts
+++ b/packages/backend/convex/content/deletion.ts
@@ -39,6 +39,7 @@ export type DocumentDeletionCascadeResult = {
     postDrafts: number;
     reactionFeedback: number;
     orphanedTags: number;
+    documentTopics: number;
   };
 };
 
@@ -94,7 +95,7 @@ export async function executeDocumentDeletionCascade({
     services,
   });
 
-  const [highlightResult, postResult, connectionPairResult] = await Promise.all([
+  const [highlightResult, postResult, connectionPairResult, topicResult] = await Promise.all([
     ctx.runMutation(internal.content.highlights.cascadeDeleteHighlights, {
       documentId,
       userId,
@@ -104,6 +105,9 @@ export async function executeDocumentDeletionCascade({
       userId,
     }),
     ctx.runMutation(internal.drafting.connectionPairs.cascadeDeleteByDocumentId, {
+      documentId,
+    }),
+    ctx.runMutation(internal.topics.topics.cascadeDeleteByDocumentId, {
       documentId,
     }),
   ]);
@@ -134,6 +138,7 @@ export async function executeDocumentDeletionCascade({
       postDrafts: chunkResult.deletedPostDrafts,
       reactionFeedback: chunkResult.deletedReactionFeedback,
       orphanedTags: docResult.deletedOrphanedTags,
+      documentTopics: topicResult.deletedDocumentTopics,
     },
   };
 }

--- a/packages/backend/convex/feed/learningGoal.ts
+++ b/packages/backend/convex/feed/learningGoal.ts
@@ -3,23 +3,43 @@ import type { GenericMutationCtx, GenericQueryCtx } from "convex/server";
 import type { DataModel, Id } from "../_generated/dataModel";
 
 /**
- * Resolver seam for the learning-goal vector used by feed scoring.
+ * Resolver seam for the learning-goal vector used by feed scoring (ADR-018 §3, ADR-019).
  *
- * Today it returns `documents.learningGoalEmbedding` for the given document. The vector
- * is colocated with the `learningGoal` text on the same document so edits on one
- * document never trample another document's goal. When per-topic goals ship
- * (ADR-018 §3 future-ready resolver seam), this function will look up the document's
- * topic, resolve the topic's embedding, and fall back to the per-document default.
- * Scoring code calls this helper and stays topic-agnostic.
+ * Resolution order is `topic → document → undefined`:
+ *  1. If the document is assigned to a topic and that topic has a `learningGoalEmbedding`,
+ *     return the topic's embedding. Topics are a personal goal-scoped lens over a subset
+ *     of documents; ranking against the topic vector lets users focus the feed.
+ *  2. Otherwise, return the document's own `learningGoalEmbedding` (the per-document goal
+ *     a user set during onboarding or on the document detail page).
+ *  3. Otherwise, return `undefined`. The serving scorer treats `undefined` as
+ *     `goalRelevance = 1.0`.
  *
- * Returns `undefined` when the document has no learning goal or the embedding has
- * not yet been computed (scheduled action still pending, or provider error). The
- * serving scorer treats `undefined` as `goalRelevance = 1.0`.
+ * Scoring code calls this helper and stays topic-agnostic. The schema permits multiple
+ * `documentTopics` rows per document so future multi-select doesn't require a migration;
+ * v1 UI is single-select, but if multiple rows exist the most-recent one wins.
+ *
+ * Note: `userProfiles.learningGoalEmbedding` is intentionally not consulted - per ADR-019,
+ * the per-document goal is the ultimate fallback, never a profile-level default.
  */
 export async function getEffectiveLearningGoalEmbedding(
   ctx: GenericQueryCtx<DataModel> | GenericMutationCtx<DataModel>,
   documentId: Id<"documents">,
 ): Promise<number[] | undefined> {
+  const assignments = await ctx.db
+    .query("documentTopics")
+    .withIndex("by_documentId", (q) => q.eq("documentId", documentId))
+    .collect();
+
+  if (assignments.length > 0) {
+    const mostRecent = assignments.reduce((best, current) =>
+      current.createdAt > best.createdAt ? current : best,
+    );
+    const topic = await ctx.db.get(mostRecent.topicId);
+    if (topic?.learningGoalEmbedding && topic.learningGoalEmbedding.length > 0) {
+      return topic.learningGoalEmbedding;
+    }
+  }
+
   const doc = await ctx.db.get(documentId);
   return doc?.learningGoalEmbedding ?? undefined;
 }

--- a/packages/backend/convex/feed/queries.ts
+++ b/packages/backend/convex/feed/queries.ts
@@ -14,6 +14,7 @@ export const list = query({
   args: {
     paginationOpts: paginationOptsValidator,
     documentId: v.optional(v.id("documents")),
+    topicId: v.optional(v.id("topics")),
   },
   handler: async (ctx, args) => {
     const user = await optionalAuth(ctx);
@@ -25,10 +26,35 @@ export const list = query({
       };
     }
 
-    const scopedDocumentId = args.documentId;
+    const scopedTopicId = args.topicId;
+    const scopedDocumentId = scopedTopicId ? undefined : args.documentId;
     if (scopedDocumentId) {
       const document = await ctx.db.get(scopedDocumentId);
       if (!document || document.userId !== user._id) {
+        return {
+          page: [],
+          isDone: true,
+          continueCursor: "",
+        };
+      }
+    }
+
+    let topicDocumentIds: Set<string> | null = null;
+    if (scopedTopicId) {
+      const topic = await ctx.db.get(scopedTopicId);
+      if (!topic || topic.userId !== user._id) {
+        return {
+          page: [],
+          isDone: true,
+          continueCursor: "",
+        };
+      }
+      const assignments = await ctx.db
+        .query("documentTopics")
+        .withIndex("by_topicId", (q) => q.eq("topicId", scopedTopicId))
+        .collect();
+      topicDocumentIds = new Set(assignments.map((a) => a.documentId as string));
+      if (topicDocumentIds.size === 0) {
         return {
           page: [],
           isDone: true,
@@ -51,7 +77,12 @@ export const list = query({
           .order("desc")
           .paginate(args.paginationOpts);
 
-    const visiblePage = result.page.filter((post) => post.reaction !== "dislike");
+    const visiblePage = result.page.filter((post) => {
+      if (post.reaction === "dislike") return false;
+      if (topicDocumentIds && !topicDocumentIds.has(post.primarySourceDocumentId as string))
+        return false;
+      return true;
+    });
 
     // Date.now() is non-deterministic in Convex queries but acceptable here:
     // isNew will update on the next query re-evaluation triggered by any data write,

--- a/packages/backend/convex/feed/serving.ts
+++ b/packages/backend/convex/feed/serving.ts
@@ -1,7 +1,8 @@
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 
 import { mutation } from "../_generated/server";
-import { allFeedScope, documentFeedScope } from "../../src/feed/logic/servingScope";
+import { requireAuth } from "../lib/functions";
+import { allFeedScope, documentFeedScope, topicFeedScope } from "../../src/feed/logic/servingScope";
 import type { ServingResult } from "./serving/orchestrator";
 import { serveFeedForScope } from "./serving/orchestrator";
 
@@ -27,6 +28,40 @@ export const serveDocumentFeed = mutation({
   handler: async (ctx, args): Promise<ServingResult> => {
     return await serveFeedForScope(ctx, {
       scope: documentFeedScope(args.documentId),
+    });
+  },
+});
+
+export const serveTopicFeed = mutation({
+  args: {
+    topicId: v.id("topics"),
+  },
+  returns: v.object({
+    posts: v.array(v.id("posts")),
+    reason: v.optional(v.union(v.literal("no_drafts"), v.literal("processing"))),
+  }),
+  handler: async (ctx, args): Promise<ServingResult> => {
+    const user = await requireAuth(ctx);
+    const topic = await ctx.db.get(args.topicId);
+    if (!topic || topic.userId !== user._id) {
+      throw new ConvexError({ code: "topic_not_found" as const });
+    }
+
+    const assignments = await ctx.db
+      .query("documentTopics")
+      .withIndex("by_topicId", (q) => q.eq("topicId", args.topicId))
+      .collect();
+
+    const documentIds = assignments
+      .filter((a) => a.userId === user._id)
+      .map((a) => a.documentId as string);
+
+    if (documentIds.length === 0) {
+      return { posts: [], reason: "no_drafts" };
+    }
+
+    return await serveFeedForScope(ctx, {
+      scope: topicFeedScope(args.topicId, documentIds),
     });
   },
 });

--- a/packages/backend/convex/feed/serving/draftPool.ts
+++ b/packages/backend/convex/feed/serving/draftPool.ts
@@ -35,7 +35,7 @@ export async function loadDraftPoolForServing(
 
   const pendingDrafts = await loadPendingDrafts(ctx, params);
   const servedDrafts =
-    params.scope.kind === "document" ? [] : await loadServedDrafts(ctx, params.userId);
+    params.scope.kind === "all" ? await loadServedDrafts(ctx, params.userId) : [];
   const draftsToScore = [...pendingDrafts, ...servedDrafts];
 
   return {
@@ -51,6 +51,21 @@ export async function determineEmptyReasonForDraftPool(
   ctx: MutationCtx,
   params: { userId: string; scope: ServingScope; scopedDocument: Doc<"documents"> | null },
 ): Promise<EmptyReason> {
+  if (params.scope.kind === "topic") {
+    const topicDocs = await loadTopicScopeDocuments(ctx, params.scope.documentIds);
+    const hasAnyDocument = topicDocs.length > 0;
+    const hasProcessingDocument = topicDocs.some(
+      (doc) =>
+        doc !== null &&
+        PROCESSING_STAGE_VALUES.includes(doc.status as (typeof PROCESSING_STAGE_VALUES)[number]),
+    );
+    return determineEmptyReasonForScope({
+      scope: params.scope,
+      hasAnyDocument,
+      hasProcessingDocument,
+    });
+  }
+
   const hasAnyDocument =
     params.scope.kind === "document"
       ? params.scopedDocument !== null
@@ -106,6 +121,16 @@ async function loadPendingDrafts(
       .take(2000);
   }
 
+  if (params.scope.kind === "topic") {
+    if (params.scope.documentIds.length === 0) return [];
+    const memberIds = new Set(params.scope.documentIds);
+    const drafts = await ctx.db
+      .query("postDrafts")
+      .withIndex("by_userId_status", (q) => q.eq("userId", params.userId).eq("status", "pending"))
+      .take(2000);
+    return drafts.filter((d) => memberIds.has(d.documentId as string));
+  }
+
   return await ctx.db
     .query("postDrafts")
     .withIndex("by_userId_status", (q) => q.eq("userId", params.userId).eq("status", "pending"))
@@ -117,4 +142,13 @@ async function loadServedDrafts(ctx: MutationCtx, userId: string): Promise<Doc<"
     .query("postDrafts")
     .withIndex("by_userId_status", (q) => q.eq("userId", userId).eq("status", "served"))
     .take(2000);
+}
+
+async function loadTopicScopeDocuments(
+  ctx: MutationCtx,
+  documentIds: string[],
+): Promise<Doc<"documents">[]> {
+  if (documentIds.length === 0) return [];
+  const docs = await Promise.all(documentIds.map((id) => ctx.db.get(id as Id<"documents">)));
+  return docs.filter((d): d is Doc<"documents"> => d !== null);
 }

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -241,4 +241,35 @@ export default defineSchema({
     .index("by_documentIdA", ["documentIdA"])
     .index("by_documentIdB", ["documentIdB"])
     .index("by_userId_status", ["userId", "status"]),
+
+  // Personal goal-scoped lens over a subset of documents (ADR-019). When the feed is
+  // scoped to a topic, posts are ranked against the topic's `learningGoalEmbedding`
+  // instead of the per-document goal — see `getEffectiveLearningGoalEmbedding`. The
+  // embedding is colocated with the goal text so edits don't trample sibling topics.
+  topics: defineTable({
+    userId: v.string(),
+    name: v.string(),
+    learningGoal: v.string(),
+    learningGoalEmbedding: v.optional(v.array(v.float64())),
+    description: v.optional(v.string()),
+    color: v.optional(v.string()),
+    icon: v.optional(v.string()),
+    parentTopicId: v.optional(v.id("topics")),
+    createdAt: v.number(),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_userId_name", ["userId", "name"]),
+
+  // Junction between documents and topics. v1 UI is single-topic-per-document, but the
+  // schema permits multiple rows per document so future multi-select doesn't require a
+  // migration. The resolver picks the most-recent assignment when several exist.
+  documentTopics: defineTable({
+    documentId: v.id("documents"),
+    topicId: v.id("topics"),
+    userId: v.string(),
+    createdAt: v.number(),
+  })
+    .index("by_documentId", ["documentId"])
+    .index("by_topicId", ["topicId"])
+    .index("by_userId", ["userId"]),
 });

--- a/packages/backend/convex/topics/topics.ts
+++ b/packages/backend/convex/topics/topics.ts
@@ -1,0 +1,604 @@
+import { ConvexError, v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { mutation, query, internalMutation } from "../_generated/server";
+import { requireAuth, optionalAuth } from "../lib/functions";
+import { WideEvent } from "../../src/platform/logging";
+
+const NAME_MAX_LENGTH = 80;
+const LEARNING_GOAL_MAX_LENGTH = 500;
+const DESCRIPTION_MAX_LENGTH = 1000;
+const APPEARANCE_MAX_LENGTH = 32;
+
+export const listTopics = query({
+  args: {},
+  returns: v.array(
+    v.object({
+      _id: v.id("topics"),
+      _creationTime: v.number(),
+      userId: v.string(),
+      name: v.string(),
+      learningGoal: v.string(),
+      learningGoalEmbedding: v.optional(v.array(v.float64())),
+      description: v.optional(v.string()),
+      color: v.optional(v.string()),
+      icon: v.optional(v.string()),
+      parentTopicId: v.optional(v.id("topics")),
+      createdAt: v.number(),
+      documentCount: v.number(),
+    }),
+  ),
+  handler: async (ctx, _args) => {
+    const user = await optionalAuth(ctx);
+    if (!user) return [];
+
+    const topics = await ctx.db
+      .query("topics")
+      .withIndex("by_userId", (q) => q.eq("userId", user._id))
+      .collect();
+
+    const counts = await Promise.all(
+      topics.map(async (topic) => {
+        const assignments = await ctx.db
+          .query("documentTopics")
+          .withIndex("by_topicId", (q) => q.eq("topicId", topic._id))
+          .collect();
+        return assignments.length;
+      }),
+    );
+
+    return topics.map((topic, idx) => ({ ...topic, documentCount: counts[idx] ?? 0 }));
+  },
+});
+
+export const getTopic = query({
+  args: { topicId: v.id("topics") },
+  returns: v.union(
+    v.object({
+      topic: v.object({
+        _id: v.id("topics"),
+        _creationTime: v.number(),
+        userId: v.string(),
+        name: v.string(),
+        learningGoal: v.string(),
+        learningGoalEmbedding: v.optional(v.array(v.float64())),
+        description: v.optional(v.string()),
+        color: v.optional(v.string()),
+        icon: v.optional(v.string()),
+        parentTopicId: v.optional(v.id("topics")),
+        createdAt: v.number(),
+      }),
+      documents: v.array(
+        v.object({
+          _id: v.id("documents"),
+          title: v.string(),
+          status: v.string(),
+          fileType: v.string(),
+          createdAt: v.number(),
+        }),
+      ),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const user = await optionalAuth(ctx);
+    if (!user) return null;
+
+    const topic = await ctx.db.get(args.topicId);
+    if (!topic || topic.userId !== user._id) return null;
+
+    const assignments = await ctx.db
+      .query("documentTopics")
+      .withIndex("by_topicId", (q) => q.eq("topicId", args.topicId))
+      .collect();
+
+    const documents = await Promise.all(assignments.map((a) => ctx.db.get(a.documentId)));
+    const ownedDocs = documents.filter(
+      (doc): doc is Doc<"documents"> => doc !== null && doc.userId === user._id,
+    );
+
+    return {
+      topic,
+      documents: ownedDocs.map((doc) => ({
+        _id: doc._id,
+        title: doc.title,
+        status: doc.status,
+        fileType: doc.fileType,
+        createdAt: doc.createdAt,
+      })),
+    };
+  },
+});
+
+export const getDocumentTopic = query({
+  args: { documentId: v.id("documents") },
+  returns: v.union(
+    v.object({
+      _id: v.id("topics"),
+      _creationTime: v.number(),
+      userId: v.string(),
+      name: v.string(),
+      learningGoal: v.string(),
+      learningGoalEmbedding: v.optional(v.array(v.float64())),
+      description: v.optional(v.string()),
+      color: v.optional(v.string()),
+      icon: v.optional(v.string()),
+      parentTopicId: v.optional(v.id("topics")),
+      createdAt: v.number(),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const user = await optionalAuth(ctx);
+    if (!user) return null;
+
+    const document = await ctx.db.get(args.documentId);
+    if (!document || document.userId !== user._id) return null;
+
+    const assignments = await ctx.db
+      .query("documentTopics")
+      .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+      .collect();
+    if (assignments.length === 0) return null;
+
+    const mostRecent = assignments.reduce((best, current) =>
+      current.createdAt > best.createdAt ? current : best,
+    );
+    const topic = await ctx.db.get(mostRecent.topicId);
+    if (!topic || topic.userId !== user._id) return null;
+    return topic;
+  },
+});
+
+export const getDocumentTopicsBatch = query({
+  args: { documentIds: v.array(v.id("documents")) },
+  handler: async (ctx, args) => {
+    const user = await optionalAuth(ctx);
+    if (!user) return {};
+
+    const result: Record<string, Doc<"topics"> | null> = {};
+
+    const docs = await Promise.all(args.documentIds.map((id) => ctx.db.get(id)));
+    const ownedDocIds: Id<"documents">[] = [];
+    for (const doc of docs) {
+      if (!doc || doc.userId !== user._id) continue;
+      ownedDocIds.push(doc._id);
+      result[doc._id] = null;
+    }
+
+    const assignmentsByDoc = await Promise.all(
+      ownedDocIds.map((documentId) =>
+        ctx.db
+          .query("documentTopics")
+          .withIndex("by_documentId", (q) => q.eq("documentId", documentId))
+          .collect(),
+      ),
+    );
+
+    const uniqueTopicIds = new Set<Id<"topics">>();
+    for (const assignments of assignmentsByDoc) {
+      for (const assignment of assignments) {
+        uniqueTopicIds.add(assignment.topicId);
+      }
+    }
+
+    const topicMap = new Map<Id<"topics">, Doc<"topics">>();
+    const topicRecords = await Promise.all([...uniqueTopicIds].map((id) => ctx.db.get(id)));
+    for (const topic of topicRecords) {
+      if (topic && topic.userId === user._id) topicMap.set(topic._id, topic);
+    }
+
+    for (let i = 0; i < ownedDocIds.length; i += 1) {
+      const documentId = ownedDocIds[i]!;
+      const assignments = assignmentsByDoc[i] ?? [];
+      if (assignments.length === 0) continue;
+      const mostRecent = assignments.reduce((best, current) =>
+        current.createdAt > best.createdAt ? current : best,
+      );
+      const topic = topicMap.get(mostRecent.topicId);
+      if (topic) result[documentId] = topic;
+    }
+
+    return result;
+  },
+});
+
+export const createTopic = mutation({
+  args: {
+    name: v.string(),
+    learningGoal: v.string(),
+    description: v.optional(v.string()),
+    color: v.optional(v.string()),
+    icon: v.optional(v.string()),
+    parentTopicId: v.optional(v.id("topics")),
+  },
+  returns: v.id("topics"),
+  handler: async (ctx, args) => {
+    const evt = new WideEvent("topics.createTopic");
+    try {
+      const user = await requireAuth(ctx);
+      evt.set("userId", user._id);
+
+      const name = validateName(args.name);
+      const learningGoal = validateLearningGoal(args.learningGoal);
+      const description = sanitizeDescription(args.description);
+      const color = sanitizeAppearance(args.color, "color");
+      const icon = sanitizeAppearance(args.icon, "icon");
+
+      await requireUniqueTopicName(ctx, { userId: user._id, name });
+
+      if (args.parentTopicId !== undefined) {
+        const parent = await ctx.db.get(args.parentTopicId);
+        if (!parent || parent.userId !== user._id) {
+          throw new ConvexError({ code: "topic_not_found" as const });
+        }
+      }
+
+      const topicId = await ctx.db.insert("topics", {
+        userId: user._id,
+        name,
+        learningGoal,
+        description,
+        color,
+        icon,
+        parentTopicId: args.parentTopicId,
+        createdAt: Date.now(),
+      });
+      evt.set({ topicId });
+
+      await ctx.scheduler.runAfter(0, internal.topics.topicsActions.embedTopicGoal, {
+        topicId,
+        learningGoal,
+      });
+
+      await ctx.scheduler.runAfter(0, internal.topics.topicsActions.captureTopicAnalytics, {
+        userId: user._id,
+        payload: {
+          event: "topic_created",
+          properties: {
+            topic_id: topicId,
+            has_description: description !== undefined && description.length > 0,
+            has_color: color !== undefined && color.length > 0,
+            has_icon: icon !== undefined && icon.length > 0,
+          },
+        },
+      });
+
+      return topicId;
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
+    }
+  },
+});
+
+export const updateTopic = mutation({
+  args: {
+    topicId: v.id("topics"),
+    name: v.optional(v.string()),
+    learningGoal: v.optional(v.string()),
+    description: v.optional(v.string()),
+    color: v.optional(v.string()),
+    icon: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const evt = new WideEvent("topics.updateTopic");
+    evt.set("topicId", args.topicId);
+    try {
+      const user = await requireAuth(ctx);
+      evt.set("userId", user._id);
+
+      const topic = await requireOwnedTopic(ctx, { topicId: args.topicId, userId: user._id });
+
+      const update: Partial<Doc<"topics">> = {};
+      if (args.name !== undefined) {
+        const nextName = validateName(args.name);
+        if (nextName !== topic.name) {
+          await requireUniqueTopicName(ctx, {
+            userId: user._id,
+            name: nextName,
+            excludeTopicId: args.topicId,
+          });
+        }
+        update.name = nextName;
+      }
+      if (args.description !== undefined) {
+        update.description = sanitizeDescription(args.description) ?? "";
+      }
+      if (args.color !== undefined) {
+        update.color = sanitizeAppearance(args.color, "color") ?? "";
+      }
+      if (args.icon !== undefined) {
+        update.icon = sanitizeAppearance(args.icon, "icon") ?? "";
+      }
+
+      let goalChanged = false;
+      let nextGoal: string | undefined;
+      if (args.learningGoal !== undefined) {
+        nextGoal = validateLearningGoal(args.learningGoal);
+        if (nextGoal !== topic.learningGoal) {
+          goalChanged = true;
+          update.learningGoal = nextGoal;
+          update.learningGoalEmbedding = undefined;
+        }
+      }
+
+      if (Object.keys(update).length > 0) {
+        await ctx.db.patch(args.topicId, update);
+      }
+
+      if (goalChanged && nextGoal !== undefined) {
+        await ctx.scheduler.runAfter(0, internal.topics.topicsActions.embedTopicGoal, {
+          topicId: args.topicId,
+          learningGoal: nextGoal,
+        });
+
+        await ctx.scheduler.runAfter(0, internal.topics.topicsActions.captureTopicAnalytics, {
+          userId: user._id,
+          payload: {
+            event: "topic_goal_edited",
+            properties: { topic_id: args.topicId },
+          },
+        });
+      }
+
+      return null;
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
+    }
+  },
+});
+
+export const deleteTopic = mutation({
+  args: { topicId: v.id("topics") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const evt = new WideEvent("topics.deleteTopic");
+    evt.set("topicId", args.topicId);
+    try {
+      const user = await requireAuth(ctx);
+      evt.set("userId", user._id);
+
+      await requireOwnedTopic(ctx, { topicId: args.topicId, userId: user._id });
+
+      const assignments = await ctx.db
+        .query("documentTopics")
+        .withIndex("by_topicId", (q) => q.eq("topicId", args.topicId))
+        .collect();
+
+      await Promise.all([
+        ...assignments.map((a) => ctx.db.delete(a._id)),
+        ctx.db.delete(args.topicId),
+      ]);
+      evt.set({ documentCount: assignments.length });
+
+      await ctx.scheduler.runAfter(0, internal.topics.topicsActions.captureTopicAnalytics, {
+        userId: user._id,
+        payload: {
+          event: "topic_deleted",
+          properties: { topic_id: args.topicId, document_count: assignments.length },
+        },
+      });
+
+      return null;
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
+    }
+  },
+});
+
+export const assignDocumentToTopic = mutation({
+  args: {
+    documentId: v.id("documents"),
+    topicId: v.id("topics"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const evt = new WideEvent("topics.assignDocumentToTopic");
+    evt.set({ documentId: args.documentId, topicId: args.topicId });
+    try {
+      const user = await requireAuth(ctx);
+      evt.set("userId", user._id);
+
+      const document = await ctx.db.get(args.documentId);
+      if (!document || document.userId !== user._id) {
+        throw new ConvexError({ code: "document_not_found" as const });
+      }
+      await requireOwnedTopic(ctx, { topicId: args.topicId, userId: user._id });
+
+      const existing = await ctx.db
+        .query("documentTopics")
+        .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+        .collect();
+
+      const sameTopic = existing.find((a) => a.topicId === args.topicId);
+      if (sameTopic) {
+        evt.set("noop", true);
+        return null;
+      }
+
+      await Promise.all(existing.map((a) => ctx.db.delete(a._id)));
+
+      await ctx.db.insert("documentTopics", {
+        documentId: args.documentId,
+        topicId: args.topicId,
+        userId: user._id,
+        createdAt: Date.now(),
+      });
+
+      await ctx.scheduler.runAfter(0, internal.topics.topicsActions.captureTopicAnalytics, {
+        userId: user._id,
+        payload: {
+          event: "document_assigned_to_topic",
+          properties: {
+            topic_id: args.topicId,
+            document_id: args.documentId,
+          },
+        },
+      });
+
+      return null;
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
+    }
+  },
+});
+
+export const removeDocumentFromTopic = mutation({
+  args: {
+    documentId: v.id("documents"),
+    topicId: v.id("topics"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const evt = new WideEvent("topics.removeDocumentFromTopic");
+    evt.set({ documentId: args.documentId, topicId: args.topicId });
+    try {
+      const user = await requireAuth(ctx);
+      evt.set("userId", user._id);
+
+      const document = await ctx.db.get(args.documentId);
+      if (!document || document.userId !== user._id) {
+        throw new ConvexError({ code: "document_not_found" as const });
+      }
+      await requireOwnedTopic(ctx, { topicId: args.topicId, userId: user._id });
+
+      const assignments = await ctx.db
+        .query("documentTopics")
+        .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+        .collect();
+
+      const matching = assignments.filter((a) => a.topicId === args.topicId);
+      await Promise.all(matching.map((a) => ctx.db.delete(a._id)));
+      evt.set({ deleted: matching.length });
+
+      if (matching.length > 0) {
+        await ctx.scheduler.runAfter(0, internal.topics.topicsActions.captureTopicAnalytics, {
+          userId: user._id,
+          payload: {
+            event: "document_removed_from_topic",
+            properties: { topic_id: args.topicId, document_id: args.documentId },
+          },
+        });
+      }
+
+      return null;
+    } catch (error) {
+      evt.setError(error);
+      throw error;
+    } finally {
+      evt.emit();
+    }
+  },
+});
+
+export const setTopicLearningGoalEmbedding = internalMutation({
+  args: {
+    topicId: v.id("topics"),
+    embedding: v.array(v.float64()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const topic = await ctx.db.get(args.topicId);
+    if (!topic) return null;
+    if (!topic.learningGoal || topic.learningGoal.trim().length === 0) return null;
+    await ctx.db.patch(args.topicId, { learningGoalEmbedding: args.embedding });
+    return null;
+  },
+});
+
+export const cascadeDeleteByDocumentId = internalMutation({
+  args: { documentId: v.id("documents") },
+  returns: v.object({ deletedDocumentTopics: v.number() }),
+  handler: async (ctx, args) => {
+    const assignments = await ctx.db
+      .query("documentTopics")
+      .withIndex("by_documentId", (q) => q.eq("documentId", args.documentId))
+      .collect();
+    await Promise.all(assignments.map((a) => ctx.db.delete(a._id)));
+    return { deletedDocumentTopics: assignments.length };
+  },
+});
+
+async function requireOwnedTopic(
+  ctx: QueryCtx | MutationCtx,
+  params: { topicId: Id<"topics">; userId: string },
+): Promise<Doc<"topics">> {
+  const topic = await ctx.db.get(params.topicId);
+  if (!topic || topic.userId !== params.userId) {
+    throw new ConvexError({ code: "topic_not_found" as const });
+  }
+  return topic;
+}
+
+async function requireUniqueTopicName(
+  ctx: MutationCtx,
+  params: { userId: string; name: string; excludeTopicId?: Id<"topics"> },
+): Promise<void> {
+  const existing = await ctx.db
+    .query("topics")
+    .withIndex("by_userId_name", (q) => q.eq("userId", params.userId).eq("name", params.name))
+    .first();
+  if (existing && existing._id !== params.excludeTopicId) {
+    throw new ConvexError({ code: "topic_name_in_use" as const });
+  }
+}
+
+function validateName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Topic name cannot be empty");
+  }
+  if (trimmed.length > NAME_MAX_LENGTH) {
+    throw new Error(`Topic name must be at most ${NAME_MAX_LENGTH} characters`);
+  }
+  return trimmed;
+}
+
+function validateLearningGoal(goal: string): string {
+  const trimmed = goal.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Learning goal cannot be empty");
+  }
+  if (trimmed.length > LEARNING_GOAL_MAX_LENGTH) {
+    throw new Error(`Learning goal must be at most ${LEARNING_GOAL_MAX_LENGTH} characters`);
+  }
+  return trimmed;
+}
+
+function sanitizeDescription(description: string | undefined): string | undefined {
+  if (description === undefined) return undefined;
+  const trimmed = description.trim();
+  if (trimmed.length === 0) return undefined;
+  if (trimmed.length > DESCRIPTION_MAX_LENGTH) {
+    throw new Error(`Description must be at most ${DESCRIPTION_MAX_LENGTH} characters`);
+  }
+  return trimmed;
+}
+
+function sanitizeAppearance(
+  value: string | undefined,
+  field: "color" | "icon",
+): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  if (trimmed.length > APPEARANCE_MAX_LENGTH) {
+    throw new Error(`Topic ${field} must be at most ${APPEARANCE_MAX_LENGTH} characters`);
+  }
+  return trimmed;
+}

--- a/packages/backend/convex/topics/topicsActions.ts
+++ b/packages/backend/convex/topics/topicsActions.ts
@@ -1,0 +1,111 @@
+"use node";
+
+import { v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import { internalAction } from "../_generated/server";
+import { WideEvent } from "../../src/platform/logging";
+import { captureEvent } from "../../src/providers/analytics/posthog";
+import { createEmbeddingProvider } from "../../src/providers/wiring";
+
+const topicAnalyticsPayload = v.union(
+  v.object({
+    event: v.literal("topic_created"),
+    properties: v.object({
+      topic_id: v.id("topics"),
+      has_description: v.boolean(),
+      has_color: v.boolean(),
+      has_icon: v.boolean(),
+    }),
+  }),
+  v.object({
+    event: v.literal("topic_goal_edited"),
+    properties: v.object({
+      topic_id: v.id("topics"),
+    }),
+  }),
+  v.object({
+    event: v.literal("topic_deleted"),
+    properties: v.object({
+      topic_id: v.id("topics"),
+      document_count: v.number(),
+    }),
+  }),
+  v.object({
+    event: v.literal("document_assigned_to_topic"),
+    properties: v.object({
+      topic_id: v.id("topics"),
+      document_id: v.id("documents"),
+    }),
+  }),
+  v.object({
+    event: v.literal("document_removed_from_topic"),
+    properties: v.object({
+      topic_id: v.id("topics"),
+      document_id: v.id("documents"),
+    }),
+  }),
+);
+
+/**
+ * Embeds a topic's learning goal and patches `topics.learningGoalEmbedding`. Mirrors
+ * the per-document `embedLearningGoal` action. The embedding model is the same as
+ * the one used for section summaries so cosine similarity at serve time is meaningful.
+ *
+ * Missing / empty goal, embedding failure, or provider misconfiguration all no-op
+ * instead of throwing. The serving scorer falls back to the per-document goal when a
+ * topic has no embedding (resolver order: topic -> document -> undefined).
+ */
+export const embedTopicGoal = internalAction({
+  args: {
+    topicId: v.id("topics"),
+    learningGoal: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const evt = new WideEvent("topicsActions.embedTopicGoal");
+    evt.set("topicId", args.topicId);
+    try {
+      const trimmed = args.learningGoal.trim();
+      if (trimmed.length === 0) {
+        evt.set("skipped", "empty_goal");
+        return null;
+      }
+
+      const embedder = createEmbeddingProvider();
+      const [vector] = await embedder.embed([trimmed]);
+      if (!vector || vector.length === 0) {
+        evt.set("skipped", "empty_vector");
+        return null;
+      }
+
+      await ctx.runMutation(internal.topics.topics.setTopicLearningGoalEmbedding, {
+        topicId: args.topicId,
+        embedding: vector,
+      });
+      evt.set({ embeddingDimensions: vector.length });
+      return null;
+    } catch (error) {
+      evt.setError(error);
+      return null;
+    } finally {
+      evt.emit();
+    }
+  },
+});
+
+export const captureTopicAnalytics = internalAction({
+  args: {
+    userId: v.string(),
+    payload: topicAnalyticsPayload,
+  },
+  returns: v.null(),
+  handler: async (_ctx, args) => {
+    await captureEvent({
+      distinctId: args.userId,
+      event: args.payload.event,
+      properties: args.payload.properties,
+    });
+    return null;
+  },
+});

--- a/packages/backend/src/feed/logic/servingScope.ts
+++ b/packages/backend/src/feed/logic/servingScope.ts
@@ -1,7 +1,10 @@
 import { DEFAULT_SCORING_CONFIG } from "./scoring";
 import type { ScoringConfig } from "./scoring";
 
-export type ServingScope = { kind: "all" } | { kind: "document"; documentId: string };
+export type ServingScope =
+  | { kind: "all" }
+  | { kind: "document"; documentId: string }
+  | { kind: "topic"; topicId: string; documentIds: string[] };
 
 export type EmptyReason = "no_drafts" | "processing";
 
@@ -24,12 +27,20 @@ export function documentFeedScope(documentId: string): ServingScope {
   return { kind: "document", documentId };
 }
 
-export function servingScopeLabel(scope: ServingScope): "all" | "document" {
+export function topicFeedScope(topicId: string, documentIds: string[]): ServingScope {
+  return { kind: "topic", topicId, documentIds };
+}
+
+export function servingScopeLabel(scope: ServingScope): "all" | "document" | "topic" {
   return scope.kind;
 }
 
 export function servingScopeDocumentId(scope: ServingScope): string | undefined {
   return scope.kind === "document" ? scope.documentId : undefined;
+}
+
+export function servingScopeTopicId(scope: ServingScope): string | undefined {
+  return scope.kind === "topic" ? scope.topicId : undefined;
 }
 
 export function buildServingConfig(scope: ServingScope): ScoringConfig {
@@ -58,6 +69,11 @@ export function determineEmptyReasonForScope(input: {
     return input.documentStatus && PROCESSING_STAGES.has(input.documentStatus)
       ? "processing"
       : "no_drafts";
+  }
+
+  if (input.scope.kind === "topic") {
+    if (!input.hasAnyDocument) return "no_drafts";
+    return input.hasProcessingDocument ? "processing" : "no_drafts";
   }
 
   if (!input.hasAnyDocument) return "no_drafts";

--- a/packages/backend/tests/access/accountDeletion.test.ts
+++ b/packages/backend/tests/access/accountDeletion.test.ts
@@ -1,6 +1,8 @@
+import { getFunctionName } from "convex/server";
 import { describe, expect, it, vi } from "vitest";
 
 import { deleteAccountDocuments } from "../../convex/access/accountActions";
+import { internal } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { createMockSummaryStore, createMockVectorStore } from "./mocks";
 
@@ -39,6 +41,7 @@ describe("deleteAccountDocuments", () => {
       .mockResolvedValueOnce({ deletedHighlights: 2 })
       .mockResolvedValueOnce({ deletedPosts: 3, deletedBookmarks: 4 })
       .mockResolvedValueOnce({ deletedConnectionPairs: 5 })
+      .mockResolvedValueOnce({ deletedDocumentTopics: 12 })
       .mockResolvedValueOnce({
         deletedChunks: 6,
         deletedSectionSummaries: 7,
@@ -68,9 +71,19 @@ describe("deleteAccountDocuments", () => {
     expect(result).toEqual({ deletedDocumentCount: 1, failedDocuments: [] });
     expect(vectorDelete).toHaveBeenCalledWith(["chunk-vec"]);
     expect(summaryDelete).toHaveBeenCalledWith(["section-vec", "doc-summary-vec"]);
-    expect(runMutation).toHaveBeenCalledTimes(6);
-    expect(runMutation.mock.calls[1]?.[1]).toEqual({ documentId, userId });
-    expect(runMutation.mock.calls[3]?.[1]).toEqual({ documentId });
+    expect(runMutation).toHaveBeenCalledTimes(7);
+
+    const parallelNames = runMutation.mock.calls
+      .slice(1, 5)
+      .map((call) => getFunctionName(call?.[0]));
+    expect(parallelNames.sort()).toEqual(
+      [
+        getFunctionName(internal.content.highlights.cascadeDeleteHighlights),
+        getFunctionName(internal.content.documents.cascadeDeletePosts),
+        getFunctionName(internal.drafting.connectionPairs.cascadeDeleteByDocumentId),
+        getFunctionName(internal.topics.topics.cascadeDeleteByDocumentId),
+      ].sort(),
+    );
   });
 
   it("recovers failed cascades out of deleting status", async () => {

--- a/packages/backend/tests/content/documentDeletionCascade.test.ts
+++ b/packages/backend/tests/content/documentDeletionCascade.test.ts
@@ -1,5 +1,7 @@
+import { getFunctionName } from "convex/server";
 import { describe, expect, it, vi } from "vitest";
 
+import { internal } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { executeDocumentDeletionCascade } from "../../convex/content/deletion";
 import { createMockSummaryStore, createMockVectorStore } from "./mocks";
@@ -12,6 +14,7 @@ describe("executeDocumentDeletionCascade", () => {
       .mockResolvedValueOnce({ deletedHighlights: 2 })
       .mockResolvedValueOnce({ deletedPosts: 3, deletedBookmarks: 4 })
       .mockResolvedValueOnce({ deletedConnectionPairs: 5 })
+      .mockResolvedValueOnce({ deletedDocumentTopics: 12 })
       .mockResolvedValueOnce({
         deletedChunks: 6,
         deletedSectionSummaries: 7,
@@ -46,10 +49,50 @@ describe("executeDocumentDeletionCascade", () => {
 
     expect(vectorDelete).toHaveBeenCalledWith(["chunk-vec"]);
     expect(summaryDelete).toHaveBeenCalledWith(["section-vec", "doc-summary-vec"]);
-    expect(runMutation).toHaveBeenCalledTimes(6);
+    expect(runMutation).toHaveBeenCalledTimes(7);
+
+    const callNames = runMutation.mock.calls.map((call) => getFunctionName(call?.[0]));
+    expect(callNames[0]).toBe(getFunctionName(internal.content.documents.updateStatus));
     expect(runMutation.mock.calls[0]?.[1]).toEqual({ id: documentId, status: "deleting" });
-    expect(runMutation.mock.calls[1]?.[1]).toEqual({ documentId, userId });
-    expect(runMutation.mock.calls[3]?.[1]).toEqual({ documentId });
+
+    const parallelCalls = runMutation.mock.calls.slice(1, 5);
+    const parallelNames = parallelCalls.map((call) => getFunctionName(call?.[0]));
+    expect(parallelNames.sort()).toEqual(
+      [
+        getFunctionName(internal.content.highlights.cascadeDeleteHighlights),
+        getFunctionName(internal.content.documents.cascadeDeletePosts),
+        getFunctionName(internal.drafting.connectionPairs.cascadeDeleteByDocumentId),
+        getFunctionName(internal.topics.topics.cascadeDeleteByDocumentId),
+      ].sort(),
+    );
+    const callByName = new Map(
+      parallelCalls.map((call) => [getFunctionName(call?.[0]), call?.[1]]),
+    );
+    expect(
+      callByName.get(getFunctionName(internal.content.highlights.cascadeDeleteHighlights)),
+    ).toEqual({
+      documentId,
+      userId,
+    });
+    expect(callByName.get(getFunctionName(internal.content.documents.cascadeDeletePosts))).toEqual({
+      documentId,
+      userId,
+    });
+    expect(
+      callByName.get(getFunctionName(internal.drafting.connectionPairs.cascadeDeleteByDocumentId)),
+    ).toEqual({
+      documentId,
+    });
+    expect(
+      callByName.get(getFunctionName(internal.topics.topics.cascadeDeleteByDocumentId)),
+    ).toEqual({
+      documentId,
+    });
+
+    expect(callNames[5]).toBe(
+      getFunctionName(internal.content.documents.cascadeDeleteChunksAndSummaries),
+    );
+    expect(callNames[6]).toBe(getFunctionName(internal.content.documents.cascadeDeleteDocument));
     expect(result).toEqual({
       chunkVectorCount: 1,
       summaryVectorCount: 2,
@@ -64,6 +107,7 @@ describe("executeDocumentDeletionCascade", () => {
         postDrafts: 9,
         reactionFeedback: 10,
         orphanedTags: 11,
+        documentTopics: 12,
       },
     });
   });
@@ -83,6 +127,7 @@ describe("executeDocumentDeletionCascade", () => {
         deletedPostDrafts: 0,
         deletedReactionFeedback: 0,
         deletedOrphanedTags: 0,
+        deletedDocumentTopics: 0,
       };
     });
     const documentId = "doc-1" as Id<"documents">;
@@ -115,6 +160,7 @@ describe("executeDocumentDeletionCascade", () => {
       "mutation",
       "vector-delete",
       "summary-delete",
+      "mutation",
       "mutation",
       "mutation",
       "mutation",


### PR DESCRIPTION
## Summary

Implements the Topics feature: a personal, goal-scoped lens over a subset of documents. When the feed is scoped to a topic, posts are re-ranked against the topic's learning-goal embedding instead of the per-document goal. Plugs directly into the resolver seam ADR-018 §3 designed for this.

## What changed

**Schema** - new `topics` and `documentTopics` tables (N:N-ready, single-select UI in v1).

**Backend**
- Topic CRUD with ownership + `(userId, name)` uniqueness
- `embedTopicGoal` internal action mirroring `embedLearningGoal`
- `serveTopicFeed` mutation mirroring `serveDocumentFeed`
- `getEffectiveLearningGoalEmbedding` resolver: topic -> document -> undefined
- Cascade `documentTopics` on document delete; cascade topics + documentTopics on account delete
- `feed.queries.list` accepts optional `topicId`
- Discriminated-union analytics validators (no `v.any()`)
- `ConvexError` for typed not-found errors

**Frontend**
- `/app/topics` list and `/app/topics/$topicId` detail routes
- Topic picker (single-select dropdown) on library detail panel + standalone document route
- Feed scope chip banner with topic color, goal preview, and edit affordance
- Topic chip on library rows (single batched query - no N+1)
- Sidebar nav entry; friendly not-found states for malformed scope ids in URLs

**Docs** - ADR-019 records the decisions, including the divergence from issue #221's literal text on resolver fallback (kept ADR-018's `topic -> document` precedence to avoid the correctness bug ADR-018 §3 calls out).

**Tests** - E2E spec covers create topic -> assign document -> scoped vs unscoped feed. Cascade-delete unit tests now assert the internal-function reference, not just args.

## Resolver precedence note

Issue #221 said "fall back to `userProfiles.learningGoalEmbedding`". ADR-018 §3 explicitly rejected that as a correctness bug. Confirmed with the user: implementation honors ADR-018 (topic -> document -> undefined). ADR-019 records this divergence.

## Deferred to follow-up #238

Architectural and scaling concerns surfaced by reviewers that don't change v1 functionality: topic-scope pagination ghost pages, `embedTopicGoal` DI extraction, `listTopics` N+1, rate limiting on createTopic, resolver unit tests, `role=button`/anchor a11y, `feed.tsx` size, mixed convexQuery/useQuery layers.

## Test plan

- [x] `bun run check` clean
- [x] `bun turbo run build` clean
- [x] Backend `bun test` 297/297 green
- [x] E2E `tests/topics-scoped-feed.spec.ts` green (seeded project, ~21s)
- [x] E2E `tests/feed-document-scope.spec.ts` still green (banner refactor regression check)
- [x] E2E `tests/upload-and-library.spec.ts` desktop-layout still green (panel mounting regression)
- [x] Manual walk-through: create topic redirects to detail page, in-panel picker assigns, scoped feed shows banner, invalid `?topicId=fake` shows friendly empty state

Closes #221