### PR TITLE
feat(#244): M3 mobile feed core - infinite feed + reactions + bookmarks

### DIFF
--- a/apps/native/app/feed.tsx
+++ b/apps/native/app/feed.tsx
@@ -1,0 +1,38 @@
+import { Redirect } from "expo-router";
+import { usePostHog } from "posthog-react-native";
+
+import { ErrorBoundary } from "@/components/error-boundary";
+import { FeedErrorState } from "@/components/feed/feed-error-state";
+import { FeedScreen } from "@/components/feed/feed-screen";
+import { authClient } from "@/lib/auth-client";
+import { ActivityIndicator, View } from "@/tw";
+
+export default function FeedRoute() {
+  const session = authClient.useSession();
+  const posthog = usePostHog();
+
+  if (session.isPending) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white">
+        <ActivityIndicator color="#171717" />
+      </View>
+    );
+  }
+
+  if (!session.data) {
+    return <Redirect href="/sign-in" />;
+  }
+
+  // The ErrorBoundary catches render-phase errors only (e.g. malformed
+  // typeData). Transport errors are handled in two places: mutation
+  // rejections surface via Alert in PostCard, and Convex auto-reconnects
+  // its WebSocket so transient query disconnects recover transparently.
+  return (
+    <ErrorBoundary
+      onError={(error) => posthog?.captureException(error)}
+      fallback={({ message, reset }) => <FeedErrorState message={message} onRetry={reset} />}
+    >
+      <FeedScreen />
+    </ErrorBoundary>
+  );
+}

--- a/apps/native/app/index.tsx
+++ b/apps/native/app/index.tsx
@@ -1,25 +1,10 @@
 import { Redirect } from "expo-router";
-import { usePostHog } from "posthog-react-native";
-import { useCallback } from "react";
 
 import { authClient } from "@/lib/auth-client";
-import { ActivityIndicator, Pressable, Text, View } from "@/tw";
+import { ActivityIndicator, View } from "@/tw";
 
 export default function HomeScreen() {
   const session = authClient.useSession();
-  const posthog = usePostHog();
-
-  const handleSignOut = useCallback(async () => {
-    // Capture before sign-out so the event keeps the user's distinct_id;
-    // reset() afterwards clears it for the next anonymous session, and runs
-    // in finally so a transient signOut() rejection still clears identity.
-    posthog?.capture("user.signed_out");
-    try {
-      await authClient.signOut();
-    } finally {
-      posthog?.reset();
-    }
-  }, [posthog]);
 
   if (session.isPending) {
     return (
@@ -33,19 +18,5 @@ export default function HomeScreen() {
     return <Redirect href="/sign-in" />;
   }
 
-  return (
-    <View className="flex-1 items-center justify-center bg-white px-6">
-      <Text className="text-2xl font-bold text-neutral-900">Scrollect</Text>
-      <Text className="mt-2 text-base text-neutral-500">
-        Signed in as {session.data.user.email}
-      </Text>
-      <Pressable
-        accessibilityRole="button"
-        onPress={handleSignOut}
-        className="mt-8 rounded-md border border-neutral-300 px-4 py-2 active:opacity-90"
-      >
-        <Text className="text-base font-medium text-neutral-900">Sign out</Text>
-      </Pressable>
-    </View>
-  );
+  return <Redirect href="/feed" />;
 }

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -22,6 +22,7 @@
     "expo-constants": "~55.0.15",
     "expo-device": "~55.0.15",
     "expo-file-system": "~55.0.17",
+    "expo-haptics": "^55.0.14",
     "expo-linking": "~55.0.14",
     "expo-localization": "~55.0.13",
     "expo-network": "~55.0.13",
@@ -31,6 +32,7 @@
     "expo-system-ui": "~55.0.16",
     "expo-web-browser": "~55.0.14",
     "lightningcss": "1.30.1",
+    "lucide-react-native": "^1.11.0",
     "nativewind": "5.0.0-preview.3",
     "posthog-react-native": "^4.43.5",
     "react": "19.2.0",
@@ -39,6 +41,7 @@
     "react-native-css": "^3.0.7",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",
+    "react-native-svg": "^15.15.4",
     "react-native-web": "^0.21.0",
     "zod": "catalog:"
   },

--- a/apps/native/src/components/error-boundary.tsx
+++ b/apps/native/src/components/error-boundary.tsx
@@ -1,0 +1,37 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+  fallback: (state: { message: string; reset: () => void }) => ReactNode;
+  onError?: (error: Error, info: ErrorInfo) => void;
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    if (this.state.error) {
+      return this.props.fallback({
+        message: this.state.error.message || "An unexpected error occurred.",
+        reset: this.reset,
+      });
+    }
+    return this.props.children;
+  }
+}

