### PR TITLE
feat(#235): "see also" related posts rail

### DIFF
--- a/apps/e2e/tests/feed-interactions.spec.ts
+++ b/apps/e2e/tests/feed-interactions.spec.ts
@@ -194,6 +194,41 @@ test.describe("Feed interactions and pagination", { tag: "@seeded" }, () => {
     ).toBeLessThanOrEqual(1);
   });
 
+  test('"see also" rail shows related posts and swaps detail content on click', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1536, height: 864 });
+    await page.goto("/app/feed?noAutoGenerate");
+    await expect(page.locator('[data-testid="post-card"]').first()).toBeVisible();
+
+    await page
+      .locator('[data-testid="post-card"]')
+      .first()
+      .locator('[data-testid="source-badge"]')
+      .click();
+
+    const panel = page.locator('[data-testid="feed-detail-panel"]');
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText("See also");
+
+    const relatedRows = panel.locator('[data-testid="detail-panel-related-post"]');
+    await expect(relatedRows.first()).toBeVisible();
+    const rowCount = await relatedRows.count();
+    expect(rowCount).toBeGreaterThanOrEqual(2);
+    expect(rowCount).toBeLessThanOrEqual(3);
+
+    const clickedRowText = (await relatedRows.first().innerText()).trim();
+    expect(clickedRowText.length).toBeGreaterThan(0);
+
+    await relatedRows.first().click();
+    await expect
+      .poll(async () => {
+        const texts = await relatedRows.allInnerTexts();
+        return texts.map((t) => t.trim()).includes(clickedRowText);
+      })
+      .toBe(false);
+  });
+
   test("empty state shows when no posts exist", async ({ page }) => {
     // Navigate to a feed state that has no posts by using noAutoGenerate
     // The seeded account has posts, so this test verifies the empty state UI exists

--- a/apps/web/src/components/detail-panel.tsx
+++ b/apps/web/src/components/detail-panel.tsx
@@ -2,11 +2,13 @@ import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { api } from "@scrollect/backend/convex/_generated/api";
+import { useConvex } from "convex/react";
 import { format } from "date-fns";
 import { BookOpen, ExternalLink, Loader2, MousePointerClick, X } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { createContext, useCallback, useContext, useState } from "react";
 import Markdown from "react-markdown";
+import { toast } from "sonner";
 
 import {
   DetailRail,
@@ -159,6 +161,7 @@ function DetailPanelContent({ post, onClose }: { post: PostView; onClose: () => 
         ) : null}
 
         <SourceMarker post={post} />
+        <RelatedPostsMarker post={post} />
       </div>
     </div>
   );
@@ -275,5 +278,89 @@ function SourceMarker({ post }: { post: PostView }) {
         </RailMarker>
       )}
     </>
+  );
+}
+
+// 2-row floor: a single related entry feels like UI noise rather than a thread
+// of related ideas; we hide the rail until there are at least two siblings.
+const RELATED_POSTS_VISIBLE_FLOOR = 2;
+
+function RelatedPostsMarker({ post }: { post: PostView }) {
+  const posthog = usePostHog();
+  const convex = useConvex();
+  const ctx = useDetailPanel();
+  const [pendingId, setPendingId] = useState<PostView["_id"] | null>(null);
+  const { data: related } = useQuery(
+    convexQuery(api.feed.posts.listRelated, { postId: post._id, limit: 3 }),
+  );
+
+  if (!related || related.length < RELATED_POSTS_VISIBLE_FLOOR) return null;
+
+  async function handleSelect(target: NonNullable<typeof related>[number]) {
+    posthog.capture("feed.related_post_clicked", {
+      source_post_id: post._id,
+      target_post_id: target._id,
+      target_post_type: target.postType,
+    });
+    setPendingId(target._id);
+    try {
+      const fullPost = await convex.query(api.feed.posts.getEnriched, { postId: target._id });
+      if (fullPost) {
+        ctx?.openDetail(fullPost);
+      } else {
+        toast("That post is no longer available.");
+      }
+    } catch (error) {
+      posthog.captureException(error);
+      toast.error("Couldn't open that post. Please try again.");
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  return (
+    <RailMarker marker="E">
+      <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+        See also
+      </div>
+      <ul className="divide-y divide-dashed divide-border/60">
+        {related.map((entry) => {
+          const isPending = pendingId === entry._id;
+          return (
+            <li key={entry._id}>
+              <button
+                type="button"
+                disabled={isPending}
+                onClick={() => {
+                  void handleSelect(entry);
+                }}
+                aria-label={`Open related ${postTypeLabel[entry.postType].toLowerCase()}: ${entry.summary}`}
+                className="group grid w-full grid-cols-[90px_1fr] items-baseline gap-x-3 py-2.5 text-left transition-transform duration-150 ease-out hover:translate-x-0.5 focus-visible:translate-x-0.5 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-progress disabled:opacity-60"
+                data-testid="detail-panel-related-post"
+                data-post-type={entry.postType}
+              >
+                <span
+                  className={cn(
+                    "font-mono text-[10px] uppercase tracking-[0.18em] decoration-current/[0.4] underline-offset-[5px] group-hover:underline group-focus-visible:underline",
+                    postTypeText[entry.postType],
+                  )}
+                >
+                  {postTypeLabel[entry.postType]}
+                </span>
+                <span className="flex items-center gap-2 font-logo text-[14px] leading-[1.55] text-foreground/80 transition-colors group-hover:text-foreground group-focus-visible:text-foreground">
+                  <span className="line-clamp-1 min-w-0 flex-1">{entry.summary}</span>
+                  {isPending && (
+                    <Loader2
+                      aria-hidden
+                      className="size-3 shrink-0 animate-spin text-muted-foreground"
+                    />
+                  )}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </RailMarker>
   );
 }

--- a/packages/backend/convex/feed/posts.ts
+++ b/packages/backend/convex/feed/posts.ts
@@ -1,9 +1,11 @@
 import { v } from "convex/values";
 
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import type { QueryCtx } from "../_generated/server";
 import { query } from "../_generated/server";
 import { requireAuth } from "../lib/functions";
+import { postType, typeData as typeDataValidator } from "../lib/validators";
+import { FRESHNESS_WINDOW_MS } from "../../src/feed/logic/constants";
 
 async function resolveTags(ctx: QueryCtx, tagIds: Id<"tags">[]) {
   const tags = await Promise.all(tagIds.map((id) => ctx.db.get(id)));
@@ -22,6 +24,160 @@ async function resolveSectionSummary(
   const section = await ctx.db.get(draft.sectionSummaryId);
   return section?.summary;
 }
+
+const RELATED_POSTS_LIMIT_MAX = 10;
+
+// v1: "related" means "same source document, newest first, excluding the
+// current post and posts the user has disliked." Future iterations may layer
+// in semantic similarity (Qdrant) or `connectionPairs` ranking.
+export const listRelated = query({
+  args: {
+    postId: v.id("posts"),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(
+    v.object({
+      _id: v.id("posts"),
+      postType,
+      summary: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const user = await requireAuth(ctx);
+
+    const sourcePost = await ctx.db.get(args.postId);
+    if (!sourcePost || sourcePost.userId !== user._id) return [];
+
+    const limit = Math.min(RELATED_POSTS_LIMIT_MAX, Math.max(1, args.limit ?? 3));
+
+    const related: { _id: Id<"posts">; postType: Doc<"posts">["postType"]; summary: string }[] = [];
+    for await (const post of ctx.db
+      .query("posts")
+      .withIndex("by_userId_document", (q) =>
+        q.eq("userId", user._id).eq("primarySourceDocumentId", sourcePost.primarySourceDocumentId),
+      )
+      .order("desc")) {
+      if (related.length >= limit) break;
+      if (post._id === args.postId) continue;
+      if (post.reaction === "dislike") continue;
+      related.push({
+        _id: post._id,
+        postType: post.postType,
+        summary: deriveTeaser(post),
+      });
+    }
+    return related;
+  },
+});
+
+function deriveTeaser(post: Doc<"posts">): string {
+  const fromTypeData = teaserFromTypeData(post.typeData);
+  const raw = fromTypeData ?? post.content ?? "";
+  return toTeaser(raw);
+}
+
+function teaserFromTypeData(typeData: Doc<"posts">["typeData"]): string | undefined {
+  switch (typeData.type) {
+    case "quote":
+      return typeData.quotedText;
+    case "quiz":
+      return typeData.question;
+    case "summary":
+      return typeData.bulletPoints[0];
+    case "connection":
+      return (
+        typeData.sourceAKeyIdea ??
+        typeData.sourceBKeyIdea ??
+        `${typeData.sourceATitleHint} / ${typeData.sourceBTitleHint}`
+      );
+    case "insight":
+      return undefined;
+  }
+}
+
+const RELATED_TEASER_MAX_CHARS = 140;
+
+function toTeaser(text: string): string {
+  const plain = text
+    .replace(/^\s*#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/`{1,3}([^`]*)`{1,3}/g, "$1")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/(^|[^*])\*([^*]+)\*/g, "$1$2")
+    .replace(/(^|[^_])_([^_]+)_/g, "$1$2")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (plain.length <= RELATED_TEASER_MAX_CHARS) return plain;
+  return `${plain.slice(0, RELATED_TEASER_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+// Enriched single-post fetch used by the detail panel when swapping in
+// a related post. Mirrors the row shape returned by `feed.queries.list`
+// (the fields the detail panel actually consumes), modulo `tags`.
+export const getEnriched = query({
+  args: { postId: v.id("posts") },
+  returns: v.union(
+    v.object({
+      _id: v.id("posts"),
+      content: v.string(),
+      postType,
+      typeData: typeDataValidator,
+      primarySourceDocumentTitle: v.string(),
+      primarySourceDocumentId: v.id("documents"),
+      fileType: v.optional(v.string()),
+      sectionTitle: v.union(v.string(), v.null()),
+      pageStart: v.union(v.number(), v.null()),
+      pageEnd: v.union(v.number(), v.null()),
+      postDraftId: v.union(v.id("postDrafts"), v.null()),
+      createdAt: v.number(),
+      reaction: v.union(v.literal("like"), v.literal("dislike"), v.null()),
+      isBookmarked: v.boolean(),
+      isNew: v.boolean(),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const user = await requireAuth(ctx);
+
+    const post = await ctx.db.get(args.postId);
+    if (!post || post.userId !== user._id) return null;
+
+    const [doc, bookmark] = await Promise.all([
+      ctx.db.get(post.primarySourceDocumentId),
+      ctx.db
+        .query("bookmarks")
+        .withIndex("by_userId_post", (q) => q.eq("userId", user._id).eq("postId", post._id))
+        .first(),
+    ]);
+    if (!doc || doc.userId !== user._id) return null;
+
+    // Date.now() is non-deterministic in Convex queries; isNew updates on the
+    // next reactive re-evaluation, not at the exact 48h mark. Same trade-off
+    // as `feed.queries.list`.
+    const isNew = Date.now() - doc.createdAt < FRESHNESS_WINDOW_MS;
+
+    return {
+      _id: post._id,
+      content: post.content,
+      postType: post.postType,
+      typeData: post.typeData,
+      primarySourceDocumentTitle: post.primarySourceDocumentTitle,
+      primarySourceDocumentId: post.primarySourceDocumentId,
+      fileType: post.fileType,
+      sectionTitle: post.sectionTitle ?? null,
+      pageStart: post.pageStart ?? null,
+      pageEnd: post.pageEnd ?? null,
+      postDraftId: post.postDraftId ?? null,
+      createdAt: post.createdAt,
+      reaction: post.reaction ?? null,
+      isBookmarked: bookmark != null,
+      isNew,
+    };
+  },
+});
 
 export const getSourceDetails = query({
   args: { postId: v.id("posts") },


### PR DESCRIPTION
## Summary

Adds a marginalia rail marker (E) to the post detail panel that surfaces up to 3 related posts from the same source document. Clicking a row swaps the detail panel content in place — no navigation, no full reload.

## Why

Every post should pull the reader deeper into their own knowledge graph rather than ending the thread. This is the cross-linking retention loop Scrollect is built around: see one insight, follow two more, build connections.

## What's in the rail

- **Backend** — `api.feed.posts.listRelated` (streams `by_userId_document`, excludes self + disliked, default 3 / max 10). Per-kind teaser derived from `typeData` (quote → quotedText, quiz → question, summary → first bullet, connection → A / B title hints with optional key-idea fallback, insight → content). Inline markdown stripped (headings, list markers, links, bold/italic, code), whitespace collapsed, capped at 140 chars.
- **Backend** — `api.feed.posts.getEnriched` returns the enriched row shape the detail panel consumes (PostView + isBookmarked + isNew). Used when swapping in a related post.
- **Frontend** — `RelatedPostsMarker` renders rows with a 90px mono post-type label (colored per kind) and a Fraunces teaser. Subtle hover: row shifts right, teaser brightens, type label gains a thin underline. Hidden when <2 related posts.
- **Frontend** — Click flow: emits `feed.related_post_clicked` with `{ source_post_id, target_post_id, target_post_type }`, calls `useConvex().query(api.feed.posts.getEnriched, ...)` for the full PostView, then `openDetail(fullPost)`. Per-row spinner during fetch, toast on null/error.
- **A11y** — `aria-label` per row, focus-visible ring, disabled state during fetch.
- **E2E** — Extended `feed-interactions.spec.ts` to assert 2-3 rows render and clicking a row swaps the detail content (the clicked teaser disappears from the new See Also list).

## Notes

- The PostHog event uses dot-notation (`feed.related_post_clicked`) rather than the underscore name from the issue (`detail_panel_related_post_clicked`) to match the project's existing convention (`source.library_navigated`, `post.reacted`, etc.). Properties stay snake_case as in recent additions. Property keys still satisfy the issue's `{ sourcePostId, targetPostId, targetPostType }` payload (in snake_case form).
- v1 selection is purely "same source document, newest first." Future iterations can layer in semantic similarity via Qdrant or `connectionPairs` ranking — flagged in a code comment so the next reader knows where to extend.
- Used `useConvex().query()` instead of `queryClient.fetchQuery(convexQuery(...))` to align with AGENTS.md "Convex-native data fetching" rule for one-shot imperative reads.

## Test plan

- [x] `bun run check` passes (lint + format)
- [x] `bun turbo run build` passes (web + backend)
- [x] `cd packages/backend && bun run test` — 332 unit tests pass
- [x] `cd apps/e2e && npx playwright test --project=setup --project=seeded tests/feed-interactions.spec.ts` — all 10 tests pass including the new "see also" rail test
- [ ] Manual: open a post on a multi-post document and verify the rail appears, hover/focus affordances feel editorial, and clicking swaps without a flash

Closes #235