--- a/apps/native/src/components/feed/dislike-reason-sheet.tsx
+++ b/apps/native/src/components/feed/dislike-reason-sheet.tsx
@@ -1,0 +1,57 @@
+import { Ban, BookCheck, Shapes, ThumbsDown, type LucideIcon } from "lucide-react-native";
+import { useCallback } from "react";
+
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { Pressable, Text, View } from "@/tw";
+
+import type { DislikeReason } from "./types";
+
+const DISLIKE_REASONS: ReadonlyArray<{
+  reason: DislikeReason;
+  label: string;
+  icon: LucideIcon;
+}> = [
+  { reason: "not_interesting", label: "Not interesting to me", icon: Ban },
+  { reason: "already_know", label: "I already know this", icon: BookCheck },
+  { reason: "wrong_type", label: "Not my preferred format", icon: Shapes },
+  { reason: "low_quality", label: "Low quality / inaccurate", icon: ThumbsDown },
+];
+
+interface DislikeReasonSheetProps {
+  open: boolean;
+  onClose: () => void;
+  onReasonSelected: (reason: DislikeReason) => void;
+}
+
+export function DislikeReasonSheet({ open, onClose, onReasonSelected }: DislikeReasonSheetProps) {
+  const handleSelect = useCallback(
+    (reason: DislikeReason) => {
+      onReasonSelected(reason);
+      onClose();
+    },
+    [onClose, onReasonSelected],
+  );
+
+  return (
+    <BottomSheet open={open} onDismiss={onClose} testID="dislike-reason-sheet">
+      <Text className="px-5 py-2 text-xs font-medium uppercase tracking-wider text-neutral-500">
+        What went wrong?
+      </Text>
+      <View accessibilityLabel="Dislike reasons">
+        {DISLIKE_REASONS.map(({ reason, label, icon: Icon }) => (
+          <Pressable
+            key={reason}
+            accessibilityRole="button"
+            accessibilityLabel={label}
+            testID={`dislike-reason-${reason}`}
+            onPress={() => handleSelect(reason)}
+            className="flex-row items-center gap-3 px-5 py-4 active:bg-neutral-100"
+          >
+            <Icon size={18} color="#737373" />
+            <Text className="text-base text-neutral-900">{label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </BottomSheet>
+  );
+}

--- a/apps/native/src/components/feed/feed-empty-state.tsx
+++ b/apps/native/src/components/feed/feed-empty-state.tsx
@@ -1,0 +1,32 @@
+import * as WebBrowser from "expo-web-browser";
+import { Sparkles } from "lucide-react-native";
+import { useCallback } from "react";
+
+import { Button } from "@/components/ui/button";
+import { env } from "@/lib/env";
+import { Text, View } from "@/tw";
+
+const LIBRARY_URL = `${env.EXPO_PUBLIC_SITE_URL}/app/library`;
+
+export function FeedEmptyState() {
+  const openLibrary = useCallback(() => {
+    void WebBrowser.openBrowserAsync(LIBRARY_URL);
+  }, []);
+
+  return (
+    <View testID="feed-empty-state" className="flex-1 items-center justify-center px-8 py-24">
+      <View className="size-16 items-center justify-center rounded-full bg-neutral-100">
+        <Sparkles size={28} color="#737373" />
+      </View>
+      <Text className="mt-5 text-center text-lg font-semibold text-neutral-900">
+        Nothing here yet
+      </Text>
+      <Text className="mt-2 text-center text-sm leading-5 text-neutral-500">
+        Add a document on Scrollect web and your feed will fill up automatically.
+      </Text>
+      <Button variant="secondary" size="sm" className="mt-6" onPress={openLibrary}>
+        Open library on web
+      </Button>
+    </View>
+  );
+}

--- a/apps/native/src/components/feed/feed-error-state.tsx
+++ b/apps/native/src/components/feed/feed-error-state.tsx
@@ -1,0 +1,26 @@
+import { AlertTriangle } from "lucide-react-native";
+
+import { Button } from "@/components/ui/button";
+import { Text, View } from "@/tw";
+
+interface FeedErrorStateProps {
+  message: string;
+  onRetry: () => void;
+}
+
+export function FeedErrorState({ message, onRetry }: FeedErrorStateProps) {
+  return (
+    <View testID="feed-error-state" className="flex-1 items-center justify-center px-8 py-24">
+      <View className="size-16 items-center justify-center rounded-full bg-red-50">
+        <AlertTriangle size={28} color="#dc2626" />
+      </View>
+      <Text className="mt-5 text-center text-lg font-semibold text-neutral-900">
+        Something went wrong
+      </Text>
+      <Text className="mt-2 text-center text-sm leading-5 text-neutral-500">{message}</Text>
+      <Button variant="secondary" size="sm" className="mt-6" onPress={onRetry}>
+        Try again
+      </Button>
+    </View>
+  );
+}

--- a/apps/native/src/components/feed/feed-screen.tsx
+++ b/apps/native/src/components/feed/feed-screen.tsx
@@ -1,0 +1,110 @@
+import { LogOut } from "lucide-react-native";
+import { usePostHog } from "posthog-react-native";
+import { useCallback, useEffect } from "react";
+import { ActivityIndicator, FlatList, type ListRenderItemInfo, RefreshControl } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { IconButton } from "@/components/ui/icon-button";
+import { useFeed } from "@/hooks/use-feed";
+import { authClient } from "@/lib/auth-client";
+import { Text, View } from "@/tw";
+
+import { FeedEmptyState } from "./feed-empty-state";
+import { FeedSkeleton } from "./feed-skeleton";
+import { PostCard } from "./post-card";
+import type { FeedPost } from "./types";
+
+const ON_END_REACHED_THRESHOLD = 0.6;
+
+export function FeedScreen() {
+  const posthog = usePostHog();
+  const { results, status, refreshing, onRefresh, onEndReached } = useFeed();
+
+  const renderItem = useCallback(({ item }: ListRenderItemInfo<FeedPost>) => {
+    return <PostCard post={item} />;
+  }, []);
+
+  const keyExtractor = useCallback((post: FeedPost) => post._id as string, []);
+
+  // Fire `feed.viewed` once per status transition out of LoadingFirstPage —
+  // we read `results.length` at fire time (closure) but intentionally omit it
+  // from deps so this fires on the load → ready transition, not on every
+  // pagination tick that grows the list.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (status === "LoadingFirstPage") return;
+    posthog?.capture("feed.viewed", { post_count: results.length });
+  }, [status]);
+
+  if (status === "LoadingFirstPage") {
+    return (
+      <SafeAreaView edges={["top"]} style={styles.root}>
+        <FeedHeader />
+        <FeedSkeleton />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView edges={["top"]} style={styles.root}>
+      <FeedHeader />
+      <FlatList
+        data={results}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        onEndReached={onEndReached}
+        onEndReachedThreshold={ON_END_REACHED_THRESHOLD}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#171717" />
+        }
+        ListEmptyComponent={<FeedEmptyState />}
+        ListFooterComponent={
+          status === "LoadingMore" ? (
+            <View className="items-center py-6">
+              <ActivityIndicator color="#171717" />
+            </View>
+          ) : status === "Exhausted" && results.length > 0 ? (
+            <View className="items-center py-8">
+              <Text className="text-xs uppercase tracking-widest text-neutral-400">
+                You&apos;re all caught up
+              </Text>
+            </View>
+          ) : null
+        }
+        contentContainerStyle={results.length === 0 ? styles.emptyContainer : undefined}
+      />
+    </SafeAreaView>
+  );
+}
+
+function FeedHeader() {
+  const posthog = usePostHog();
+
+  const handleSignOut = useCallback(async () => {
+    posthog?.capture("user.signed_out");
+    try {
+      await authClient.signOut();
+    } finally {
+      posthog?.reset();
+    }
+  }, [posthog]);
+
+  return (
+    <View className="flex-row items-end justify-between border-b border-neutral-200 bg-white px-5 pt-2 pb-4">
+      <View>
+        <Text className="text-[11px] font-medium uppercase tracking-widest text-neutral-400">
+          Your Feed
+        </Text>
+        <Text className="mt-1 text-2xl font-semibold text-neutral-900">Scrollect</Text>
+      </View>
+      <IconButton accessibilityLabel="Sign out" testID="sign-out-button" onPress={handleSignOut}>
+        <LogOut size={18} color="#737373" />
+      </IconButton>
+    </View>
+  );
+}
+
+const styles = {
+  root: { flex: 1, backgroundColor: "#ffffff" } as const,
+  emptyContainer: { flexGrow: 1 } as const,
+};

--- a/apps/native/src/components/feed/feed-skeleton.tsx
+++ b/apps/native/src/components/feed/feed-skeleton.tsx
@@ -1,0 +1,26 @@
+import { View } from "@/tw";
+
+const SKELETON_KEYS = ["a", "b", "c"] as const;
+
+export function FeedSkeleton() {
+  return (
+    <View testID="feed-skeleton" className="flex-1 bg-white">
+      {SKELETON_KEYS.map((key) => (
+        <View key={key} className="border-b border-neutral-200 bg-white px-5 py-6">
+          <View className="h-3 w-16 rounded bg-neutral-200" />
+          <View className="mt-4 h-4 w-full rounded bg-neutral-100" />
+          <View className="mt-2 h-4 w-5/6 rounded bg-neutral-100" />
+          <View className="mt-2 h-4 w-2/3 rounded bg-neutral-100" />
+          <View className="mt-5 flex-row items-center justify-between">
+            <View className="h-3 w-32 rounded bg-neutral-100" />
+            <View className="flex-row gap-2">
+              <View className="size-9 rounded-full bg-neutral-100" />
+              <View className="size-9 rounded-full bg-neutral-100" />
+              <View className="size-9 rounded-full bg-neutral-100" />
+            </View>
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/apps/native/src/components/feed/post-card-content.tsx
+++ b/apps/native/src/components/feed/post-card-content.tsx
@@ -1,0 +1,302 @@
+import { ArrowLeftRight, CheckCircle2, Eye, XCircle } from "lucide-react-native";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Pressable, Text, View } from "@/tw";
+
+import type { FeedPost } from "./types";
+
+interface PostCardContentProps {
+  post: FeedPost;
+}
+
+export function PostCardContent({ post }: PostCardContentProps) {
+  const { typeData } = post;
+  switch (typeData.type) {
+    case "insight":
+      return <InsightContent content={post.content} />;
+    case "quote":
+      return (
+        <QuoteContent
+          quotedText={typeData.quotedText}
+          attribution={typeData.attribution}
+          context={post.content}
+        />
+      );
+    case "summary":
+      return <SummaryContent bulletPoints={typeData.bulletPoints} fallbackContent={post.content} />;
+    case "connection":
+      return (
+        <ConnectionContent
+          sourceATitle={typeData.sourceATitleHint}
+          sourceBTitle={typeData.sourceBTitleHint}
+          sourceAKeyIdea={typeData.sourceAKeyIdea}
+          sourceBKeyIdea={typeData.sourceBKeyIdea}
+          summary={post.content}
+        />
+      );
+    case "quiz":
+      if (typeData.variant === "multiple_choice") {
+        return (
+          <QuizMcContent
+            question={typeData.question}
+            options={typeData.options}
+            correctIndex={typeData.correctIndex}
+            explanation={typeData.explanation}
+          />
+        );
+      }
+      return (
+        <QuizRevealContent
+          question={typeData.question}
+          options={typeData.options}
+          correctIndex={typeData.correctIndex}
+          explanation={typeData.explanation}
+        />
+      );
+    default:
+      typeData satisfies never;
+      return null;
+  }
+}
+
+function InsightContent({ content }: { content: string }) {
+  return (
+    <Text testID="insight-content" className="text-base leading-6 text-neutral-900">
+      {content}
+    </Text>
+  );
+}
+
+interface QuoteContentProps {
+  quotedText: string;
+  attribution?: string;
+  context: string;
+}
+
+function QuoteContent({ quotedText, attribution, context }: QuoteContentProps) {
+  return (
+    <View>
+      <Text testID="quoted-text" className="text-2xl font-semibold leading-8 text-neutral-900">
+        &ldquo;{quotedText}&rdquo;
+      </Text>
+      {attribution ? (
+        <Text
+          testID="quote-attribution"
+          className="mt-3 text-xs uppercase tracking-widest text-amber-600"
+        >
+          &mdash; {attribution}
+        </Text>
+      ) : null}
+      {context ? (
+        <Text
+          testID="quote-context"
+          className="mt-3 border-l-2 border-neutral-200 pl-3 text-sm leading-5 text-neutral-500"
+        >
+          {context}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+interface SummaryContentProps {
+  bulletPoints: string[];
+  fallbackContent: string;
+}
+
+function SummaryContent({ bulletPoints, fallbackContent }: SummaryContentProps) {
+  if (bulletPoints.length === 0) {
+    return (
+      <Text testID="summary-content" className="text-base leading-6 text-neutral-900">
+        {fallbackContent}
+      </Text>
+    );
+  }
+  return (
+    <View testID="summary-bullets">
+      {bulletPoints.map((point, i) => (
+        <View
+          key={i}
+          className={`flex-row gap-3 py-2 ${i > 0 ? "border-t border-dashed border-neutral-200" : ""}`}
+        >
+          <Text className="w-7 text-xs font-medium uppercase tracking-wider text-blue-500">
+            {String(i + 1).padStart(2, "0")}
+          </Text>
+          <Text className="flex-1 text-sm leading-5 text-neutral-900">{point}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+interface ConnectionContentProps {
+  sourceATitle: string;
+  sourceBTitle: string;
+  sourceAKeyIdea?: string;
+  sourceBKeyIdea?: string;
+  summary: string;
+}
+
+function ConnectionContent({
+  sourceATitle,
+  sourceBTitle,
+  sourceAKeyIdea,
+  sourceBKeyIdea,
+  summary,
+}: ConnectionContentProps) {
+  return (
+    <View testID="connection-content">
+      <View className="mb-4 flex-row items-stretch gap-2">
+        <ConnectionSource
+          testID="connection-source-a"
+          label="Source A"
+          title={sourceATitle}
+          keyIdea={sourceAKeyIdea}
+        />
+        <View className="items-center justify-center px-1">
+          <ArrowLeftRight size={18} color="#8b5cf6" />
+        </View>
+        <ConnectionSource
+          testID="connection-source-b"
+          label="Source B"
+          title={sourceBTitle}
+          keyIdea={sourceBKeyIdea}
+        />
+      </View>
+      <Text className="text-base leading-6 text-neutral-900">{summary}</Text>
+    </View>
+  );
+}
+
+interface ConnectionSourceProps {
+  testID: string;
+  label: string;
+  title: string;
+  keyIdea?: string;
+}
+
+function ConnectionSource({ testID, label, title, keyIdea }: ConnectionSourceProps) {
+  return (
+    <View testID={testID} className="flex-1 border border-neutral-200 bg-violet-500/5 px-3 py-3">
+      <Text className="mb-1 text-[10px] font-medium uppercase tracking-widest text-violet-500">
+        {label}
+      </Text>
+      <Text numberOfLines={1} className="text-xs text-neutral-500">
+        {title}
+      </Text>
+      {keyIdea ? (
+        <Text className="mt-2 text-xs italic leading-4 text-neutral-700">
+          &ldquo;{keyIdea}&rdquo;
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+interface QuizContentProps {
+  question: string;
+  options: string[];
+  correctIndex: number;
+  explanation: string;
+}
+
+function QuizMcContent({ question, options, correctIndex, explanation }: QuizContentProps) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const answered = selectedIndex !== null;
+
+  return (
+    <View>
+      <Text testID="quiz-question" className="mb-3 text-lg font-semibold text-neutral-900">
+        {question}
+      </Text>
+      <View>
+        {options.map((option, i) => {
+          const isCorrect = i === correctIndex;
+          const isPicked = i === selectedIndex;
+          return (
+            <Pressable
+              key={i}
+              testID="quiz-option"
+              accessibilityRole="radio"
+              accessibilityState={{ selected: isPicked, disabled: answered }}
+              disabled={answered}
+              onPress={() => {
+                if (!answered) setSelectedIndex(i);
+              }}
+              className={`mb-1.5 flex-row items-center gap-3 border px-3 py-2.5 ${
+                answered && isCorrect
+                  ? "border-emerald-500/45 bg-emerald-50"
+                  : answered && isPicked && !isCorrect
+                    ? "border-red-500/45 bg-red-50"
+                    : "border-neutral-200 bg-white"
+              } ${answered && !isPicked && !isCorrect ? "opacity-50" : ""}`}
+            >
+              <Text className="w-5 text-xs font-medium tracking-wider text-neutral-500">
+                {String.fromCharCode(65 + i)}
+              </Text>
+              <Text className="flex-1 text-sm text-neutral-900">{option}</Text>
+              {answered && isCorrect ? (
+                <View className="flex-row items-center gap-1">
+                  <CheckCircle2 size={14} color="#059669" />
+                  <Text className="text-[10px] font-medium uppercase text-emerald-600">
+                    Correct
+                  </Text>
+                </View>
+              ) : null}
+              {answered && isPicked && !isCorrect ? (
+                <View className="flex-row items-center gap-1">
+                  <XCircle size={14} color="#ef4444" />
+                  <Text className="text-[10px] font-medium uppercase text-red-500">Your pick</Text>
+                </View>
+              ) : null}
+            </Pressable>
+          );
+        })}
+      </View>
+      {answered ? (
+        <View
+          testID="quiz-explanation"
+          className={`mt-3 border px-3 py-2.5 ${
+            selectedIndex === correctIndex ? "border-emerald-500/35" : "border-red-500/35"
+          }`}
+        >
+          <Text className="text-sm leading-5 text-neutral-900">{explanation}</Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function QuizRevealContent({ question, options, correctIndex, explanation }: QuizContentProps) {
+  const [revealed, setRevealed] = useState(false);
+  return (
+    <View>
+      <Text testID="quiz-question" className="mb-3 text-lg font-semibold text-neutral-900">
+        {question}
+      </Text>
+      {!revealed ? (
+        <Button
+          testID="quiz-reveal-button"
+          variant="secondary"
+          size="sm"
+          onPress={() => setRevealed(true)}
+        >
+          <View className="flex-row items-center gap-2">
+            <Eye size={14} color="#171717" />
+            <Text className="text-sm font-medium text-neutral-900">Reveal answer</Text>
+          </View>
+        </Button>
+      ) : (
+        <View testID="quiz-answer" className="border border-emerald-500/35 p-3">
+          <Text className="text-base font-semibold text-emerald-700">
+            {options[correctIndex] ?? "Answer unavailable"}
+          </Text>
+          <Text testID="quiz-explanation" className="mt-2 text-sm leading-5 text-neutral-700">
+            {explanation}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/apps/native/src/components/feed/post-card.tsx
+++ b/apps/native/src/components/feed/post-card.tsx
@@ -1,0 +1,229 @@
+import { api } from "@scrollect/backend/convex/_generated/api";
+import type { OptimisticLocalStore } from "convex/browser";
+import { useMutation } from "convex/react";
+import { usePostHog } from "posthog-react-native";
+import { useCallback, useState } from "react";
+import { Alert } from "react-native";
+
+import { haptics } from "@/lib/haptics";
+import { Text, View } from "@/tw";
+
+import { DislikeReasonSheet } from "./dislike-reason-sheet";
+import { PostCardContent } from "./post-card-content";
+import { ReactionRow } from "./reaction-row";
+import type { DislikeReason, FeedPost } from "./types";
+
+const POST_TYPE_LABEL: Record<FeedPost["postType"], string> = {
+  insight: "Insight",
+  quiz: "Quiz",
+  quote: "Quote",
+  summary: "Summary",
+  connection: "Connection",
+};
+
+interface PostCardProps {
+  post: FeedPost;
+}
+
+function updatePostInPaginatedPages(
+  localStore: OptimisticLocalStore,
+  postId: FeedPost["_id"],
+  updater: (post: Record<string, unknown>) => Record<string, unknown>,
+) {
+  const allPages = localStore.getAllQueries(api.feed.queries.list);
+  for (const { args, value } of allPages) {
+    if (value === undefined) continue;
+    if (!value.page.some((p) => p._id === postId)) continue;
+    localStore.setQuery(api.feed.queries.list, args, {
+      ...value,
+      page: value.page.map((p) => (p._id === postId ? { ...p, ...updater(p) } : p)),
+    });
+  }
+}
+
+function removePostFromPaginatedPages(localStore: OptimisticLocalStore, postId: FeedPost["_id"]) {
+  const allPages = localStore.getAllQueries(api.feed.queries.list);
+  for (const { args, value } of allPages) {
+    if (value === undefined) continue;
+    if (!value.page.some((p) => p._id === postId)) continue;
+    localStore.setQuery(api.feed.queries.list, args, {
+      ...value,
+      page: value.page.filter((p) => p._id !== postId),
+    });
+  }
+}
+
+export function PostCard({ post }: PostCardProps) {
+  const posthog = usePostHog();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [reasonSelectedDuringSession, setReasonSelectedDuringSession] = useState(false);
+
+  const toggleBookmark = useMutation(api.content.bookmarks.toggle).withOptimisticUpdate(
+    (localStore, args) => {
+      updatePostInPaginatedPages(localStore, args.postId, (p) => ({
+        isBookmarked: !p.isBookmarked,
+      }));
+    },
+  );
+
+  const setReaction = useMutation(api.feed.queries.setReaction).withOptimisticUpdate(
+    (localStore, args) => {
+      if (args.reaction === "dislike") {
+        removePostFromPaginatedPages(localStore, args.postId);
+        return;
+      }
+      updatePostInPaginatedPages(localStore, args.postId, () => ({
+        reaction: args.reaction === "none" ? undefined : args.reaction,
+      }));
+    },
+  );
+
+  const reportMutationError = useCallback(
+    (error: unknown, context: "bookmark" | "reaction") => {
+      const err = error instanceof Error ? error : new Error("Unknown error");
+      posthog?.captureException(err, { context });
+      // Use the system Alert: we don't have a toast library on mobile (M3
+      // scope) and silently swallowing the error after an optimistic update
+      // would leave the UI in a state that disagrees with the server.
+      Alert.alert(
+        context === "bookmark" ? "Couldn't update bookmark" : "Couldn't save reaction",
+        err.message || "Please try again.",
+      );
+    },
+    [posthog],
+  );
+
+  const handleToggleBookmark = useCallback(async () => {
+    haptics.bookmark();
+    posthog?.capture("post.bookmarked", {
+      post_type: post.postType,
+      bookmarked: !post.isBookmarked,
+    });
+    try {
+      await toggleBookmark({ postId: post._id });
+    } catch (error) {
+      reportMutationError(error, "bookmark");
+    }
+  }, [post._id, post.isBookmarked, post.postType, posthog, reportMutationError, toggleBookmark]);
+
+  const handleToggleLike = useCallback(async () => {
+    const nextReaction = post.reaction === "like" ? "none" : "like";
+    haptics.reactionLike();
+    posthog?.capture("post.reacted", {
+      post_type: post.postType,
+      reaction: nextReaction,
+    });
+    try {
+      await setReaction({ postId: post._id, reaction: nextReaction });
+    } catch (error) {
+      reportMutationError(error, "reaction");
+    }
+  }, [post._id, post.postType, post.reaction, posthog, reportMutationError, setReaction]);
+
+  const handleOpenDislike = useCallback(() => {
+    setReasonSelectedDuringSession(false);
+    setSheetOpen(true);
+    posthog?.capture("post.dislike_reason_sheet_opened", {
+      post_type: post.postType,
+    });
+  }, [post.postType, posthog]);
+
+  const handleCloseDislike = useCallback(() => {
+    setSheetOpen(false);
+    posthog?.capture("post.dislike_reason_sheet_dismissed", {
+      post_type: post.postType,
+      selected: reasonSelectedDuringSession,
+    });
+  }, [post.postType, posthog, reasonSelectedDuringSession]);
+
+  const handleReasonSelected = useCallback(
+    async (reason: DislikeReason) => {
+      setReasonSelectedDuringSession(true);
+      haptics.reactionDislike();
+      posthog?.capture("post.reacted", {
+        post_type: post.postType,
+        reaction: "dislike",
+        dislike_reason: reason,
+      });
+      posthog?.capture("post.dislike_reason_selected", {
+        post_type: post.postType,
+        dislike_reason: reason,
+        source_document_id: post.primarySourceDocumentId,
+        post_draft_id: post.postDraftId ?? null,
+      });
+      posthog?.capture("post.hidden_by_dislike", {
+        post_type: post.postType,
+        dislike_reason: reason,
+      });
+      try {
+        await setReaction({
+          postId: post._id,
+          reaction: "dislike",
+          dislikeReason: reason,
+        });
+      } catch (error) {
+        reportMutationError(error, "reaction");
+      }
+    },
+    [
+      post._id,
+      post.postDraftId,
+      post.postType,
+      post.primarySourceDocumentId,
+      posthog,
+      reportMutationError,
+      setReaction,
+    ],
+  );
+
+  return (
+    <>
+      <View
+        testID="post-card"
+        accessibilityLabel={`${POST_TYPE_LABEL[post.postType]} post`}
+        className="border-b border-neutral-200 bg-white px-5 pt-5 pb-4"
+      >
+        <View className="mb-3 flex-row items-center justify-between">
+          <Text className="text-[10px] font-medium uppercase tracking-widest text-neutral-500">
+            {POST_TYPE_LABEL[post.postType]}
+          </Text>
+          {post.sectionTitle ? (
+            <Text
+              numberOfLines={1}
+              className="ml-3 max-w-[55%] text-[10px] uppercase tracking-wider text-neutral-400"
+            >
+              &sect; {post.sectionTitle}
+            </Text>
+          ) : null}
+        </View>
+
+        <PostCardContent post={post} />
+
+        <View className="mt-4 flex-row items-center justify-between border-t border-neutral-100 pt-3">
+          <View className="flex-1 pr-3">
+            <Text
+              testID="source-badge"
+              numberOfLines={1}
+              className="text-xs font-medium text-neutral-700"
+            >
+              {post.primarySourceDocumentTitle ?? "Untitled"}
+            </Text>
+          </View>
+          <ReactionRow
+            reaction={post.reaction ?? undefined}
+            isBookmarked={!!post.isBookmarked}
+            onToggleBookmark={handleToggleBookmark}
+            onToggleLike={handleToggleLike}
+            onOpenDislike={handleOpenDislike}
+          />
+        </View>
+      </View>
+
+      <DislikeReasonSheet
+        open={sheetOpen}
+        onClose={handleCloseDislike}
+        onReasonSelected={handleReasonSelected}
+      />
+    </>
+  );
+}

--- a/apps/native/src/components/feed/reaction-row.tsx
+++ b/apps/native/src/components/feed/reaction-row.tsx
@@ -1,0 +1,65 @@
+import { Bookmark, BookmarkCheck, ThumbsDown, ThumbsUp } from "lucide-react-native";
+
+import { IconButton } from "@/components/ui/icon-button";
+import { View } from "@/tw";
+
+interface ReactionRowProps {
+  reaction: "like" | "dislike" | undefined;
+  isBookmarked: boolean;
+  onToggleLike: () => void;
+  onOpenDislike: () => void;
+  onToggleBookmark: () => void;
+}
+
+const ICON_SIZE = 18;
+const NEUTRAL_COLOR = "#737373";
+const LIKE_COLOR = "#059669";
+const DISLIKE_COLOR = "#ef4444";
+const BOOKMARK_COLOR = "#171717";
+
+export function ReactionRow({
+  reaction,
+  isBookmarked,
+  onToggleLike,
+  onOpenDislike,
+  onToggleBookmark,
+}: ReactionRowProps) {
+  return (
+    <View className="flex-row items-center gap-1">
+      <IconButton
+        testID="save-button"
+        accessibilityLabel={isBookmarked ? "Remove bookmark" : "Bookmark"}
+        active={isBookmarked}
+        tone="bookmark"
+        onPress={onToggleBookmark}
+      >
+        {isBookmarked ? (
+          <BookmarkCheck size={ICON_SIZE} color={BOOKMARK_COLOR} />
+        ) : (
+          <Bookmark size={ICON_SIZE} color={NEUTRAL_COLOR} />
+        )}
+      </IconButton>
+      <IconButton
+        testID="like-button"
+        accessibilityLabel={reaction === "like" ? "Remove like" : "Like"}
+        active={reaction === "like"}
+        tone="like"
+        onPress={onToggleLike}
+      >
+        <ThumbsUp size={ICON_SIZE} color={reaction === "like" ? LIKE_COLOR : NEUTRAL_COLOR} />
+      </IconButton>
+      <IconButton
+        testID="dislike-button"
+        accessibilityLabel="Dislike"
+        active={reaction === "dislike"}
+        tone="dislike"
+        onPress={onOpenDislike}
+      >
+        <ThumbsDown
+          size={ICON_SIZE}
+          color={reaction === "dislike" ? DISLIKE_COLOR : NEUTRAL_COLOR}
+        />
+      </IconButton>
+    </View>
+  );
+}

--- a/apps/native/src/components/feed/types.ts
+++ b/apps/native/src/components/feed/types.ts
@@ -1,0 +1,7 @@
+import type { api } from "@scrollect/backend/convex/_generated/api";
+import type { FunctionReturnType } from "convex/server";
+
+export type FeedListResult = FunctionReturnType<typeof api.feed.queries.list>;
+export type FeedPost = FeedListResult["page"][number];
+
+export type DislikeReason = "not_interesting" | "already_know" | "wrong_type" | "low_quality";

--- a/apps/native/src/components/ui/bottom-sheet.tsx
+++ b/apps/native/src/components/ui/bottom-sheet.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import { Modal, Pressable as RNPressable } from "react-native";
+
+import { View } from "@/tw";
+
+interface BottomSheetProps {
+  open: boolean;
+  onDismiss: () => void;
+  children: ReactNode;
+  testID?: string;
+}
+
+export function BottomSheet({ open, onDismiss, children, testID }: BottomSheetProps) {
+  return (
+    <Modal
+      animationType="slide"
+      transparent
+      visible={open}
+      onRequestClose={onDismiss}
+      statusBarTranslucent
+    >
+      {/* Layout: a flex column where the dismiss-backdrop fills the area
+          ABOVE the sheet via `flex-1`, and the sheet sits at the bottom in
+          normal flow. Avoiding absolute positioning here means the
+          accessibility tree only exposes "Dismiss" for the empty area
+          above the sheet — VoiceOver inside the sheet content stays
+          focused on the sheet's children. */}
+      <View className="flex-1 justify-end bg-black/40">
+        <RNPressable
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss"
+          onPress={onDismiss}
+          style={styles.backdrop}
+        />
+        <View testID={testID} className="rounded-t-2xl bg-white pb-8 pt-2 shadow-lg">
+          <View className="mx-auto mb-2 mt-1 h-1 w-10 rounded-full bg-neutral-300" />
+          {children}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = {
+  backdrop: { flex: 1 },
+} as const;

--- a/apps/native/src/components/ui/button.tsx
+++ b/apps/native/src/components/ui/button.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from "react";
+
+import { ActivityIndicator, Pressable, Text, type PressableProps } from "@/tw";
+
+type ButtonVariant = "primary" | "secondary" | "ghost";
+type ButtonSize = "default" | "sm";
+
+interface ButtonProps extends Omit<PressableProps, "children"> {
+  children: ReactNode;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  loading?: boolean;
+  className?: string;
+}
+
+const variantClass: Record<ButtonVariant, string> = {
+  primary: "bg-neutral-900 active:opacity-90 disabled:opacity-50",
+  secondary: "border border-neutral-300 bg-white active:opacity-90 disabled:opacity-50",
+  ghost: "active:opacity-70 disabled:opacity-50",
+};
+
+const variantTextClass: Record<ButtonVariant, string> = {
+  primary: "text-white",
+  secondary: "text-neutral-900",
+  ghost: "text-neutral-900",
+};
+
+const sizeClass: Record<ButtonSize, string> = {
+  default: "px-4 py-3",
+  sm: "px-3 py-2",
+};
+
+export function Button({
+  children,
+  variant = "primary",
+  size = "default",
+  loading,
+  disabled,
+  className,
+  accessibilityRole,
+  ...rest
+}: ButtonProps) {
+  const isDisabled = disabled || loading;
+  return (
+    <Pressable
+      accessibilityRole={accessibilityRole ?? "button"}
+      accessibilityState={{ disabled: !!isDisabled }}
+      disabled={isDisabled}
+      className={`flex-row items-center justify-center rounded-md ${variantClass[variant]} ${sizeClass[size]}${
+        className ? ` ${className}` : ""
+      }`}
+      {...rest}
+    >
+      {loading ? (
+        <ActivityIndicator color={variant === "primary" ? "#ffffff" : "#171717"} />
+      ) : typeof children === "string" ? (
+        <Text className={`text-base font-medium ${variantTextClass[variant]}`}>{children}</Text>
+      ) : (
+        children
+      )}
+    </Pressable>
+  );
+}

--- a/apps/native/src/components/ui/icon-button.tsx
+++ b/apps/native/src/components/ui/icon-button.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+
+import { Pressable, type PressableProps } from "@/tw";
+
+const PRESS_HIT_SLOP = 8;
+
+interface IconButtonProps extends Omit<PressableProps, "children"> {
+  children: ReactNode;
+  active?: boolean;
+  tone?: "neutral" | "like" | "dislike" | "bookmark";
+  className?: string;
+}
+
+const inactiveByTone = "bg-transparent active:bg-neutral-100";
+
+const activeByTone: Record<NonNullable<IconButtonProps["tone"]>, string> = {
+  neutral: "bg-neutral-100",
+  like: "bg-emerald-50",
+  dislike: "bg-red-50",
+  bookmark: "bg-neutral-900/5",
+};
+
+export function IconButton({
+  children,
+  active = false,
+  tone = "neutral",
+  className,
+  accessibilityRole,
+  ...rest
+}: IconButtonProps) {
+  const stateClass = active ? activeByTone[tone] : inactiveByTone;
+  return (
+    <Pressable
+      accessibilityRole={accessibilityRole ?? "button"}
+      accessibilityState={{ selected: active, disabled: !!rest.disabled }}
+      hitSlop={PRESS_HIT_SLOP}
+      className={`size-11 items-center justify-center rounded-full ${stateClass}${
+        className ? ` ${className}` : ""
+      }`}
+      {...rest}
+    >
+      {children}
+    </Pressable>
+  );
+}

--- a/apps/native/src/hooks/use-feed.ts
+++ b/apps/native/src/hooks/use-feed.ts
@@ -1,0 +1,74 @@
+import { api } from "@scrollect/backend/convex/_generated/api";
+import { usePaginatedQuery } from "convex/react";
+import { usePostHog } from "posthog-react-native";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const INITIAL_PAGE_SIZE = 10;
+const LOAD_MORE_PAGE_SIZE = 10;
+const REFRESH_SPINNER_FLOOR_MS = 300;
+
+export function useFeed() {
+  const posthog = usePostHog();
+  const { results, status, loadMore } = usePaginatedQuery(
+    api.feed.queries.list,
+    {},
+    { initialNumItems: INITIAL_PAGE_SIZE },
+  );
+
+  const [refreshing, setRefreshing] = useState(false);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending refresh-spinner timer if the screen unmounts mid-gesture
+  // — leaving it pending would trigger a state update on an unmounted hook.
+  useEffect(() => {
+    return () => {
+      if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+    };
+  }, []);
+
+  const onRefresh = useCallback(() => {
+    // A refresh gesture during LoadingMore / LoadingFirstPage is intentionally
+    // a no-op — the spinner already conveys "data in flight". Stacking another
+    // pull-to-refresh on top would only confuse the user.
+    if (status === "LoadingFirstPage" || status === "LoadingMore" || refreshing) return;
+    setRefreshing(true);
+    posthog?.capture("feed.refreshed");
+    // The Convex paginated query subscribes via WebSocket, so data is already
+    // live — we don't need to manually re-fetch. The spinner stays up for a
+    // short floor so the gesture feels intentional rather than dismissed
+    // instantly.
+    if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+    refreshTimerRef.current = setTimeout(() => {
+      setRefreshing(false);
+      refreshTimerRef.current = null;
+    }, REFRESH_SPINNER_FLOOR_MS);
+  }, [posthog, refreshing, status]);
+
+  const onEndReached = useCallback(() => {
+    if (status !== "CanLoadMore") return;
+    posthog?.capture("feed.paginated", {
+      loaded_count: results.length,
+    });
+    loadMore(LOAD_MORE_PAGE_SIZE);
+  }, [loadMore, posthog, results.length, status]);
+
+  // Fire `feed.exhausted` exactly once per mount. Stricter than web (web's
+  // `prevStatusRef` re-fires on every transition INTO Exhausted across
+  // load-more cycles), but a once-per-session signal is more useful for
+  // analytics and avoids double-counting when the feed shrinks and grows.
+  const exhaustedFiredRef = useRef(false);
+  useEffect(() => {
+    if (status !== "Exhausted") return;
+    if (exhaustedFiredRef.current) return;
+    exhaustedFiredRef.current = true;
+    posthog?.capture("feed.exhausted", { total_posts: results.length });
+  }, [posthog, results.length, status]);
+
+  return {
+    results,
+    status,
+    refreshing,
+    onRefresh,
+    onEndReached,
+  };
+}

--- a/apps/native/src/lib/haptics.ts
+++ b/apps/native/src/lib/haptics.ts
@@ -1,0 +1,24 @@
+import * as Haptics from "expo-haptics";
+
+// Mobile feel parity with web: a like/bookmark commit feels like a "tap",
+// a dislike (which removes the post) feels like a heavier negative confirm.
+// Errors thrown by Haptics on platforms without a haptic engine are swallowed
+// — haptics are an enhancement, never a hard dependency.
+function safe(fn: () => Promise<unknown>) {
+  void fn().catch(() => {});
+}
+
+export const haptics = {
+  selection() {
+    safe(Haptics.selectionAsync);
+  },
+  reactionLike() {
+    safe(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light));
+  },
+  reactionDislike() {
+    safe(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium));
+  },
+  bookmark() {
+    safe(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light));
+  },
+};

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "expo-constants": "~55.0.15",
         "expo-device": "~55.0.15",
         "expo-file-system": "~55.0.17",
+        "expo-haptics": "^55.0.14",
         "expo-linking": "~55.0.14",
         "expo-localization": "~55.0.13",
         "expo-network": "~55.0.13",
@@ -61,6 +62,7 @@
         "expo-system-ui": "~55.0.16",
         "expo-web-browser": "~55.0.14",
         "lightningcss": "1.30.1",
+        "lucide-react-native": "^1.11.0",
         "nativewind": "5.0.0-preview.3",
         "posthog-react-native": "^4.43.5",
         "react": "19.2.0",
@@ -69,6 +71,7 @@
         "react-native-css": "^3.0.7",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.23.0",
+        "react-native-svg": "^15.15.4",
         "react-native-web": "^0.21.0",
         "zod": "catalog:",
       },
@@ -2061,7 +2064,7 @@
 
     "css-selector-parser": ["css-selector-parser@3.3.0", "", {}, "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g=="],
 
-    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+    "css-tree": ["css-tree@1.1.3", "", { "dependencies": { "mdn-data": "2.0.14", "source-map": "^0.6.1" } }, "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q=="],
 
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
@@ -2346,6 +2349,8 @@
     "expo-font": ["expo-font@55.0.6", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-x9czUA3UQWjIwa0ZUEs/eWJNqB4mAue/m4ltESlNPLZhHL0nWWqIfsyHmklTLFH7mVfcHSJvew6k+pR2FE1zVw=="],
 
     "expo-glass-effect": ["expo-glass-effect@55.0.10", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-5kL/jATvgJWdrqPdxixrECJqD2l8cfQ4ALr1DK7qi9XkyI97ejXvUjB2VsfEePNy3Fg+/VwzA3n3L7Nv3tAPkw=="],
+
+    "expo-haptics": ["expo-haptics@55.0.14", "", { "peerDependencies": { "expo": "*" } }, "sha512-KjDItBsA9mi1f5nRwf8g1wOdfEcLHwvEdt5Jl1sMCDETR/homcGOl+F3QIiPOl/PRlbGVieQsjTtF4DGtHOj6g=="],
 
     "expo-image": ["expo-image@55.0.9", "", { "dependencies": { "sf-symbols-typescript": "^2.2.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-+NVgWv+tr7a6EpBEaIIVVp+XfruRA2JL5xOxvd6ajvFGdH0rOhagwX1m1piAII6w7sh6uAnBr8X+fDZsav7B2w=="],
 
@@ -2901,6 +2906,8 @@
 
     "lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
 
+    "lucide-react-native": ["lucide-react-native@1.11.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-native": "*", "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0" } }, "sha512-/dEt+/noOpsvgH1dbMHHSv+f8+npB1BJSKCqK9v9yvHbssN3OJJJXrih6N1prJGG3vj0e1zKiVLtet+OKYmiXg=="],
+
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-regexp": ["magic-regexp@0.10.0", "", { "dependencies": { "estree-walker": "^3.0.3", "magic-string": "^0.30.12", "mlly": "^1.7.2", "regexp-tree": "^0.1.27", "type-level-regexp": "~0.1.17", "ufo": "^1.5.4", "unplugin": "^2.0.0" } }, "sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg=="],
@@ -2969,7 +2976,7 @@
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
-    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+    "mdn-data": ["mdn-data@2.0.14", "", {}, "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="],
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
@@ -4119,6 +4126,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@asamuzakjp/dom-selector/css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
     "@astrojs/mdx/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -4132,6 +4141,10 @@
     "@babel/helper-create-regexp-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@bramus/specificity/css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "@csstools/css-syntax-patches-for-csstree/css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -4385,6 +4398,8 @@
 
     "@unocss/preset-web-fonts/ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 
+    "@unocss/transformer-directives/css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
     "@vitejs/plugin-react/react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
     "@vitejs/plugin-vue/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.2", "", {}, "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw=="],
@@ -4454,6 +4469,8 @@
     "cross-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "css-tree/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
@@ -4556,6 +4573,8 @@
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
+    "jsdom/css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
     "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
@@ -4661,8 +4680,6 @@
 
     "react-native-css/babel-plugin-react-compiler": ["babel-plugin-react-compiler@19.1.0-rc.1-rc-af1b7da-20250421", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-E3kaokBhWDLf7ZD8fuYjYn0ZJHYZ+3EHtAWCdX2hl4lpu1z9S/Xr99sxhx2bTCVB41oIesz9FtM8f4INsrZaOw=="],
 
-    "react-native-svg/css-tree": ["css-tree@1.1.3", "", { "dependencies": { "mdn-data": "2.0.14", "source-map": "^0.6.1" } }, "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q=="],
-
     "react-native-web/@react-native/normalize-colors": ["@react-native/normalize-colors@0.74.89", "", {}, "sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg=="],
 
     "react-native-web/memoize-one": ["memoize-one@6.0.0", "", {}, "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="],
@@ -4713,6 +4730,8 @@
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
+    "svgo/css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "test-exclude/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
@@ -4724,6 +4743,8 @@
     "unconfig/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "unconfig-core/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+
+    "unifont/css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
     "unifont/ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 
@@ -4756,6 +4777,12 @@
     "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "write-file-atomic/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "@asamuzakjp/dom-selector/css-tree/mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "@bramus/specificity/css-tree/mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "@csstools/css-syntax-patches-for-csstree/css-tree/mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
@@ -4993,6 +5020,8 @@
 
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "@unocss/transformer-directives/css-tree/mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
     "@vueuse/motion/@vueuse/core/@vueuse/metadata": ["@vueuse/metadata@13.9.0", "", {}, "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg=="],
 
     "astro/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
@@ -5111,6 +5140,8 @@
 
     "jest-validate/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "jsdom/css-tree/mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
     "jszip/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -5137,13 +5168,11 @@
 
     "pptxgenjs/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "react-native-svg/css-tree/mdn-data": ["mdn-data@2.0.14", "", {}, "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="],
-
-    "react-native-svg/css-tree/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "resolve-global/global-directory/ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "svgo/css-tree/mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
@@ -5200,6 +5229,8 @@
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
 
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "unifont/css-tree/mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "unstorage/h3/cookie-es": ["cookie-es@1.2.2", "", {}, "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="],
 


### PR DESCRIPTION
## Summary
- Adds the read-only feed experience for the native app: post cards rendered with NativeWind primitives, infinite pagination via `usePaginatedQuery`, pull-to-refresh, like/dislike (with reason BottomSheet) and bookmark — all syncing in real time with web via Convex's reactive subscription.
- All five post types are rendered (`insight`, `quote`, `summary`, `connection`, `quiz` MC + reveal) with explicit empty / loading (skeleton) / error (boundary + Alert) states — features, not edge cases per the issue.
- PostHog events mirror web exactly: `post.reacted`, `post.bookmarked`, `post.dislike_reason_sheet_opened/dismissed/selected`, `post.hidden_by_dislike`, `feed.exhausted`. Mobile-only gestures (refresh, view, paginate) get `feed.viewed`, `feed.refreshed`, `feed.paginated` — kept in dot-notation for consistency.
- Haptics on like / dislike / bookmark via `expo-haptics`. Optimistic updates mirror the web `PostShell` (dislike removes the post from paginated pages, like/bookmark patch the field in place).

## Architecture notes
- Plain `convex/react` hooks (`useQuery`, `useMutation`, `usePaginatedQuery`) — not the `@convex-dev/react-query` adapter, per the issue.
- Bottom sheet built on RN `Modal` + `Pressable` backdrop (no `@gorhom/bottom-sheet` dependency added). Backdrop and sheet stack via flex column to keep VoiceOver focus inside the sheet content.
- Mutation rejections surface via system `Alert` — no toast library in M3 scope.
- `feed.exhausted` fires once per mount on mobile (stricter than web's per-transition). Documented inline.
- Pull-to-refresh shows a 300ms spinner floor since Convex queries are reactive over WebSocket — no real refetch needed, just gesture acknowledgement.
- A small `ErrorBoundary` wraps the feed screen for render-phase errors. Transport errors are handled via mutation Alerts + Convex auto-reconnect.

## Files
- `apps/native/app/feed.tsx` (new route) + `app/index.tsx` updated to redirect signed-in users to `/feed`
- `apps/native/src/components/feed/*` — post-card, post-card-content (per-type renderers), reaction-row, dislike-reason-sheet, feed-screen, feed-empty-state, feed-error-state, feed-skeleton
- `apps/native/src/components/ui/*` — button, icon-button, bottom-sheet primitives
- `apps/native/src/hooks/use-feed.ts` — paginated query + analytics + refresh state
- `apps/native/src/lib/haptics.ts` — `expo-haptics` wrapper
- Deps: `expo-haptics`, `lucide-react-native`, `react-native-svg`

## Test plan
- [ ] Sign in on iOS/Android — feed loads within 2s on warm cache, skeleton shows during cold load
- [ ] Scroll: infinite pagination triggers, footer spinner visible, exhausted state shows "You're all caught up"
- [ ] Pull to refresh: gesture feedback works, spinner dismisses after 300ms
- [ ] Like a post → web shows the like immediately (real-time sync)
- [ ] Dislike → reason sheet opens, picking a reason removes the post and persists; web shows the post hidden
- [ ] Bookmark → web Saved page lists it; toggle off removes it
- [ ] Haptic feedback fires on each react / bookmark
- [ ] Force a network error (airplane mode → mutate) → Alert surfaces, no silent drop
- [ ] Empty state designed: no spinner; CTA opens web library in browser
- [ ] PostHog dashboard shows mobile events (`post.reacted`, `post.bookmarked`, etc.) under the same names web emits

## Out of scope (deferred per epic #241)
- Bottom-tab nav (M4)
- Saved / Topics / Settings screens (M4)
- Push notifications (M5)
- Maestro E2E (M6)
- Account deletion + Pro IAP (web-only)

Closes #244